### PR TITLE
[FEATURE] Add GCP functionality for redeploy playbook with option canary=start

### DIFF
--- a/redeploy/_scheme_addnewvm_rmdisk_rollback/tasks/by_type_host.yml
+++ b/redeploy/_scheme_addnewvm_rmdisk_rollback/tasks/by_type_host.yml
@@ -54,6 +54,36 @@
         private_zone: "{{cluster_vars.route53_private_zone | default(true)}}"
         overwrite: true
       when: cluster_vars.dns_server == "route53"
+    
+    - name: Gather info for a pre-existing GCP Managed Zone and store as dict
+      gcp_dns_managed_zone_info:
+        auth_kind: serviceaccount
+        dns_name: "{{dns_tld_external}}"
+        project: "{{ GOOGLE_PROJECT }}"
+        service_account_file: "{{gcp_credentials_file}}"
+      register: gcp_dns_managed_zone_info
+      become: false
+      delegate_to: localhost
+      run_once: true
+      when: cluster_vars.dns_server == "clouddns" 
+    
+    - name: Create/Update DNS CNAME records in Cloud DNS via GCP
+      gcp_dns_resource_record_set:
+        auth_kind: serviceaccount
+        managed_zone:
+          name: "{{gcp_dns_managed_zone_info.resources.0.name}}"
+          dnsName: "{{gcp_dns_managed_zone_info.resources.0.dnsName}}"
+        name: "{{instance_to_create | regex_replace('-(?!.*-).*')}}.{{cluster_vars.dns_zone_external}}"
+        project: "{{ GOOGLE_PROJECT }}"
+        service_account_file: "{{gcp_credentials_file}}"
+        state: present
+        target: "{{instance_to_create}}.{{cluster_vars.dns_zone_external}}"
+        type: CNAME
+        ttl: 60
+      become: false
+      delegate_to: localhost
+      run_once: true   
+      when: cluster_vars.dns_server == "clouddns"
 
 # ##### Uncomment the below to simulate redploy failure#######
 # ############################################################

--- a/redeploy/_scheme_addnewvm_rmdisk_rollback/tasks/gce_stop_instance.yml
+++ b/redeploy/_scheme_addnewvm_rmdisk_rollback/tasks/gce_stop_instance.yml
@@ -62,3 +62,46 @@
           private_zone: "{{cluster_vars.route53_private_zone | default(true)}}"
         when: dns_rec.set.value is defined
       when: cluster_vars.dns_server == "route53" and cluster_vars.dns_zone_external is defined and cluster_vars.dns_zone_external != ""
+
+    - name: Delete DNS entries from clouddns
+      block:
+      - name: Gather info for a pre-existing GCP Managed Zone and store as dict
+        gcp_dns_managed_zone_info:
+          auth_kind: serviceaccount
+          dns_name: "{{dns_tld_external}}"
+          project: "{{ GOOGLE_PROJECT }}"
+          service_account_file: "{{gcp_credentials_file}}"
+        register: gcp_dns_managed_zone_info
+        become: false
+        delegate_to: localhost
+        run_once: true
+        when: (cluster_vars.dns_server is defined and cluster_vars.dns_server != "") and cluster_vars.dns_server=="clouddns" and (cluster_vars.dns_zone_external is defined and cluster_vars.dns_zone_external != "")
+      
+      - name: Get DNS entries from clouddns
+        gcp_dns_resource_record_set_info:
+          auth_kind: serviceaccount
+          managed_zone:
+            name: "{{gcp_dns_managed_zone_info.resources.0.name}}"
+            dnsName: "{{gcp_dns_managed_zone_info.resources.0.dnsName}}"
+          project: "{{ GOOGLE_PROJECT }}"
+          service_account_file: "{{gcp_credentials_file}}"
+        register: gcp_dns_resource_record_set_info
+
+      - name: Remove related clusterverse A records from clouddns only
+        gcp_dns_resource_record_set:
+          auth_kind: serviceaccount
+          managed_zone:
+            name: "{{gcp_dns_managed_zone_info.resources.0.name}}"
+            dnsName: "{{gcp_dns_managed_zone_info.resources.0.dnsName}}"        
+          name: "{{ cluster_hosts_flat | json_query('[? hostname == `' + host_to_stop.hostname + '`].hostname|[0]')}}.{{cluster_vars.dns_zone_external}}"
+          project: "{{ GOOGLE_PROJECT }}"
+          service_account_file: "{{gcp_credentials_file}}"
+          state: absent    
+          target: "{{ gcp_dns_resource_record_set_info | json_query('resources[?type == `A`].rrdatas|[]|[0]')}}" 
+          type: A
+          ttl: "{{ gcp_dns_resource_record_set_info | json_query('resources[?type == `A`].ttl|[]|[0]')}}" 
+        become: false
+        delegate_to: localhost
+        run_once: true
+        register: gcp_dns_resource_record_set_2
+        when: (cluster_vars.dns_server is defined and cluster_vars.dns_server != "") and cluster_vars.dns_server=="clouddns" and (cluster_vars.dns_zone_external is defined and cluster_vars.dns_zone_external != "")


### PR DESCRIPTION
Currently in AWS, users can invocate the `redeploy.yml` playbook with the option `canary=start` which replaces the first node within the index and updates Route53.

This implementation already exists for GCP, however the DNS records do not get updated accordingly. This PR allows for Cloud DNS to be updated as necessary when a node is replaced.