### PR TITLE
Fix Route53 deletion with private zones

### DIFF
--- a/clean/tasks/main.yml
+++ b/clean/tasks/main.yml
@@ -41,7 +41,7 @@
       zone: "{{cluster_vars.dns_zone_external}}"
       record: "{{item.hostname}}.{{cluster_vars.dns_zone_external}}"
       type: "A"
-      private_zone: true
+      private_zone: "{{cluster_vars.route53_private_zone | default(true)}}"
     register: dns_rec
     with_items: "{{ cluster_hosts_flat }}"
 
@@ -55,7 +55,7 @@
       type: "{{ item.set.type }}"
       ttl: "{{ item.set.ttl }}"
       value: ["{{ item.set.value }}"]
-      private_zone: true
+      private_zone: "{{cluster_vars.route53_private_zone | default(true)}}"
     with_items: "{{ dns_rec.results }}"
     when: item.set.value is defined
 
@@ -67,7 +67,7 @@
       zone: "{{cluster_vars.dns_zone_external}}"
       record: "{{item.hostname | regex_replace('-(?!.*-)[0-9]{10}$')}}.{{cluster_vars.dns_zone_external}}"
       type: "CNAME"
-      private_zone: true
+      private_zone: "{{cluster_vars.route53_private_zone | default(true)}}"
     register: dns_rec
     with_items: "{{ cluster_hosts_flat }}"
 
@@ -81,7 +81,7 @@
       type: "{{ item.set.type }}"
       ttl: "{{ item.set.ttl }}"
       value: ["{{ item.set.value }}"]
-      private_zone: true
+      private_zone: "{{cluster_vars.route53_private_zone | default(true)}}"
     with_items: "{{ dns_rec.results }}"
     when: item.set.value is defined
   when: cluster_vars.dns_server == "route53" and cluster_vars.dns_zone_external is defined and cluster_vars.dns_zone_external != ""


### PR DESCRIPTION
Made use of cluster_vars.route53_private_zone in the clean role in the same way it's used in the config role