### PR TITLE
Modify 'cli_facts.py' to return dict for 'self._cliargs' in order to …

### DIFF
--- a/_dependencies/callback_plugins/cli_facts.py
+++ b/_dependencies/callback_plugins/cli_facts.py
@@ -54,5 +54,5 @@ class CallbackModule(CallbackBase):
             # Ansible 2.9 (https://github.com/ansible/ansible/pull/58400) changed the 'host' type in ansible/vars/manager.py::set_host_variable() from type <class 'ansible.inventory.host.Host'> to type string.
             if CLI.version_info()['major'] >= 2 and CLI.version_info()['minor'] >= 9:
                 host = str(host)
-            variable_manager.set_host_variable(host, "cliargs", self._cliargs)
+            variable_manager.set_host_variable(host, "cliargs", dict(self._cliargs))
             variable_manager.set_host_variable(host, "argv", self._argv)


### PR DESCRIPTION
…fix stdout_callback

Now `cli_facts.py`  callback plugin returns `self._cliargs` as  ImmutableDict. This  breaks [stdout_callback](https://docs.ansible.com/ansible/latest/reference_appendices/config.html#default-stdout-callback) option.

To test:

Set environment variable `export ANSIBLE_STDOUT_CALLBACK=yaml` and run a role with any debug task, i.e. `- debug: msg="{{ vars }}"`

Expected result:
```
TASK [clusterverse/create : debug] *****************************************************************************************
ok: [localhost] =>
  msg:
    _cloud_type: aws
    _region: eu-west-1
    ansible_check_mode: false
    ansible_connection: local
    ansible_dependent_role_names: []
    ansible_diff_mode: false
    ansible_facts: {}
    ansible_forks: 50

```
Current result:

```
TASK [clusterverse/create : debug] *****************************************************************************************
ok: [localhost] =>
  msg: '{''ansible_python_interpreter'': ''/Users/krasnyam/.virtualenvs/py3/bin/python3.7'', ''release_version'': '''', ''redeploy_scheme'': ''_scheme_addnewvm_rmdisk_rollback'', ''prometheus_node_exporter_install'': True, ''prometheus_node_exporter_port'': ''19100'', ''prometheus_node_exporter_version'': ''0.18.1'', ''prometheus_node_exporter_options'': ''--collector.systemd '',....

```