### PR TITLE
Add support for another approach to load group_vars

### DIFF
--- a/_dependencies/action_plugins/README_merge_vars.md
+++ b/_dependencies/action_plugins/README_merge_vars.md
@@ -1,0 +1,33 @@
+### Action Plugin Merge_Vars
+
+this plugin similar to `include_vars`, but designed to merge all the variables(including dicts) in the files specified by from rather than replacing(default ansible behaviour for dicts).
+
+This plugin is designed to support the inclusion of DRY application configuration within ansible vars. For example, if you have multiple porjects (foo, bar), and multiple environments (dev, qa, prod), and some vars are shared at various levels (project, or environment), and you want to keep your configuration DRY.
+
+Example:
+
+  ```
+  environment/
+  └── aws
+      ├── cbe
+      │   └── clusterid
+      │       ├── app_vars.yml
+      │       ├── cluster.yml
+      │       └── dev_metadata.yml
+      └── dev.yml
+    ```
+
+#### How to use:
+
+```
+  - name: Merge dict
+    merge_vars:
+        ignore_missing_files: True
+        from:
+        	- "test1.yml"
+        	- "test2.yml"
+```
+
+where, 
+	ignore_missing_files if false - raise an error, default behaviour
+	from - list of files to be merged - order matters.

--- a/_dependencies/action_plugins/merge_vars.py
+++ b/_dependencies/action_plugins/merge_vars.py
@@ -1,0 +1,78 @@
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+from ansible.errors import AnsibleError
+from ansible.plugins.action import ActionBase
+from ansible.utils.vars import merge_hash
+from ansible.module_utils._text import to_native, to_text
+from os import path, listdir
+
+class ActionModule(ActionBase):
+
+    VALID_ARGUMENTS = [ 'from', 'ignore_missing_files' ]
+
+    def run(self, tmp=None, task_vars=None):
+
+        if task_vars is None:
+            task_vars = dict()
+
+        for arg in self._task.args:
+            if not arg in self.VALID_ARGUMENTS:
+                raise AnsibleError('%s is not a valid option in merge_vars' % arg)
+
+        self.ignore_missing_files = self._task.args.get('ignore_missing_files', False)
+
+        self.show_content = True;
+        self._task.action = 'include_vars';
+
+        failed = False
+
+        files = []
+        for source in self._task.args['from']:
+            if path.isfile(source):
+                files.append(source)
+            elif not path.isfile(source) and self.ignore_missing_files:
+                continue
+            elif path.isdir(source):
+                dirfiles = [path.join(source, filename) for filename in listdir(source)]
+                dirfiles.sort()
+                files.append(dirfiles)
+            elif not path.isdir(source) and self.ignore_missing_files:
+                continue
+            else:
+                failed = True
+                err_msg = to_native('%s does not exist' % source)
+                break
+
+        data = {}
+        if not failed:
+            for filename in files:
+                try:
+                    data = merge_hash(data, self._load_from_file(filename))
+
+                except AnsibleError as e:
+                    failed = True
+                    err_msg = to_native(e)
+
+        result = super(ActionModule, self).run(task_vars=task_vars)
+
+        if failed:
+            result['failed'] = failed
+            result['message'] = err_msg
+
+        result['ansible_included_var_files'] = files
+        result['ansible_facts'] = data
+        result['_ansible_no_log'] = not self.show_content
+        
+        return result
+
+    def _load_from_file(self, filename):
+        # this is the approach used by include_vars in order to get the show_content
+        # value based on whether decryption occured.  load_from_file does not return
+        # that value. 
+        #    https://github.com/ansible/ansible/blob/v2.7.5/lib/ansible/plugins/action/include_vars.py#L236-L240
+        b_data, show_content = self._loader._get_file_contents(filename)
+        data = to_text(b_data, errors='surrogate_or_strict')
+
+        self.show_content = show_content
+        return self._loader.load(data, file_name=filename, show_content=show_content) or {}

--- a/_dependencies/defaults/main.yml
+++ b/_dependencies/defaults/main.yml
@@ -26,3 +26,5 @@ reboot_on_package_upgrade: false                          # when set to true, re
 # Vulnerability scanning agents configurations
 qualys_agent_pkg: ""
 nessus_agent_pkg: ""
+
+merge_dict_vars_list: []

--- a/_dependencies/defaults/main.yml
+++ b/_dependencies/defaults/main.yml
@@ -27,4 +27,5 @@ reboot_on_package_upgrade: false                          # when set to true, re
 qualys_agent_pkg: ""
 nessus_agent_pkg: ""
 
-merge_dict_vars_list: []
+# supported formats are: native and tiered.
+cluster_vars_format: "native"

--- a/_dependencies/defaults/main.yml
+++ b/_dependencies/defaults/main.yml
@@ -26,6 +26,3 @@ reboot_on_package_upgrade: false                          # when set to true, re
 # Vulnerability scanning agents configurations
 qualys_agent_pkg: ""
 nessus_agent_pkg: ""
-
-# supported formats are: native and tiered.
-cluster_vars_format: "native"

--- a/_dependencies/tasks/main.yml
+++ b/_dependencies/tasks/main.yml
@@ -4,14 +4,15 @@
   - name: Force include of group_vars on localhost (no inventory yet, so cannot import automatically)
     include_vars: { dir: "{{ playbook_dir }}/group_vars/{{ clusterid }}" }
     when: 
-      - not merge_dict_vars|default(False)|bool
+      - cluster_vars_format == 'native'
 
   - name: Merge dict from different configuration files
     merge_vars:
         ignore_missing_files: True
         from: "{{ merge_dict_vars_list }}"
     when:
-      - merge_dict_vars|default(False)|bool
+      - cluster_vars_format == 'tiered'
+      - merge_dict_vars_list is defined and merge_dict_vars_list | length > 0
 
   tags: clusterverse_clean,clusterverse_create,clusterverse_dynamic_inventory,clusterverse_config,clusterverse_readiness
 

--- a/_dependencies/tasks/main.yml
+++ b/_dependencies/tasks/main.yml
@@ -1,7 +1,18 @@
 ---
 
-- name: Force include of group_vars on localhost (no inventory yet, so cannot import automatically)
-  include_vars: { dir: "{{ playbook_dir }}/group_vars/{{ clusterid }}" }
+- block:
+  - name: Force include of group_vars on localhost (no inventory yet, so cannot import automatically)
+    include_vars: { dir: "{{ playbook_dir }}/group_vars/{{ clusterid }}" }
+    when: 
+      - not merge_dict_vars|default(False)|bool
+
+  - name: Merge dict from different configuration files
+    merge_vars:
+        ignore_missing_files: True
+        from: "{{ merge_dict_vars_list }}"
+    when:
+      - merge_dict_vars|default(False)|bool
+
   tags: clusterverse_clean,clusterverse_create,clusterverse_dynamic_inventory,clusterverse_config,clusterverse_readiness
 
 - name: Preflight check

--- a/_dependencies/tasks/main.yml
+++ b/_dependencies/tasks/main.yml
@@ -4,14 +4,14 @@
   - name: Force include of group_vars on localhost (no inventory yet, so cannot import automatically)
     include_vars: { dir: "{{ playbook_dir }}/group_vars/{{ clusterid }}" }
     when: 
-      - cluster_vars_format == 'native'
+      - cluster_vars_format|default('native') == 'native'
 
   - name: Merge dict from different configuration files
     merge_vars:
         ignore_missing_files: True
         from: "{{ merge_dict_vars_list }}"
     when:
-      - cluster_vars_format == 'tiered'
+      - cluster_vars_format|default('native') == 'tiered'
       - merge_dict_vars_list is defined and merge_dict_vars_list | length > 0
 
   tags: clusterverse_clean,clusterverse_create,clusterverse_dynamic_inventory,clusterverse_config,clusterverse_readiness


### PR DESCRIPTION
Add support for another approach to load group_vars from external repository and not from group_vars.

As an example:
	we have external repository that contains cluster and application configuration based on Cloud/Region/App/Etc

	```
	environment/
	└── aws
	    ├── cbe
	    │   └── tan02
	    │       ├── app_vars.yml
	    │       ├── cluster.yml
	    │       └── dev_metadata.yml
	    └── dev.yml
    ```
How to use:

    In group_vars you need `all.yml` that contains list of configuration files(order matters)
    ```
		merge_dict_vars_list:
			- "./environment/{{ _cloud_type }}/{{ buildenv }}.yml"
			- "./environment/{{ _cloud_type }}/{{ app_name }}/{{ clusterid }}/cluster.yml"
			- "./environment/{{ _cloud_type }}/{{ app_name }}/{{ clusterid }}/{{ buildenv }}_metadata.yml"
			- "./environment/{{ _cloud_type }}/{{ app_name }}/{{ clusterid }}/app_vars.yml"
    ```

Run:

    ```
    	ansible-playbook -u ubuntu cluster.yml -e buildenv=dev -e clusterid=tan02 --vault-id=dev@.vaultpass-client.py -e merge_dict_vars=True -e _cloud_type=aws -e app_name=cbe
    ```

where:
    	- merge_dict_vars=True - enables different Vars schema.
    	- _cloud_type= and app_name - variables that used in all.yml to identify path to files