### PR TITLE
[FIX] Switch from wait_for to ping + delegate_to to force SSH usage

### DIFF
--- a/clean/tasks/gce.yml
+++ b/clean/tasks/gce.yml
@@ -79,6 +79,7 @@
       service_account_file: "{{gcp_credentials_file}}"
     register: gcp_dns_resource_record_set_info
     with_items: "{{ cluster_hosts_flat }}"
+    when: (cluster_vars.dns_server is defined and cluster_vars.dns_server != "") and cluster_vars.dns_server=="clouddns" and (cluster_vars.dns_zone_external is defined and cluster_vars.dns_zone_external != "")
   
   - name: Remove related clusterverse A records from clouddns only
     gcp_dns_resource_record_set:

--- a/config/tasks/main.yml
+++ b/config/tasks/main.yml
@@ -194,7 +194,7 @@
   with_items: "{{ cluster_hosts_flat }}"
   when: cluster_vars.dns_server == "route53" and instance_to_create is undefined and rescuing_instance is undefined
 
-  - name: Create/Update DNS CNAME records in Cloud DNS via GCP
+- name: Create/Update DNS CNAME records in Cloud DNS via GCP
   gcp_dns_resource_record_set:
     auth_kind: serviceaccount
     managed_zone:

--- a/dynamic_inventory/tasks/main.yml
+++ b/dynamic_inventory/tasks/main.yml
@@ -17,7 +17,7 @@
   ping:
   delegate_to: "{{ item.inventory_ip }}"
   with_items: "{{ dynamic_inventory_flat }}"
-  retries: 120
+  retries: 12
 
 - name: Add hosts to dynamic inventory
   add_host:

--- a/dynamic_inventory/tasks/main.yml
+++ b/dynamic_inventory/tasks/main.yml
@@ -11,14 +11,13 @@
 
 - debug: msg="{{dynamic_inventory_flat}}"
 
-- name: Wait for port 22 to become open and contain "OpenSSH".
-  wait_for:
-    port: 22
-    host: "{{ item.inventory_ip }}"
-    search_regex: OpenSSH
-    delay: 1
+# The following is using ping (instead of wait_for to check for port 22) to actually establish SSH connectivity with the destination host,
+# this is particularly useful if using a jumphost to access the destination host, and the ansible-running-machine doesn't have direct
+- name: Wait for SSH connectivity
+  ping:
+  delegate_to: "{{ item.inventory_ip }}"
   with_items: "{{ dynamic_inventory_flat }}"
-  connection: local
+  retries: 120
 
 - name: Add hosts to dynamic inventory
   add_host:

--- a/dynamic_inventory/tasks/main.yml
+++ b/dynamic_inventory/tasks/main.yml
@@ -12,7 +12,7 @@
 - debug: msg="{{dynamic_inventory_flat}}"
 
 # The following is using ping (instead of wait_for to check for port 22) to actually establish SSH connectivity with the destination host,
-# this is particularly useful if using a jumphost to access the destination host, and the ansible-running-machine doesn't have direct
+# this is particularly useful if using a jumphost to access the destination host, and the ansible-running machine doesn't have direct access to it.
 - name: Wait for SSH connectivity
   ping:
   delegate_to: "{{ item.inventory_ip }}"


### PR DESCRIPTION
The previous module (`wait_for`) probed port 22 on the remote hosts directly from the machine running ansible, using a tcp connection.
This meant that the module wasn't using SSH and therefore overriding any `ssh_args` in the ansible.cfg file, as well as potential jump-hosts.

The fix introduces a harmless module, `ping`, while delegating the action to the destination host - thus forcing SSH connectivity to the host (and therefore testing that sshd is up and running), while introducing `retries` to the module in case the host is immediately unavailable.