### PR TITLE
[FEATURE] Add Cloud DNS automation for GCP A/CNAME records

### DIFF
--- a/EXAMPLE/group_vars/test_gce_euw1/cluster_vars.yml
+++ b/EXAMPLE/group_vars/test_gce_euw1/cluster_vars.yml
@@ -41,8 +41,9 @@ cluster_vars:
   image: "projects/ubuntu-os-cloud/global/images/ubuntu-1804-bionic-v20191113"
   region: &region "europe-west1"
   dns_zone_internal: "c.{{gcp_credentials_json.project_id}}.internal"
-  dns_zone_external: "{%- if dns_tld_external -%}{{_cloud_type}}-{{_region}}.{{app_class}}.{{buildenv}}.{{dns_tld_external}} {%- endif -%}"
-  dns_server: ""                    # Specify DNS server. nsupdate or route53.  If empty string is specified, no DNS will be added.
+  # dns_zone_external: "{%- if dns_tld_external -%}{{_cloud_type}}-{{_region}}.{{app_class}}.{{buildenv}}.{{dns_tld_external}} {%- endif -%}"
+  dns_zone_external: "clusterverse.vtp.com."
+  dns_server: "clouddns"                    # Specify DNS server. nsupdate or route53.  If empty string is specified, no DNS will be added.
   assign_public_ip: "yes"
   inventory_ip: "public"            # 'public' or 'private', (private in case we're operating in a private LAN).  If public, 'assign_public_ip' must be 'yes'
   project_id: "{{gcp_credentials_json.project_id}}"
@@ -66,8 +67,8 @@ cluster_vars:
     hosttype_vars:
       sys: {vms_by_az: {b: 1, c: 1, d: 1}, flavor: f1-micro, rootvol_size: "10", auto_volumes: []}
       #sysdisks: {vms_by_az: {b: 1, c: 1, d: 1}, flavor: f1-micro, rootvol_size: "10", auto_volumes: [{auto_delete: true, interface: "SCSI", volume_size: 2, mountpoint: "/var/log/mysvc", fstype: "ext4", perms: {owner: "root", group: "sudo", mode: "775"}}, {auto_delete: true, interface: "SCSI", volume_size: 2,  mountpoint: "/var/log/mysvc2", fstype: "ext4"}, {auto_delete: true, interface: "SCSI", volume_size: 3,  mountpoint: "/var/log/mysvc3", fstype: "ext4"}]}
-    vpc_network_name: "test-{{buildenv}}"
-    vpc_subnet_name: ""
+    vpc_network_name: "default"
+    vpc_subnet_name: "default"
     preemptible: "false"
     deletion_protection: "no"
 _cloud_type: *cloud_type

--- a/EXAMPLE/group_vars/test_gce_euw1/cluster_vars.yml
+++ b/EXAMPLE/group_vars/test_gce_euw1/cluster_vars.yml
@@ -7,7 +7,7 @@ gcp_credentials_json: "{{ lookup('file', gcp_credentials_file) | default({'proje
 app_name: "test"                  # The name of the application cluster (e.g. 'couchbase', 'nginx'); becomes part of cluster_name.
 app_class: "test"                 # The class of application (e.g. 'database', 'webserver'); becomes part of the fqdn
 
-dns_tld_external: ""              # Top-level domain for external access.  Leave blank if no external DNS (use IPs only)
+dns_tld_external: "clusterverse.vtp.com."              # Top-level domain for external access.  Leave blank if no external DNS (use IPs only)
 
 ## Vulnerablity scanners - Tenable and/ or Qualys cloud agents:
 cloud_agent:
@@ -41,8 +41,7 @@ cluster_vars:
   image: "projects/ubuntu-os-cloud/global/images/ubuntu-1804-bionic-v20191113"
   region: &region "europe-west1"
   dns_zone_internal: "c.{{gcp_credentials_json.project_id}}.internal"
-  # dns_zone_external: "{%- if dns_tld_external -%}{{_cloud_type}}-{{_region}}.{{app_class}}.{{buildenv}}.{{dns_tld_external}} {%- endif -%}"
-  dns_zone_external: "clusterverse.vtp.com."
+  dns_zone_external: "{%- if dns_tld_external -%}{{_cloud_type}}-{{_region}}.{{app_class}}.{{buildenv}}.{{dns_tld_external}} {%- endif -%}"
   dns_server: "clouddns"                    # Specify DNS server. nsupdate or route53.  If empty string is specified, no DNS will be added.
   assign_public_ip: "yes"
   inventory_ip: "public"            # 'public' or 'private', (private in case we're operating in a private LAN).  If public, 'assign_public_ip' must be 'yes'

--- a/clean/tasks/gce.yml
+++ b/clean/tasks/gce.yml
@@ -54,3 +54,66 @@
     project: "{{cluster_vars.project_id}}"
     state: absent
   when: create_gce_network is defined and create_gce_network|bool
+
+- name: Delete DNS entries from clouddns
+  block:
+  - name: Gather info for a pre-existing GCP Managed Zone and store as dict
+    gcp_dns_managed_zone_info:
+      auth_kind: serviceaccount
+      dns_name: "{{dns_tld_external}}"
+      project: "{{ GOOGLE_PROJECT }}"
+      service_account_file: "{{gcp_credentials_file}}"
+    register: gcp_dns_managed_zone_info
+    become: false
+    delegate_to: localhost
+    run_once: true
+    when: (cluster_vars.dns_server is defined and cluster_vars.dns_server != "") and cluster_vars.dns_server=="clouddns" and (cluster_vars.dns_zone_external is defined and cluster_vars.dns_zone_external != "")
+  
+  - name: Get DNS entries from clouddns
+    gcp_dns_resource_record_set_info:
+      auth_kind: serviceaccount
+      managed_zone:
+        name: "{{gcp_dns_managed_zone_info.resources.0.name}}"
+        dnsName: "{{gcp_dns_managed_zone_info.resources.0.dnsName}}"
+      project: "{{ GOOGLE_PROJECT }}"
+      service_account_file: "{{gcp_credentials_file}}"
+    register: gcp_dns_resource_record_set_info
+    with_items: "{{ cluster_hosts_flat }}"
+  
+  - name: Remove related clusterverse A records from clouddns only
+    gcp_dns_resource_record_set:
+      auth_kind: serviceaccount
+      managed_zone:
+        name: "{{gcp_dns_managed_zone_info.resources.0.name}}"
+        dnsName: "{{gcp_dns_managed_zone_info.resources.0.dnsName}}"
+      name: "{{ item.name }}" 
+      project: "{{ GOOGLE_PROJECT }}"
+      service_account_file: "{{gcp_credentials_file}}"
+      state: absent    
+      target: "{{ item.rrdatas[0] }}" 
+      type: A
+      ttl: "{{ item.ttl }}" 
+    become: false
+    delegate_to: localhost
+    run_once: true
+    with_items: "{{ gcp_dns_resource_record_set_info.results.0.resources }}"
+    when: (cluster_vars.dns_server is defined and cluster_vars.dns_server != "") and cluster_vars.dns_server=="clouddns" and (cluster_vars.dns_zone_external is defined and cluster_vars.dns_zone_external != "")
+
+  - name: Remove related clusterverse CNAME records from clouddns only
+    gcp_dns_resource_record_set:
+      auth_kind: serviceaccount
+      managed_zone:
+        name: "{{gcp_dns_managed_zone_info.resources.0.name}}"
+        dnsName: "{{gcp_dns_managed_zone_info.resources.0.dnsName}}"
+      name: "{{ item.name }}"
+      project: "{{ GOOGLE_PROJECT }}"
+      service_account_file: "{{gcp_credentials_file}}"
+      state: absent    
+      target: "{{ item.rrdatas[0] }}" 
+      type: CNAME
+      ttl: "{{ item.ttl }}"
+    become: false
+    delegate_to: localhost
+    run_once: true
+    with_items: "{{ gcp_dns_resource_record_set_info.results.0.resources }}"
+    when: (cluster_vars.dns_server is defined and cluster_vars.dns_server != "") and cluster_vars.dns_server=="clouddns" and (cluster_vars.dns_zone_external is defined and cluster_vars.dns_zone_external != "")

--- a/config/tasks/main.yml
+++ b/config/tasks/main.yml
@@ -104,7 +104,7 @@
   run_once: true
   when: (cluster_vars.dns_server is defined and cluster_vars.dns_server != "") and cluster_vars.dns_server=="clouddns" and (cluster_vars.dns_zone_external is defined and cluster_vars.dns_zone_external != "")
 
-- name: Create/Update DNS A records in Cloud DNS in GCP 
+- name: Create/Update DNS A records in Cloud DNS via GCP 
   gcp_dns_resource_record_set:
     auth_kind: serviceaccount
     managed_zone:
@@ -114,7 +114,7 @@
     project: "{{ GOOGLE_PROJECT }}"
     service_account_file: "{{gcp_credentials_file}}"
     state: present    
-    target: "{{ hostvars[item.hostname]['ansible_host'] }}"
+    target: "{%- if gcp_dns_managed_zone_info.resources.0.visibility == 'private' -%} {{ hostvars[item.hostname]['ansible_private_host'] }} {%- else -%} {{ hostvars[item.hostname]['ansible_host'] }} {%- endif -%}"
     type: A
     ttl: 60
   become: false
@@ -172,7 +172,7 @@
   with_items: "{{ cluster_hosts_flat }}"
   when: cluster_vars.dns_server == "route53" and instance_to_create is undefined and rescuing_instance is undefined
 
-- name: Create/Update DNS CNAME records in Cloud DNS in GCP
+  - name: Create/Update DNS CNAME records in Cloud DNS via GCP
   gcp_dns_resource_record_set:
     auth_kind: serviceaccount
     managed_zone:

--- a/config/tasks/main.yml
+++ b/config/tasks/main.yml
@@ -95,7 +95,7 @@
 - name: Gather info for a pre-existing GCP Managed Zone and store as dict
   gcp_dns_managed_zone_info:
     auth_kind: serviceaccount
-    dns_name: "{{cluster_vars.dns_zone_external}}"
+    dns_name: "{{dns_tld_external}}"
     project: "{{ GOOGLE_PROJECT }}"
     service_account_file: "{{gcp_credentials_file}}"
   register: gcp_dns_managed_zone_info

--- a/config/tasks/main.yml
+++ b/config/tasks/main.yml
@@ -91,6 +91,38 @@
   with_items: "{{ cluster_hosts_flat }}"
   when: (cluster_vars.dns_server is defined and cluster_vars.dns_server != "") and cluster_vars.dns_server=="route53" and (cluster_vars.dns_zone_external is defined and cluster_vars.dns_zone_external != "")
 
+# Register gcp_dns_managed_zone_info dict for subsequent ansible tasks that require it 
+- name: Gather info for a pre-existing GCP Managed Zone and store as dict
+  gcp_dns_managed_zone_info:
+    auth_kind: serviceaccount
+    dns_name: "{{cluster_vars.dns_zone_external}}"
+    project: "{{ GOOGLE_PROJECT }}"
+    service_account_file: "{{gcp_credentials_file}}"
+  register: gcp_dns_managed_zone_info
+  become: false
+  delegate_to: localhost
+  run_once: true
+  when: (cluster_vars.dns_server is defined and cluster_vars.dns_server != "") and cluster_vars.dns_server=="clouddns" and (cluster_vars.dns_zone_external is defined and cluster_vars.dns_zone_external != "")
+
+- name: Create/Update DNS A records in Cloud DNS in GCP 
+  gcp_dns_resource_record_set:
+    auth_kind: serviceaccount
+    managed_zone:
+      name: "{{gcp_dns_managed_zone_info.resources.0.name}}"
+      dnsName: "{{gcp_dns_managed_zone_info.resources.0.dnsName}}"
+    name: "{{item.hostname}}.{{cluster_vars.dns_zone_external}}"
+    project: "{{ GOOGLE_PROJECT }}"
+    service_account_file: "{{gcp_credentials_file}}"
+    state: present    
+    target: "{{ hostvars[item.hostname]['ansible_host'] }}"
+    type: A
+    ttl: 60
+  become: false
+  delegate_to: localhost
+  run_once: true
+  with_items: "{{ cluster_hosts_flat }}"
+  when: (cluster_vars.dns_server is defined and cluster_vars.dns_server != "") and cluster_vars.dns_server=="clouddns" and (cluster_vars.dns_zone_external is defined and cluster_vars.dns_zone_external != "")
+
 - name: Check that DNS has updated (or otherwise wait for it to do so)  [Note lookup('dig', new_fqdn) doesn't work - seems to cache - https://github.com/ansible/ansible/issues/44128]
   shell: "dig {{new_fqdn}} +short @{{bind9[buildenv].server}}"
   register: dig_result
@@ -139,3 +171,22 @@
   run_once: true
   with_items: "{{ cluster_hosts_flat }}"
   when: cluster_vars.dns_server == "route53" and instance_to_create is undefined and rescuing_instance is undefined
+
+- name: Create/Update DNS CNAME records in Cloud DNS in GCP
+  gcp_dns_resource_record_set:
+    auth_kind: serviceaccount
+    managed_zone:
+      name: "{{gcp_dns_managed_zone_info.resources.0.name}}"
+      dnsName: "{{gcp_dns_managed_zone_info.resources.0.dnsName}}"
+    name: "{{item.hostname | regex_replace('-(?!.*-)[0-9]{10}$')}}.{{cluster_vars.dns_zone_external}}"
+    project: "{{ GOOGLE_PROJECT }}"
+    service_account_file: "{{gcp_credentials_file}}"
+    state: present
+    target: "{{item.hostname}}.{{cluster_vars.dns_zone_external}}"
+    type: CNAME
+    ttl: 60
+  become: false
+  delegate_to: localhost
+  run_once: true   
+  with_items: "{{ cluster_hosts_flat }}"  
+  when: cluster_vars.dns_server == "clouddns" and instance_to_create is undefined and rescuing_instance is undefined

--- a/dynamic_inventory/tasks/main.yml
+++ b/dynamic_inventory/tasks/main.yml
@@ -21,10 +21,10 @@
   add_host:
     name: "{{ item.hostname }}"
     groups: ["{{ item.hosttype }}","{{ cluster_name }}","{{ clusterid }}"]
+    ansible_private_host: "{%- if cluster_vars.inventory_ip == 'public' and cluster_vars.inventory_ip !='' -%} {{ item.private_ip }} {%- endif -%}" 
     ansible_host: "{{ item.inventory_ip }}"
     hosttype: "{{ item.hosttype }}"
   with_items: "{{ dynamic_inventory_flat }}"
-
 
 - stat: path={{inventory_file}}
   register: stat_inventory_file
@@ -40,7 +40,7 @@
       {% if groupname not in ["all", "ungrouped"] -%}
       [{{ groupname }}]
       {% for hostname in groups[groupname] %}
-      {{ hostname }} ansible_host={{hostvars[hostname].ansible_host}} hosttype={{ hostvars[hostname].hosttype }}
+      {{ hostname }} ansible_host={{hostvars[hostname].ansible_host}} hosttype={{ hostvars[hostname].hosttype }} ansible_private_host={{ hostvars[hostname].ansible_private_host }}
       {% endfor %}
 
       {% endif %}


### PR DESCRIPTION
This PR implements the following:

* Retrieves a managed zone in GCP using the value stored in var `dns_tld_external` under `cluster_vars.yml`
* Adds a A record under the managed zone provided 
* Adds a CNAME record under the managed zone provided
* If the GCP managed zone is `private`, the value of the A record will be the private ip of the VM
* If the GCP managed zone is `public`, the value of the A record will be the public ip of the VM

The following pre-requisites are required for the code to work:

* Pre-existing managed zone within GCP
* Setting the var `dns_tld_external` to the `dns name` of the GCP managed zone and including the `.` i.e. `clusterverse.vtp.com.`
* Setting the var `dns_server` to `clouddns` under `cluster_vars.yml`