### PR TITLE
[FEATURE] Centos support init

### DIFF
--- a/EXAMPLE/group_vars/test_aws_euw1/cluster_vars.yml
+++ b/EXAMPLE/group_vars/test_aws_euw1/cluster_vars.yml
@@ -60,10 +60,12 @@ cluster_vars:
       rule_desc: "Access from all VMs attached to the {{ cluster_name }}-sg group"
   sandbox:
     hosttype_vars:
-      sys: {vms_by_az: {a: 1, b: 1, c: 1}, flavor: t3.micro, auto_volumes: []}
-      #sysdisks: {vms_by_az: {a: 1, b: 1, c: 1}, flavor: t3.micro, auto_volumes: [{"device_name": "/dev/sdb", mountpoint: "/var/log/mysvc", fstype: "ext4", "volume_type": "gp2", "volume_size": 2, ephemeral: False, encrypted: True, "delete_on_termination": true, perms: {owner: "root", group: "sudo", mode: "775"} }, {"device_name": "/dev/sdc", mountpoint: "/var/log/mysvc2", fstype: "ext4", "volume_type": "gp2", "volume_size": 2, ephemeral: False, encrypted: True, "delete_on_termination": true}, {"device_name": "/dev/sdd", mountpoint: "/var/log/mysvc3", fstype: "ext4", "volume_type": "gp2", "volume_size": 2, ephemeral: False, encrypted: True, "delete_on_termination": true}]}
-      #sysnvme_multi: {vms_by_az: {a: 1, b: 1, c: 1}, flavor: i3en.2xlarge, auto_volumes: [], nvme: {volumes: [{mountpoint: "/var/log/mysvc", fstype: ext4, volume_size: 2500}, {mountpoint: "/var/log/mysvc2", fstype: ext4, volume_size: 2500}]} } }
-      #sysnvme_lvm: {vms_by_az: {a: 1, b: 1, c: 1}, flavor: i3en.2xlarge, auto_volumes: [], nvme: {volumes: [{mountpoint: "/var/log/mysvc", fstype: ext4, volume_size: 2500}, {mountpoint: "/var/log/mysvc", fstype: ext4, volume_size: 2500}], lvmparams: {vg_name: "vg0", lv_name: "lv0", lv_size: "100%FREE"} } }
+      sys: {vms_by_az: {a: 1, b: 1, c: 1}, flavor: t3.nano, auto_volumes: []}
+#      sysdisks: {vms_by_az: {a: 1, b: 0, c: 0}, flavor: t3.nano, auto_volumes: [{"device_name": "/dev/sdb", mountpoint: "/var/log/mysvc", fstype: "ext4", "volume_type": "gp2", "volume_size": 2, ephemeral: False, encrypted: True, "delete_on_termination": true, perms: {owner: "root", group: "sudo", mode: "775"} }, {"device_name": "/dev/sdc", mountpoint: "/var/log/mysvc2", fstype: "ext4", "volume_type": "gp2", "volume_size": 3, ephemeral: False, encrypted: True, "delete_on_termination": true}, {"device_name": "/dev/sdd", mountpoint: "/var/log/mysvc3", fstype: "ext4", "volume_type": "gp2", "volume_size": 2, ephemeral: False, encrypted: True, "delete_on_termination": true}]}
+#      hostnvme_multi: {vms_by_az: {a: 1, b: 0, c: 0}, flavor: i3en.2xlarge, auto_volumes: [], nvme: {volumes: [{mountpoint: "/var/log/mysvc", fstype: ext4, volume_size: 2500}, {mountpoint: "/var/log/mysvc2", fstype: ext4, volume_size: 2500}]} }
+#      hostnvme_lvm: {vms_by_az: {a: 1, b: 0, c: 0}, flavor: i3en.2xlarge, auto_volumes: [], nvme: {volumes: [{mountpoint: "/var/log/mysvc", fstype: ext4, volume_size: 2500}, {mountpoint: "/var/log/mysvc", fstype: ext4, volume_size: 2500}], lvmparams: {vg_name: "vg0", lv_name: "lv0", lv_size: "+100%FREE"} } }
+#      hostssd: {vms_by_az: {a: 1, b: 0, c: 0}, flavor: c3.large, auto_volumes: [{device_name: "/dev/sdb", mountpoint: "/var/log/mysvc", fstype: "ext4", "volume_type": "gp2", "volume_size": 2, ephemeral: False, encrypted: True, "delete_on_termination": true}]}
+#      hosthdd: {vms_by_az: {a: 1, b: 0, c: 0}, flavor: h1.2xlarge, auto_volumes: [{device_name: "/dev/sdb", mountpoint: "/var/log/mysvc", fstype: "ext4", "volume_type": "gp2", "volume_size": 2, ephemeral: False, encrypted: True, "delete_on_termination": true}]}
     aws_access_key: ""
     aws_secret_key: ""
     vpc_name: "test{{buildenv}}"

--- a/config/tasks/cloud_agents.yml
+++ b/config/tasks/cloud_agents.yml
@@ -2,17 +2,33 @@
 
 - name: cloud_agents | Qualys cloud agent
   block:
-    - name: cloud_agents | Remove existing Qualys cloud agent pkg
+    - name: cloud_agents | Remove existing Qualys cloud agent pkg Debian
       become: yes
       apt:
         name: "{{ cloud_agent.qualys.service }}"
         state: absent
+      when: ansible_os_family == 'Debian'
 
-    - name: cloud_agents | Download and install Qualys cloud agent pkg
+    - name: cloud_agents | Download and install Qualys cloud agent pkg Debian
       become: yes
       apt:
         deb: "{{ cloud_agent.qualys.debpackage }}"
         state: present
+      when: ansible_os_family == 'Debian'
+    
+    - name: cloud_agents | Remove existing Qualys cloud agent pkg RedHat
+      become: yes
+      yum:
+        name: "{{ cloud_agent.qualys.service }}"
+        state: absent
+      when: ansible_os_family == 'RedHat'
+
+    - name: cloud_agents | Download and install Qualys cloud agent pkg RedHat
+      become: yes
+      yum:
+        name: "{{ cloud_agent.qualys.rpmpackage }}"
+        state: present
+      when: ansible_os_family == 'RedHat'
 
     - name: cloud_agents | link Qualys cloud agent
       become: yes
@@ -58,4 +74,3 @@
         state: started
         enabled: yes
   when: "'tenable' in cloud_agent"
-

--- a/config/tasks/disks_auto.yml
+++ b/config/tasks/disks_auto.yml
@@ -1,17 +1,19 @@
 ---
 #- debug: msg={{ cluster_vars[buildenv].hosttype_vars[hostvars[inventory_hostname].hosttype].auto_volumes }}
+- debug: msg={{ ansible_facts.devices }}
+- block:
+    - name: autodisks | Get unused block devices
+      set_fact:
+        block_devices: "{{ {'dev': item, 'size_b': (ansible_facts.devices[item].sectors|int) * (ansible_facts.devices[item].sectorsize|int)} }}"
+      with_items: "{{ ansible_facts.devices }}"
+      register: block_devices_list
+      when: item | regex_search("nvme|[xvsh]+d") and ansible_facts.devices[item].partitions == {}
 
-- name: autodisks | Get block devices as json
-  shell: lsblk -Jb
-  register: lsblk
+    - name: autodisks | Create unused block devices list
+      set_fact:
+        lsblk_volumes: "{{ block_devices_list.results | map(attribute='ansible_facts.block_devices') | select('defined') | list }}"
 
-#- debug: msg={{ lsblk.stdout | from_json }}
-
-- name: autodisks | Retrieve unused (i.e. unmounted, with unmounted child partitions), 'disk' devices (i.e. not cdroms or loopback)
-  set_fact:
-    lsblk_volumes: "{{ lsblk.stdout | from_json | json_query(\"blockdevices[?type=='disk' && !mountpoint && (!children || length(children[?mountpoint])==`0`)].{dev: name, size_b: size}\") }}"
-
-#- debug: msg={{ lsblk_volumes }}
+    - debug: msg={{ lsblk_volumes }}
 
 - name: autodisks | Create 'hostvols' fact that contains a list of available host devices (lsblk) mapped to the mountpoints defined in cluster_vars.  Allow for multiple disks with same size.
   set_fact:

--- a/config/tasks/disks_auto_aws_nvme.yml
+++ b/config/tasks/disks_auto_aws_nvme.yml
@@ -63,7 +63,7 @@
             mode: "{{ item.perms.mode | default(omit)}}"
             owner: "{{ item.perms.owner | default(omit)}}"
             group: "{{ item.perms.group | default(omit)}}"
-          with_items: "{{ hostvols }}"
+          with_items: "{{ nvmevols }}"
       when: (nvmevols | map(attribute='mountpoint') | list | unique | count == nvmevols | map(attribute='mountpoint') | list | count)
 
     # The following block mounts all nvme attached volumes that have a single, common mountpoint, by creating a logical volume

--- a/config/tasks/disks_auto_aws_nvme.yml
+++ b/config/tasks/disks_auto_aws_nvme.yml
@@ -1,18 +1,19 @@
 ---
 #- debug: msg={{ cluster_vars[buildenv].hosttype_vars[hostvars[inventory_hostname].hosttype].nvme_volumes }}
-
+- debug: msg={{ ansible_facts.devices }}
 - block:
-    - name: autodisks | Get block devices as json
-      shell: lsblk -Jb
-      register: lsblk
-
-#    - debug: msg={{ lsblk.stdout | from_json }}
-
-    - name: autodisks | Retrieve unused (i.e. unmounted, with unmounted child partitions), 'disk' devices (i.e. not cdroms or loopback)
+    - name: autodisks | Get unused block devices
       set_fact:
-        lsblk_volumes: "{{ lsblk.stdout | from_json | json_query(\"blockdevices[?type=='disk' && !mountpoint && (!children || length(children[?mountpoint])==`0`)].{dev: name, size_b: size}\") }}"
+        block_devices: "{{ {'dev': item, 'size_b': (ansible_facts.devices[item].sectors|int) * (ansible_facts.devices[item].sectorsize|int)} }}"
+      with_items: "{{ ansible_facts.devices }}"
+      register: block_devices_list
+      when: item | regex_search("nvme") and ansible_facts.devices[item].partitions == {}
 
-#    - debug: msg={{ lsblk_volumes }}
+    - name: autodisks | Create unused block devices list
+      set_fact:
+        lsblk_volumes: "{{ block_devices_list.results | map(attribute='ansible_facts.block_devices') | select('defined') | list }}"
+
+    - debug: msg={{ lsblk_volumes }}
 
     - name: autodisks | Create 'nvmevols' fact that contains a list of available host nvme devices (lsblk) mapped to the mountpoints defined in cluster_vars. Handles single mounting points with LV/VG
       set_fact:

--- a/config/tasks/disks_auto_aws_nvme.yml
+++ b/config/tasks/disks_auto_aws_nvme.yml
@@ -71,6 +71,13 @@
       block:
         #- debug: msg={{nvmevols | map(attribute='device') | join(',')}}
 
+        - name: autodisks | Install logical volume management tooling. (yum - RedHat/CentOS)
+          become: true
+          yum:
+            name: "lvm*"
+            state: present
+          when: ansible_os_family == 'RedHat'
+
         - name: autodisks | Create a volume group from all nvme devices
           become: yes
           lvg:

--- a/config/tasks/filebeat.yml
+++ b/config/tasks/filebeat.yml
@@ -7,3 +7,13 @@
   register: apt_jobs
   until: apt_jobs is success
   retries: 5
+  when: ansible_os_family == 'Debian'
+
+- name: Filebeat | Download and install filebeat from elastic.co
+  become: yes
+  yum:
+    name: "https://artifacts.elastic.co/downloads/beats/filebeat/filebeat-{{ filebeat_version }}-x86_64.rpm"
+  register: yum_jobs
+  until: yum_jobs is success
+  retries: 5
+  when: ansible_os_family == 'RedHat'


### PR DESCRIPTION
- Add CentOS support by configuring a distro agnostic approach to disk configuration
- Modify Filebeat, Qualy and Nessus agent installs to work with `yum`

This has been tested on `aws` and `gcp` across `ubuntu` and `centos` on both