### PR TITLE
Increase cluster definition flexibility.  Fix GCP redeploy in Ansible 2.9

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Credentials can be encrypted inline in the playbooks using [ansible-vault](https
 
 
 ### Cluster Variables
-The clusters are defined as code, within Ansible yaml files as below:
+The clusters are defined as code, within Ansible yaml file as below:
 
 #### group_vars/\<clusterid\>/cluster_vars.yml:
 ```
@@ -71,7 +71,7 @@ cluster_vars:
       <hosttype>: {...}
 ```
 
-#### group_vars/\<clusterid\>/cluster_vars.yml:
+#### group_vars/\<clusterid\>/app_vars.yml:
 Contains your application-specific variables
 
 ---

--- a/group_vars/_skel/cluster_vars.yml
+++ b/group_vars/_skel/cluster_vars.yml
@@ -65,10 +65,10 @@ cluster_name: "{{app_name}}-{{buildenv}}"
 #      rule_desc: "Access from all VMs attached to the {{ cluster_name }}-sg group"
 #  sandbox:
 #    hosttype_vars:
-#      sys: {count_per_az: 1, az: ["a", "b"], flavor: t3.micro, auto_volumes: []}
-#      #sysdisks: {count_per_az: 1, az: ["a", "b"], flavor: t3.micro, auto_volumes: [{"device_name": "/dev/sdb", mountpoint: "/var/log/mysvc", fstype: "ext4", "volume_type": "gp2", "volume_size": 2, ephemeral: False, encrypted: True, "delete_on_termination": true, perms: {owner: "root", group: "sudo", mode: "775"} }, {"device_name": "/dev/sdc", mountpoint: "/var/log/mysvc2", fstype: "ext4", "volume_type": "gp2", "volume_size": 2, ephemeral: False, encrypted: True, "delete_on_termination": true}, {"device_name": "/dev/sdd", mountpoint: "/var/log/mysvc3", fstype: "ext4", "volume_type": "gp2", "volume_size": 2, ephemeral: False, encrypted: True, "delete_on_termination": true}]}
-#      #sysnvme_multi: {count_per_az: 1, az: ["a"], flavor: i3en.2xlarge, auto_volumes: [], nvme: {volumes: [{mountpoint: "/var/log/mysvc", fstype: ext4, volume_size: 2500}, {mountpoint: "/var/log/mysvc2", fstype: ext4, volume_size: 2500}]} } }
-#      #sysnvme_lvm: {count_per_az: 1, az: ["a"], flavor: i3en.2xlarge, auto_volumes: [], nvme: {volumes: [{mountpoint: "/var/log/mysvc", fstype: ext4, volume_size: 2500}, {mountpoint: "/var/log/mysvc", fstype: ext4, volume_size: 2500}], lvmparams: {vg_name: "vg0", lv_name: "lv0", lv_size: "100%FREE"} } }
+#      sys: {vms_by_az: {a: 1, b: 1, c: 1}, flavor: t3.micro, auto_volumes: []}
+#      #sysdisks: {vms_by_az: {a: 1, b: 1, c: 1}, flavor: t3.micro, auto_volumes: [{"device_name": "/dev/sdb", mountpoint: "/var/log/mysvc", fstype: "ext4", "volume_type": "gp2", "volume_size": 2, ephemeral: False, encrypted: True, "delete_on_termination": true, perms: {owner: "root", group: "sudo", mode: "775"} }, {"device_name": "/dev/sdc", mountpoint: "/var/log/mysvc2", fstype: "ext4", "volume_type": "gp2", "volume_size": 2, ephemeral: False, encrypted: True, "delete_on_termination": true}, {"device_name": "/dev/sdd", mountpoint: "/var/log/mysvc3", fstype: "ext4", "volume_type": "gp2", "volume_size": 2, ephemeral: False, encrypted: True, "delete_on_termination": true}]}
+#      #sysnvme_multi: {vms_by_az: {a: 1, b: 1, c: 1}, flavor: i3en.2xlarge, auto_volumes: [], nvme: {volumes: [{mountpoint: "/var/log/mysvc", fstype: ext4, volume_size: 2500}, {mountpoint: "/var/log/mysvc2", fstype: ext4, volume_size: 2500}]} } }
+#      #sysnvme_lvm: {vms_by_az: {a: 1, b: 1, c: 1}, flavor: i3en.2xlarge, auto_volumes: [], nvme: {volumes: [{mountpoint: "/var/log/mysvc", fstype: ext4, volume_size: 2500}, {mountpoint: "/var/log/mysvc", fstype: ext4, volume_size: 2500}], lvmparams: {vg_name: "vg0", lv_name: "lv0", lv_size: "100%FREE"} } }
 #    aws_access_key: ""
 #    aws_secret_key: ""
 #    vpc_name: "<team_name>-{{buildenv}}"
@@ -107,8 +107,8 @@ cluster_name: "{{app_name}}-{{buildenv}}"
 #      description: "Access from all VMs attached to the {{cluster_name}}-nwtag group"
 #  sandbox:
 #    hosttype_vars:
-#      sys: {count_per_az: 1, az: ["b", "c"], flavor: f1-micro, rootvol_size: "10", auto_volumes: []}
-#      #sysdisks: {count_per_az: 1, az: ["b"], flavor: f1-micro, rootvol_size: "10", auto_volumes: [{auto_delete: true, interface: "SCSI", volume_size: 2, mountpoint: "/var/log/mysvc", fstype: "ext4", perms: {owner: "root", group: "sudo", mode: "775"}}, {auto_delete: true, interface: "SCSI", volume_size: 2,  mountpoint: "/var/log/mysvc2", fstype: "ext4"}, {auto_delete: true, interface: "SCSI", volume_size: 3,  mountpoint: "/var/log/mysvc3", fstype: "ext4"}]}
+#      sys: {vms_by_az: {b: 1, c: 1, d: 1}, flavor: f1-micro, rootvol_size: "10", auto_volumes: []}
+#      #sysdisks: {vms_by_az: {b: 1, c: 1, d: 1}, flavor: f1-micro, rootvol_size: "10", auto_volumes: [{auto_delete: true, interface: "SCSI", volume_size: 2, mountpoint: "/var/log/mysvc", fstype: "ext4", perms: {owner: "root", group: "sudo", mode: "775"}}, {auto_delete: true, interface: "SCSI", volume_size: 2,  mountpoint: "/var/log/mysvc2", fstype: "ext4"}, {auto_delete: true, interface: "SCSI", volume_size: 3,  mountpoint: "/var/log/mysvc3", fstype: "ext4"}]}
 #    vpc_network_name: "<team_name>-{{buildenv}}"
 #    vpc_subnet_name: ""
 #    preemptible: "false"

--- a/jenkinsfiles/Jenkinsfile_exec_deploy
+++ b/jenkinsfiles/Jenkinsfile_exec_deploy
@@ -20,7 +20,7 @@ pipeline {
           if (GENUINE_BUILD == "false"){
             error "Parameters not specified, Tick the GENUINE_BUILD box to run the job"
           }
-        }          
+        }
         sh 'env'
         sh 'pipenv install --python /usr/bin/python3'
       }
@@ -29,7 +29,7 @@ pipeline {
       environment {
         VAULT_PASSWORD_BUILDENV = credentials("VAULT_PASSWORD_${params.DEPLOY_ENV.toUpperCase()}")
         DEPLOY_ENV="${params.DEPLOY_ENV}"
-      }  
+      }
       when {
         expression { params.DEPLOY_TYPE == 'Deploy' }
       }
@@ -47,7 +47,7 @@ pipeline {
         DEPLOY_ENV="${params.DEPLOY_ENV}"
         CANARY="-e canary=${params.CANARY}"
         MYHOSTTYPES="-e myhosttypes=${params.MYHOSTTYPES}"
-      }      
+      }
       when {
         expression { params.DEPLOY_TYPE == 'ReDeploy' && params.MYHOSTTYPES != ""}
       }
@@ -64,7 +64,7 @@ pipeline {
         VAULT_PASSWORD_BUILDENV = credentials("VAULT_PASSWORD_${params.DEPLOY_ENV.toUpperCase()}")
         DEPLOY_ENV="${params.DEPLOY_ENV}"
         CANARY="-e canary=${params.CANARY}"
-      }      
+      }
       when {
         expression { params.DEPLOY_TYPE == 'ReDeploy' && params.MYHOSTTYPES == ""}
       }
@@ -75,12 +75,12 @@ pipeline {
           sh 'pipenv run ansible-playbook  -u ${sshuser} --private-key=${keyfile}  -e buildenv=$DEPLOY_ENV -e clusterid=$CLUSTER_ID  -e skip_package_upgrade=true --vault-id=$DEPLOY_ENV@.vaultpass-client.py redeploy.yml $CANARY'
         }
       }
-    }    
+    }
     stage('Execute Clean Playbook') {
       environment {
         VAULT_PASSWORD_BUILDENV = credentials("VAULT_PASSWORD_${params.DEPLOY_ENV.toUpperCase()}")
-        DEPLOY_ENV="${params.DEPLOY_ENV}"   
-      }      
+        DEPLOY_ENV="${params.DEPLOY_ENV}"
+      }
       when {
         expression { params.DEPLOY_TYPE == 'Clean' }
       }
@@ -90,7 +90,7 @@ pipeline {
           sh 'echo "$DEPLOY_ENV: len $(echo -n $VAULT_PASSWORD_BUILDENV | /usr/bin/wc -c) sum $(echo -n $VAULT_PASSWORD_BUILDENV | /usr/bin/sum)  "'
           sh 'pipenv run ansible-playbook  -u ${sshuser} --private-key=${keyfile}  -e buildenv=$DEPLOY_ENV -e clusterid=$CLUSTER_ID  -e skip_package_upgrade=true --vault-id=$DEPLOY_ENV@.vaultpass-client.py cluster.yml --tags=clusterverse_clean -e clean=true'
         }
-      }            
+      }
     }
   }
 }

--- a/jenkinsfiles/Jenkinsfile_exec_release
+++ b/jenkinsfiles/Jenkinsfile_exec_release
@@ -10,13 +10,13 @@ pipeline {
   }
   triggers {
       cron('0 9-16/1 * * 1-5')
-  }  
+  }
   stages {
     stage('Create Release') {
       environment {
         NEW_VERSION="${params.NEW_VERSION}"
         GIT_TOKEN = credentials("GITHUB_SVC_USER")
-      }         
+      }
       steps {
         script {
           def apiUrl = "https://api.github.com/repos/sky-uk/clusterverse/releases"
@@ -29,7 +29,7 @@ pipeline {
             int index=version.lastIndexOf('.')+1
             String major=version.substring(0,version.lastIndexOf('.')+1)
             NEW_VERSION = "${major}${m}"
-          }          
+          }
           def body = sh(returnStdout: true, script: "git log ${latestRelease.tag_name}..HEAD --pretty=format:\"<li> %H - %s</li>\"").trim()
           if (body != "") {
             def payload = JsonOutput.toJson(["tag_name": "${NEW_VERSION}", "name": "${NEW_VERSION}", "body": "${body}"])
@@ -49,6 +49,6 @@ pipeline {
           build job: "clusterverse-release-deploy", wait: false, parameters: [string(name: 'GENUINE_BUILD', value: "true"), string(name: 'DEPLOY_ENV', value: "sandbox"), string(name: 'RELEASE', value: "${VERSION_TO_DEPLOY}")]
         }
       }
-    }        
+    }
   }
 }

--- a/jenkinsfiles/Jenkinsfile_exec_release_deploy
+++ b/jenkinsfiles/Jenkinsfile_exec_release_deploy
@@ -16,7 +16,7 @@ pipeline {
     stage('Init Environment') {
       environment {
         GENUINE_BUILD="${params.GENUINE_BUILD}"
-      }      
+      }
       steps {
         script{
           if (GENUINE_BUILD == "false"){
@@ -26,8 +26,8 @@ pipeline {
         sh 'env'
         sh 'pipenv install --python /usr/bin/python3'
       }
-    }    
-    stage('ReDeploy Release') { 
+    }
+    stage('ReDeploy Release') {
       environment {
         DEPLOY_ENV="${params.DEPLOY_ENV}"
         RELEASE ="${params.RELEASE}"
@@ -35,7 +35,7 @@ pipeline {
         VAULT_PASSWORD_BUILDENV = credentials("VAULT_PASSWORD_${params.DEPLOY_ENV.toUpperCase()}")
         CANARY="-e canary=${params.CANARY}"
         MYHOSTTYPES="-e myhosttypes=${params.MYHOSTTYPES}"
-      }             
+      }
       steps {
         script {
           try {
@@ -43,13 +43,13 @@ pipeline {
             sh "git remote set-url origin https://${GIT_TOKEN_USR}:${GIT_TOKEN_PSW}@github.com/sky-uk/clusterverse.git"
             sh 'git fetch --tags'
             sh 'git checkout ${RELEASE}'
-            withCredentials([sshUserPrivateKey(credentialsId: "VTP_${params.DEPLOY_ENV.toUpperCase()}_SSH_KEY", keyFileVariable: 'keyfile', usernameVariable: 'sshuser')]) {          
+            withCredentials([sshUserPrivateKey(credentialsId: "VTP_${params.DEPLOY_ENV.toUpperCase()}_SSH_KEY", keyFileVariable: 'keyfile', usernameVariable: 'sshuser')]) {
               sh 'env'
               sh 'echo "$DEPLOY_ENV: len $(echo -n $VAULT_PASSWORD_BUILDENV | /usr/bin/wc -c) sum $(echo -n $VAULT_PASSWORD_BUILDENV | /usr/bin/sum)"'
               sh 'pipenv run ansible-playbook  -u ${sshuser} --private-key=${keyfile}  -e buildenv=$DEPLOY_ENV -e clusterid=$CLUSTER_ID -e skip_package_upgrade=true --vault-id=$DEPLOY_ENV@.vaultpass-client.py redeploy.yml $CANARY $MYHOSTTYPES -e release_version=$RELEASE'
-            }    
+            }
           } catch (err) {
-            // echo "Failed: ${err} - Version ${broken_version} will be deleted and the previous version will be deployed."  
+            // echo "Failed: ${err} - Version ${broken_version} will be deleted and the previous version will be deployed."
             // def stable_version = sh(returnStdout: true, script: "git describe --abbrev=0 --tags `git rev-list --tags --skip=1 --max-count=1`").trim()
             // def broken_version = sh(returnStdout: true, script: "git describe --tags `git rev-list --tags --max-count=1`").trim()
             //   sh "git checkout -b ${broken_version}-broken-version"
@@ -57,15 +57,15 @@ pipeline {
             //   sh "git push --delete origin ${broken_version}"
             //   sh 'git fetch --tags'
             //   sh "git checkout ${stable_version}"
-            //   withCredentials([sshUserPrivateKey(credentialsId: "VTP_${params.DEPLOY_ENV.toUpperCase()}_SSH_KEY", keyFileVariable: 'keyfile', usernameVariable: 'sshuser')]) {          
+            //   withCredentials([sshUserPrivateKey(credentialsId: "VTP_${params.DEPLOY_ENV.toUpperCase()}_SSH_KEY", keyFileVariable: 'keyfile', usernameVariable: 'sshuser')]) {
             //   sh 'env'
             //   sh 'echo "$DEPLOY_ENV: len $(echo -n $VAULT_PASSWORD_BUILDENV | /usr/bin/wc -c) sum $(echo -n $VAULT_PASSWORD_BUILDENV | /usr/bin/sum)  "'
             //   sh 'pipenv run ansible-playbook  -u ${sshuser} --private-key=${keyfile}  -e buildenv=$DEPLOY_ENV -e clusterid=$CLUSTER_ID  -e skip_package_upgrade=true --vault-id=$DEPLOY_ENV@.vaultpass-client.py cluster.yml -e clean=true --tags=clusterverse_clean'
             // }
-              error "${RELEASE} deployment failed"               
+              error "${RELEASE} deployment failed"
           }
-        }        
+        }
       }
-    }       
+    }
   }
 }

--- a/roles/clusterverse/clean/tasks/gce.yml
+++ b/roles/clusterverse/clean/tasks/gce.yml
@@ -7,6 +7,15 @@
   run_once: true
   when: "cluster_vars[buildenv].deletion_protection == 'yes'"
 
+#- name: Remove deletion protection (broken)
+#  gcp_compute_instance:
+#    name: "{{item.hostname}}"
+#    project: "{{cluster_vars.project_id}}"
+#    zone: "{{cluster_vars.region}}-{{item.az_name}}"
+#    auth_kind: "serviceaccount"
+#    service_account_file: "{{gcp_credentials_file}}"
+#    deletion_protection: no
+
 - name: Delete GCE VMs asynchronously
   gcp_compute_instance:
     name: "{{item.hostname}}"

--- a/roles/clusterverse/cluster_hosts/tasks/aws.yml
+++ b/roles/clusterverse/cluster_hosts/tasks/aws.yml
@@ -15,8 +15,6 @@
   set_fact:
     vpc_id: "{{ vpcdata.vpcs[0].id }}"
 
-#- debug: msg={{cluster_vars[buildenv].hosttype_vars | json_query('*.[az]|[]|[]') | unique}}
-
 - name: Looking up proxy Subnet facts
   ec2_vpc_subnet_facts:
     region:         "{{ cluster_vars.region }}"
@@ -26,7 +24,7 @@
       "tag:Name": "{{ cluster_vars[buildenv].vpc_subnet_name_prefix }}{{item}}"
       vpc-id:     "{{ vpc_id }}"
   register: subnetdata
-  with_items: "{{cluster_vars[buildenv].hosttype_vars | json_query('*.[az]|[]|[]') | unique}}"
+  with_items: "{{ cluster_vars[buildenv].hosttype_vars | json_query(\"*[vms_by_az][][keys(@)][][]\") | unique }}"
   delegate_to: localhost
   run_once: true
 

--- a/roles/clusterverse/cluster_hosts/tasks/gce.yml
+++ b/roles/clusterverse/cluster_hosts/tasks/gce.yml
@@ -53,7 +53,7 @@
     auth_kind: "serviceaccount"
     service_account_file: "{{gcp_credentials_file}}"
     scopes: ["https://www.googleapis.com/auth/compute.readonly"]
-  with_items: "{{ cluster_vars[buildenv].hosttype_vars | json_query('*.az|[]') | unique }}"
+  with_items: "{{ cluster_vars[buildenv].hosttype_vars | json_query(\"*[vms_by_az][][keys(@)][][]\") | unique }}"
   register: gcp_compute_instance_info
   delegate_to: localhost
   run_once: true
@@ -140,7 +140,7 @@
   delegate_to: localhost
 
 - set_fact:
-    current_release_per_instance: "{{gcp_compute_instance_info_updated.results | json_query(\"[].resources[].{value: metadata.items[?key==`release`].value | [0], key: name}\") | items2dict}}"
+    current_release_per_instance: "{{gcp_compute_instance_info_updated.results | json_query(\"[].resources[].{value: labels.release, key: name}\") | items2dict}}"
     current_deploy_status_per_instance: "{{gcp_compute_instance_info_updated.results | json_query(\"[].resources[].{value: labels.deploy_status, key: name}\") | items2dict}}"
 
 - name: update cluster_hosts_flat with current release and deploy_status

--- a/roles/clusterverse/cluster_hosts/tasks/main.yml
+++ b/roles/clusterverse/cluster_hosts/tasks/main.yml
@@ -9,8 +9,8 @@
     cluster_hosts_flat: |
       {% set res = [] -%}
       {%- for hostttype in cluster_vars[buildenv].hosttype_vars.keys() -%}
-        {%- for azname in cluster_vars[buildenv].hosttype_vars[hostttype].az -%}
-          {%- for azcount in range(0,cluster_vars[buildenv].hosttype_vars[hostttype].count_per_az|int) -%}
+        {%- for azname in cluster_vars[buildenv].hosttype_vars[hostttype].vms_by_az.keys() -%}
+          {%- for azcount in range(0,cluster_vars[buildenv].hosttype_vars[hostttype].vms_by_az[azname]|int) -%}
             {% set _dummy = res.extend([{
               'hosttype': hostttype,
               'hostname': cluster_name + '-' + hostttype + '-' + azname + azcount|string,
@@ -22,24 +22,6 @@
         {%- endfor %}
       {%- endfor %}
       {{ res }}
-
-- name: get other hosts
-  set_fact:
-    other_hosts: "{{ (hostvars[ansible_play_hosts[0]].cluster_hosts_flat | json_query('[].hostname') + ['localhost']) | unique | symmetric_difference(ansible_play_hosts) }}"
-  run_once: true
-
-#- name: other_hosts
-#  debug: msg={{other_hosts}}
-#  run_once: true
-
-- name: set the cluster_hosts_flat variable on all other hosts
-  set_fact:
-    cluster_hosts_flat: "{{hostvars['localhost'].cluster_hosts_flat}}"
-    cacheable: true
-  delegate_to: "{{item}}"
-  delegate_facts: True
-  run_once: true
-  with_items: "{{ other_hosts }}"
 
 - include_tasks: aws.yml
   when: cluster_vars.type == "aws"

--- a/roles/clusterverse/create/tasks/gce.yml
+++ b/roles/clusterverse/create/tasks/gce.yml
@@ -81,29 +81,33 @@
   block:
     - name: Create GCP VMs asynchronously
       gcp_compute_instance:
+        auth_kind: "serviceaccount"
+        service_account_file: "{{gcp_credentials_file}}"
+        project: "{{cluster_vars.project_id}}"
+        zone: "{{cluster_vars.region}}-{{item.az_name}}"
         name: "{{item.hostname}}"
         machine_type: "{{item.flavor}}"
         disks: "{{_host_disks}}"
         metadata:
+          startup-script: "{%- if cluster_vars.ssh_guard_whitelist is defined and cluster_vars.ssh_guard_whitelist | length > 0 -%}#! /bin/bash\n\n#Whitelist my inbound IPs\n[ -f /etc/sshguard/whitelist ] && echo \"{{cluster_vars.ssh_guard_whitelist | join ('\n')}}\" >>/etc/sshguard/whitelist && /bin/systemctl restart sshguard{%- endif -%}"
+          ssh-keys: "{{ gce_ssh_username }}:{{ gce_ssh_pubkey }} {{ gce_ssh_username }}"
+        labels:
           hosttype: "{{item.hosttype}}"
           env: "{{buildenv}}"
           release: "{%- if rescuing is defined and rescuing != \"false\" and instance_to_create is defined and instance_to_create == item.hostname -%}{{rescuing}}{%- elif instance_to_create is defined and instance_to_create == item.hostname -%}{{item.release}}{%- else -%}{{item.current_release}}{%- endif -%}"
           cluster_name: "{{cluster_name}}"
           owner: "{{ lookup('env','USER') }}"
-          startup-script: "{%- if cluster_vars.ssh_guard_whitelist is defined and cluster_vars.ssh_guard_whitelist | length > 0 -%}#! /bin/bash\n\n#Whitelist my inbound IPs\n[ -f /etc/sshguard/whitelist ] && echo \"{{cluster_vars.ssh_guard_whitelist | join ('\n')}}\" >>/etc/sshguard/whitelist && /bin/systemctl restart sshguard{%- endif -%}"
-          ssh-keys: "{{ gce_ssh_username }}: {{ gce_ssh_pubkey }} {{ gce_ssh_username }}"
+          maintenance_mode: "true"
+          deploy_status: "{%- if rescuing is defined and rescuing != \"false\" and instance_to_create is defined and instance_to_create == item.hostname -%}old{%- elif instance_to_create is defined and instance_to_create == item.hostname -%}new{%- else -%}{{item.current_deploy_status}}{%- endif -%}"
         network_interfaces:
           - network: "{{ gcp_compute_network_info['items'][0] | default({}) }}"
             subnetwork: "{{ gcp_compute_subnetwork_info['resources'][0] | default({}) }}"
             access_configs: "{%- if cluster_vars.assign_public_ip == 'yes' -%}[{\"name\": \"External NAT\", \"type\": \"ONE_TO_ONE_NAT\"}]{%- else -%}[]{%- endif -%}"
-        zone: "{{cluster_vars.region}}-{{item.az_name}}"
+        tags: { items: "{{cluster_vars.network_fw_tags}}" }
         can_ip_forward : "{{cluster_vars.ip_forward}}"
         scheduling: { automatic_restart: yes, preemptible: "{{cluster_vars[buildenv].preemptible}}" }
         state: present
-        tags: { items: "{{cluster_vars.network_fw_tags}}" }
-        project: "{{cluster_vars.project_id}}"
-        auth_kind: "serviceaccount"
-        service_account_file: "{{gcp_credentials_file}}"
+        deletion_protection: "{{cluster_vars[buildenv].deletion_protection}}"
       vars:
         __autodisksnames: "{%- if cluster_vars[buildenv].hosttype_vars[item.hosttype].auto_volumes | length -%}[{%- for vol in cluster_vars[buildenv].hosttype_vars[item.hosttype].auto_volumes -%}{%- set mountname = vol.mountpoint | regex_replace('.*\\/(.*)', '\\\\1') -%}{{vol|combine({'mountname': mountname})}}{% if not loop.last %},{% endif %}{%- endfor -%}]{%- else -%}[]{%- endif-%}"
         _autodisks: "{{__autodisksnames | to_json | from_json | json_query(\" [].{auto_delete: auto_delete, interface: interface, device_name: join('',[`\"+item.hostname+\"--`,mountname]), initialize_params: {disk_name: join('',[`\"+item.hostname+\"--`,mountname]), disk_size_gb: volume_size}} \") }}"
@@ -130,56 +134,6 @@
       delegate_to: localhost
       run_once: true
 
-    - name: Set deletion protection
-      command: "gcloud compute instances update {{item.hostname}} --deletion-protection --zone {{cluster_vars.region}}-{{item.az_name}}"
-      with_items: "{{cluster_hosts_flat}}"
-      delegate_to: localhost
-      run_once: true
-      when: "cluster_vars[buildenv].deletion_protection == 'yes'"
-
-    # Currently GCP doesn't allow to amend a metadata field and labels don't support . (e.g. v1.0.0)
-    # - name: update release tag when run normal deploy
-    #   gce_labels:
-    #     resource_name: "{{item.hostname}}"
-    #     resource_type: instances
-    #     resource_location: "{{cluster_vars.region}}-{{item.az_name}}"
-    #     project_id: "{{cluster_vars.project_id}}"
-    #     credentials_file: "{{gcp_credentials_file}}"
-    #     labels:
-    #       release: "{{ release_version }}"
-    #     state: present
-    #   with_items: "{{cluster_hosts_flat}}"
-    #   when: (instance_to_create is undefined and rescuing is undefined)
-
-    - name: force set maintenance_mode to true (when prometheus_set_unset_maintenance_mode)
-      gce_labels:
-        resource_name: "{{item.hostname}}"
-        resource_type: instances
-        resource_location: "{{cluster_vars.region}}-{{item.az_name}}"
-        project_id: "{{cluster_vars.project_id}}"
-        credentials_file: "{{gcp_credentials_file}}"
-        labels:
-          maintenance_mode: "true"
-        state: present
-      delegate_to: localhost
-      run_once: true
-      with_items: "{{cluster_hosts_flat}}"
-      when: (prometheus_set_unset_maintenance_mode is defined and prometheus_set_unset_maintenance_mode|bool)
-
-    - name: set deploy_status label
-      gce_labels:
-        resource_name: "{{item.hostname}}"
-        resource_type: instances
-        resource_location: "{{cluster_vars.region}}-{{item.az_name}}"
-        project_id: "{{cluster_vars.project_id}}"
-        credentials_file: "{{gcp_credentials_file}}"
-        labels:
-          deploy_status: "{%- if rescuing is defined and rescuing != \"false\" and instance_to_create is defined and instance_to_create == item.hostname -%}old{%- elif instance_to_create is defined and instance_to_create == item.hostname -%}new{%- else -%}{{item.current_deploy_status}}{%- endif -%}"
-        state: present
-      delegate_to: localhost
-      run_once: true
-      with_items: "{{cluster_hosts_flat}}"
-      when: (prometheus_set_unset_maintenance_mode is defined and prometheus_set_unset_maintenance_mode|bool)
 
     # Need this because the gcp_compute_instance module does not return all the facts if the instance is already existing (only if newly created)
     # Note: 'scopes' comes from here (https://developers.google.com/identity/protocols/googlescopes#computev1)
@@ -196,13 +150,13 @@
       register: gcp_compute_instance_info
       run_once: true
 
-    # - debug: msg={{gcp_compute_instance_info}}
+#    - debug: msg={{gcp_compute_instance_info}}
 
     - set_fact:
         dynamic_inventory_flat: |
           {%- if cluster_vars.inventory_ip == 'private' -%}
-            {{ gcp_compute_instance_info.results | json_query('[*].resources[].{hosttype: metadata.items[?key==`hosttype`].value|[0], hostname: name, private_ip: networkInterfaces[0].networkIP, public_ip: networkInterfaces[0].accessConfigs[0].natIP, inventory_ip: networkInterfaces[0].networkIP}') }}
+            {{ gcp_compute_instance_info.results | json_query('[*].resources[].{hosttype: labels.hosttype, hostname: name, private_ip: networkInterfaces[0].networkIP, public_ip: networkInterfaces[0].accessConfigs[0].natIP, inventory_ip: networkInterfaces[0].networkIP}') }}
           {%- else -%}
-            {{ gcp_compute_instance_info.results | json_query('[*].resources[].{hosttype: metadata.items[?key==`hosttype`].value|[0], hostname: name, private_ip: networkInterfaces[0].networkIP, public_ip: networkInterfaces[0].accessConfigs[0].natIP, inventory_ip: networkInterfaces[0].accessConfigs[0].natIP}') }}
+            {{ gcp_compute_instance_info.results | json_query('[*].resources[].{hosttype: labels.hosttype, hostname: name, private_ip: networkInterfaces[0].networkIP, public_ip: networkInterfaces[0].accessConfigs[0].natIP, inventory_ip: networkInterfaces[0].accessConfigs[0].natIP}') }}
           {%- endif -%}
 

--- a/roles/clusterverse/redeploy/_scheme_addnewvm_rmdisk_rollback/tasks/gce_del.yml
+++ b/roles/clusterverse/redeploy/_scheme_addnewvm_rmdisk_rollback/tasks/gce_del.yml
@@ -24,6 +24,15 @@
       run_once: true
       when: "cluster_vars[buildenv].deletion_protection == 'yes'"
 
+#    - name: Remove deletion protection (broken)
+#      gcp_compute_instance:
+#        name: "{{item.name}}"
+#        project: "{{cluster_vars.project_id}}"
+#        zone: "{{item.zone | regex_replace('.*/(.*)$', '\\1')}}"
+#        auth_kind: "serviceaccount"
+#        service_account_file: "{{gcp_credentials_file}}"
+#        deletion_protection: no
+
     - name: Delete GCE VMs asynchronously
       gcp_compute_instance:
         name: "{{item.name}}"

--- a/roles/clusterverse/redeploy/_scheme_addnewvm_rmdisk_rollback/tasks/gce_del.yml
+++ b/roles/clusterverse/redeploy/_scheme_addnewvm_rmdisk_rollback/tasks/gce_del.yml
@@ -24,37 +24,6 @@
       run_once: true
       when: "cluster_vars[buildenv].deletion_protection == 'yes'"
 
-    - name: delete maintenance_mode label
-      gce_labels:
-        resource_name: "{{ item.name }}"
-        resource_type: instances
-        resource_location: "{{item.zone | regex_replace('.*/(.*)$', '\\1')}}"
-        project_id: "{{ cluster_vars.project_id }}"
-        credentials_file: "{{ gcp_credentials_file }}"
-        labels:
-          maintenance_mode: "{{ maintenance_mode_tag }}"
-        state: absent
-      delegate_to: localhost
-      run_once: true
-      vars:
-        maintenance_mode_tag: "{{gcp_compute_instance_info.results | json_query('[].resources[?name==`' + item.name + '`].labels.maintenance_mode | [] | [0]')}}"
-      with_items: "{{gcp_compute_instance_info.results | json_query('[].resources[]')}}"
-      when: maintenance_mode_tag != ""
-
-    - name: remove_maintenance_mode
-      gce_labels:
-        resource_name: "{{item.name}}"
-        resource_type: instances
-        resource_location: "{{item.zone | regex_replace('.*/(.*)$', '\\1')}}"
-        project_id: "{{cluster_vars.project_id}}"
-        credentials_file: "{{gcp_credentials_file}}"
-        labels:
-          maintenance_mode: "true"
-        state: present
-      delegate_to: localhost
-      run_once: true
-      with_items: "{{gcp_compute_instance_info.results | json_query('[].resources[]')}}"
-
     - name: Delete GCE VMs asynchronously
       gcp_compute_instance:
         name: "{{item.name}}"

--- a/roles/clusterverse/redeploy/_scheme_addnewvm_rmdisk_rollback/tasks/gce_rescue_instance.yml
+++ b/roles/clusterverse/redeploy/_scheme_addnewvm_rmdisk_rollback/tasks/gce_rescue_instance.yml
@@ -2,6 +2,17 @@
 
 - debug: msg="Attempting to rollback {{host_to_rollback}}"
 
+- name: "Get GCP instance facts for {{host_to_rollback}}"
+  gcp_compute_instance_info:
+    zone: "{{cluster_vars.region}}-{{host_to_rollback | regex_replace('.*-([a-z])[0-9]-.*', '\\1')}}"
+    filters:
+      - "name = {{host_to_rollback}}*"
+    project: "{{cluster_vars.project_id}}"
+    auth_kind: "serviceaccount"
+    service_account_file: "{{gcp_credentials_file}}"
+    scopes: ["https://www.googleapis.com/auth/compute.readonly"]
+  register: gcp_compute_instance_info
+
 - name: Rescuing GCP instance
   gcp_compute_instance:
     name: "{{host_to_rollback}}"
@@ -10,18 +21,7 @@
     auth_kind: "serviceaccount"
     service_account_file: "{{gcp_credentials_file}}"
     status: "RUNNING"
-  async: 7200
-  poll: 0
-  delegate_to: localhost
-  register: gcp_compute_instance
-
-- name: Wait for gce instance start to complete
-  async_status:
-    jid: "{{ gcp_compute_instance.ansible_job_id }}"
-  register: gcp_jobs
-  until: gcp_jobs.finished
-  retries: 300
-  delegate_to: localhost
+    labels: "{{ gcp_compute_instance_info.resources[0].labels }}"
 
 - name: "set argument variables for {{mainclusteryml}}"
   set_fact:

--- a/roles/clusterverse/redeploy/_scheme_addnewvm_rmdisk_rollback/tasks/gce_stop_instance.yml
+++ b/roles/clusterverse/redeploy/_scheme_addnewvm_rmdisk_rollback/tasks/gce_stop_instance.yml
@@ -2,51 +2,30 @@
 
 - debug: msg="Stop {{host_to_stop.hostname}}"
 
-
 - name: gcp_stop | Stop GCE instance
   block:
-
     - name: Get GCP instance facts
       gcp_compute_instance_info:
         zone: "{{cluster_vars.region}}-{{host_to_stop.hostname | regex_replace('.*-([a-z])[0-9]-.*', '\\1')}}"
         filters:
           - "name = {{host_to_stop.hostname}}*"
-          - "status = RUNNING"
         project: "{{cluster_vars.project_id}}"
         auth_kind: "serviceaccount"
         service_account_file: "{{gcp_credentials_file}}"
         scopes: ["https://www.googleapis.com/auth/compute.readonly"]
       register: gcp_compute_instance_info
-      delegate_to: localhost
 
-    - name: Delete maintenance_mode label
-      gce_labels:
-        resource_name: "{{ host_to_stop.hostname }}"
-        resource_type: instances
-        resource_location: "{{cluster_vars.region}}-{{host_to_stop.hostname | regex_replace('.*-([a-z])[0-9]-.*', '\\1')}}"
-        project_id: "{{ cluster_vars.project_id }}"
-        credentials_file: "{{ gcp_credentials_file }}"
-        labels:
-          maintenance_mode: "{{ maintenance_mode_tag }}"
-        state: absent
-      delegate_to: localhost
-      run_once: true
-      vars:
-        maintenance_mode_tag: "{{gcp_compute_instance_info | json_query('resources[?name==`' + host_to_stop.hostname + '`].labels.maintenance_mode | [] | [0]')}}"
-      when: maintenance_mode_tag != ""
-
-    - name: Set_maintenance_mode
-      gce_labels:
-        resource_name: "{{host_to_stop.hostname}}"
-        resource_type: instances
-        resource_location: "{{cluster_vars.region}}-{{host_to_stop.hostname | regex_replace('.*-([a-z])[0-9]-.*', '\\1')}}"
-        project_id: "{{cluster_vars.project_id}}"
-        credentials_file: "{{gcp_credentials_file}}"
-        labels:
-          maintenance_mode: "true"
-        state: present
-      delegate_to: localhost
-      run_once: true
+    - name: Stop GCE VM and set maintenance_mode to true
+      gcp_compute_instance:
+        name: "{{host_to_stop.hostname}}"
+        project: "{{cluster_vars.project_id}}"
+        zone: "{{cluster_vars.region}}-{{host_to_stop.hostname | regex_replace('.*-([a-z])[0-9]-.*', '\\1')}}"
+        auth_kind: "serviceaccount"
+        service_account_file: "{{gcp_credentials_file}}"
+        deletion_protection: "{{cluster_vars[buildenv].deletion_protection}}"
+        status: "TERMINATED"
+        labels: "{{ gcp_compute_instance_info.resources[0].labels | combine({'maintenance_mode': true}) }}"
+      register: gcp_compute_instance
 
     - name: Delete DNS A records using nsupdate (if applicable)
       nsupdate:
@@ -83,24 +62,3 @@
           private_zone: "{{cluster_vars.route53_private_zone | default(true)}}"
         when: dns_rec.set.value is defined
       when: cluster_vars.dns_server == "route53" and cluster_vars.dns_zone_external is defined and cluster_vars.dns_zone_external != ""
-
-    - name: Stop GCE VMs asynchronously
-      gcp_compute_instance:
-        name: "{{host_to_stop.hostname}}"
-        project: "{{cluster_vars.project_id}}"
-        zone: "{{cluster_vars.region}}-{{host_to_stop.hostname | regex_replace('.*-([a-z])[0-9]-.*', '\\1')}}"
-        auth_kind: "serviceaccount"
-        service_account_file: "{{gcp_credentials_file}}"
-        status: "TERMINATED"
-      register: gcp_compute_instance
-      async: 7200
-      poll: 0
-      delegate_to: localhost
-
-    - name: Wait for gce instance stop to complete
-      async_status:
-        jid: "{{ gcp_compute_instance.ansible_job_id }}"
-      register: gcp_jobs
-      until: gcp_jobs.finished
-      retries: 300
-      delegate_to: localhost

--- a/roles/clusterverse/redeploy/_scheme_rmvm_rmdisks_only/tasks/gce_del.yml
+++ b/roles/clusterverse/redeploy/_scheme_rmvm_rmdisks_only/tasks/gce_del.yml
@@ -1,6 +1,6 @@
 ---
 
-- debug: msg="Stop {{host_to_del.hostname}}"
+- debug: msg="Delete {{host_to_del.hostname}}"
 
 - name: Delete GCE instance
   block:
@@ -49,6 +49,19 @@
           when: item.set.value is defined
       when: cluster_vars[clusterid].dns_server == "route53" and cluster_vars[clusterid].dns_zone_external is defined and cluster_vars[clusterid].dns_zone_external != ""
 
+    - name: Remove deletion protection
+      command: "gcloud compute instances update {{host_to_del.hostname}} --no-deletion-protection --zone {{cluster_vars[clusterid].region}}-{{host_to_del.hostname | regex_replace('.*-([a-z])[0-9]-.*', '\\1')}}"
+      when: "cluster_vars[buildenv].deletion_protection == 'yes'"
+
+#    - name: Remove deletion protection (broken)
+#      gcp_compute_instance:
+#        name: "{{host_to_del.hostname}}"
+#        project: "{{cluster_vars.project_id}}"
+#        zone: "{{cluster_vars[clusterid].region}}-{{host_to_del.hostname | regex_replace('.*-([a-z])[0-9]-.*', '\\1')}}"
+#        auth_kind: "serviceaccount"
+#        service_account_file: "{{gcp_credentials_file}}"
+#        deletion_protection: no
+
     - name: Delete GCE VM
       gcp_compute_instance:
         name: "{{host_to_del.hostname}}"
@@ -58,14 +71,3 @@
         service_account_file: "{{gcp_credentials_file}}"
         status: "absent"
       register: gcp_compute_instance
-      async: 7200
-      poll: 0
-      delegate_to: localhost
-
-    - name: Wait for gce instance stop to complete
-      async_status:
-        jid: "{{ gcp_compute_instance.ansible_job_id }}"
-      register: gcp_jobs
-      until: gcp_jobs.finished
-      retries: 300
-      delegate_to: localhost


### PR DESCRIPTION
+ Define the clusters as a count of nodes per AZ, rather than a count of AZ-clusters.  Allows us to have non-multiples of availability zones (e.g. 5 Zookeeper nodes).
+ Fix GCP redeploy: gcp_compute_instance changed in 2.9.  deletion_protection is now defined in gcp_compute_instance, and must be set.  Labels also must always be set, or their absence causes them to be removed.