### PR TITLE
[FEATURE] Set Python interpreter discovery in ansible.cfg

### DIFF
--- a/EXAMPLE/ansible.cfg
+++ b/EXAMPLE/ansible.cfg
@@ -6,6 +6,7 @@ vault_password_file = .vaultpass-client.py
 host_key_checking = False
 force_valid_group_names = ignore
 roles_path = ./roles
+interpreter_python = auto
 
 [ssh_connection]
 retries=5


### PR DESCRIPTION
Set Python interpreter discovery in ansible.cfg, under the [default] section: `interpreter_python: auto`.

This covers edge-cases where Ansible doesn't discover Python's path in a target host.

Will be a default setting starting in 2.12, as explained here: https://docs.ansible.com/ansible/latest/reference_appendices/interpreter_discovery.html