### PR TITLE
[FIX] Add region args as required and convert owner label to lowercase

### DIFF
--- a/create/tasks/aws.yml
+++ b/create/tasks/aws.yml
@@ -40,7 +40,7 @@
           release: "{%- if rescuing is defined and rescuing != \"false\" and instance_to_create is defined and instance_to_create == item.hostname -%}{{rescuing}}{%- elif instance_to_create is defined and instance_to_create == item.hostname -%}{{item.release}}{%- else -%}{{item.current_release}}{%- endif -%}"
           deploy_status: "{%- if rescuing is defined and rescuing != \"false\" and instance_to_create is defined and instance_to_create == item.hostname -%}old{%- elif instance_to_create is defined and instance_to_create == item.hostname -%}new{%- else -%}{{item.current_deploy_status}}{%- endif -%}"
           cluster_name: "{{cluster_name}}"
-          owner: "{{ lookup('env','USER') }}"
+          owner: "{{ lookup('env','USER')| lower }}"
           maintenance_mode: "{%- if prometheus_set_unset_maintenance_mode|bool -%}true{%- else -%}false{%- endif -%}"
         termination_protection: "{{cluster_vars[buildenv].termination_protection}}"
         volumes: "{{cluster_vars[buildenv].hosttype_vars[item.hosttype].auto_volumes | default([])}}"

--- a/create/tasks/gce.yml
+++ b/create/tasks/gce.yml
@@ -46,6 +46,7 @@
         auth_kind: "serviceaccount"
         service_account_file: "{{gcp_credentials_file}}"
         scopes: ["https://www.googleapis.com/auth/compute.readonly"]
+        region: "{{cluster_vars.region}}"
       register: gcp_compute_subnetwork_info
       when: (cluster_vars[buildenv].vpc_subnet_name is defined) and (cluster_vars[buildenv].vpc_subnet_name != "")
 
@@ -96,7 +97,7 @@
           env: "{{buildenv}}"
           release: "{%- if rescuing is defined and rescuing != \"false\" and instance_to_create is defined and instance_to_create == item.hostname -%}{{rescuing}}{%- elif instance_to_create is defined and instance_to_create == item.hostname -%}{{item.release}}{%- else -%}{{item.current_release}}{%- endif -%}"
           cluster_name: "{{cluster_name}}"
-          owner: "{{ lookup('env','USER') }}"
+          owner: "{{ lookup('env','USER')| lower }}"
           maintenance_mode: "true"
           deploy_status: "{%- if rescuing is defined and rescuing != \"false\" and instance_to_create is defined and instance_to_create == item.hostname -%}old{%- elif instance_to_create is defined and instance_to_create == item.hostname -%}new{%- else -%}{{item.current_deploy_status}}{%- endif -%}"
         network_interfaces:


### PR DESCRIPTION
This PR fixes two items:

1. Line 49 - The `gcp_compute_subnetwork_info` module has a mandatory parameter `region` and this was not set in the code, so setting the var `gcp_compute_subnetwork_info` currently fails. Further info [here](https://docs.ansible.com/ansible/latest/modules/gcp_compute_subnetwork_info_module.html#gcp-compute-subnetwork-info-module).

2. Line 100 - GCP labels only support lowercase characters. My username by default in AD is all uppercase so when creating labels in ansible from my local machine, the build results in a failure. Further info [here](https://cloud.google.com/compute/docs/labeling-resources#label_format).