### PR TITLE
[DOCS] Canary variable mandatory for redeploy invocation

### DIFF
--- a/EXAMPLE/README.md
+++ b/EXAMPLE/README.md
@@ -98,8 +98,8 @@ ansible-playbook -u <username> --private-key=/home/<user>/.ssh/<rsa key> redeplo
 ### Mandatory command-line variables:
 + `-e clusterid=<vtp_aws_euw1>` - A directory named `clusterid` must be present in `group_vars`.  Holds the parameters that define the cluster; enables a multi-tenanted repository.
 + `-e buildenv=<sandbox>` - The environment (dev, stage, etc), which must be an attribute of `cluster_vars` defined in `group_vars/<clusterid>/cluster_vars.yml`
++ `-e canary=['start', 'finish', 'none']` - Specify whether to start or finish a canary deploy, or 'none' deploy
 
 ### Extra variables:
 + `-e 'redeploy_scheme'=<subrole_name>` - The scheme corresponds to one defined in 
-+ `-e canary=['start', 'finish', 'none']` - Specify whether to start or finish a canary deploy, or 'none' deploy
 + `-e myhosttypes="master,slave"`- In redeployment you can define which host type you like to redeploy. If not defined it will redeploy all host types


### PR DESCRIPTION
While testing PR #26, I invoked the `redeploy.yml` playbook, however the script failed due to the following assertion:

```
TASK [clusterverse/redeploy : assert] ***********************************************************************************************************************************************************************************************************************
fatal: [localhost]: FAILED! => {
    "assertion": "canary is defined and (canary is defined and canary in ['start', 'finish', 'none'])",
    "changed": false,
    "evaluated_to": false,
    "msg": "Canary must be 'start', 'finish' or 'none'"
}

PLAY RECAP **************************************************************************************************************************************************************************************************************************************************
localhost                  : ok=21   changed=2    unreachable=0    failed=1    skipped=3    rescued=0    ignored=0   
```

Adding `--e canary` as mandatory on docs. 