### PR TITLE
Add az_name to the dynamic_inventory,

### DIFF
--- a/cluster_hosts/tasks/get_cluster_hosts_target.yml
+++ b/cluster_hosts/tasks/get_cluster_hosts_target.yml
@@ -13,7 +13,8 @@
               'hostname': cluster_name + '-' + hostttype + '-' + azname + azcount|string + '-' + cluster_suffix|string,
               'az_name': azname|string,
               'flavor': cluster_vars[buildenv].hosttype_vars[hostttype].flavor,
-              'auto_volumes': cluster_vars[buildenv].hosttype_vars[hostttype].auto_volumes
+              'auto_volumes': cluster_vars[buildenv].hosttype_vars[hostttype].auto_volumes,
+              'additional_services': cluster_vars[buildenv].hosttype_vars[hostttype].additional_services|default('')
               }]) -%}
           {%- endfor %}
         {%- endfor %}

--- a/create/tasks/aws.yml
+++ b/create/tasks/aws.yml
@@ -4,10 +4,10 @@
   ec2_group:
     name: "{{ cluster_name }}-sg"
     description: "{{ cluster_name }} rules"
-    region: "{{cluster_vars.region}}"
-    vpc_id: "{{vpc_id}}"
-    aws_access_key: "{{cluster_vars[buildenv].aws_access_key}}"
-    aws_secret_key: "{{cluster_vars[buildenv].aws_secret_key}}"
+    region: "{{ cluster_vars.region }}"
+    vpc_id: "{{ vpc_id }}"
+    aws_access_key: "{{ cluster_vars[buildenv].aws_access_key }}"
+    aws_secret_key: "{{ cluster_vars[buildenv].aws_secret_key }}"
     tags:
       Name: "{{ cluster_name }}-sg"
       env: "{{ buildenv }}"
@@ -22,33 +22,35 @@
   block:
     - name: create/aws | Create EC2 VMs asynchronously
       ec2:
-        aws_access_key: "{{cluster_vars[buildenv].aws_access_key}}"
-        aws_secret_key: "{{cluster_vars[buildenv].aws_secret_key}}"
-        region: "{{cluster_vars.region}}"
-        key_name: "{{cluster_vars[buildenv].key_name}}"
-        instance_type: "{{item.flavor}}"
-        instance_profile_name: "{{cluster_vars.instance_profile_name  | default(omit)}}"
-        image: "{{cluster_vars.image}}"
-        vpc_subnet_id: "{{item.vpc_subnet_id}}"
-        assign_public_ip: "{{cluster_vars.assign_public_ip}}"
+        aws_access_key: "{{ cluster_vars[buildenv].aws_access_key }}"
+        aws_secret_key: "{{ cluster_vars[buildenv].aws_secret_key }}"
+        region: "{{ cluster_vars.region }}"
+        key_name: "{{ cluster_vars[buildenv].key_name }}"
+        instance_type: "{{ item.flavor }}"
+        instance_profile_name: "{{ cluster_vars.instance_profile_name | default(omit) }}"
+        image: "{{ cluster_vars.image }}"
+        vpc_subnet_id: "{{ item.vpc_subnet_id }}"
+        assign_public_ip: "{{ cluster_vars.assign_public_ip }}"
         group: "{{ cluster_vars.secgroups_existing }} {%- if cluster_vars.secgroup_new | length > 0 -%} + {{ ([r__ec2_group.group_name | default()] | default())}} {%- endif -%}"
         wait: yes
         instance_tags:
-          Name: "{{item.hostname}}"
-          hosttype: "{{item.hosttype}}"
-          env: "{{buildenv}}"
-          cluster_name: "{{cluster_name}}"
-          cluster_suffix: "{{cluster_suffix}}"
-          owner: "{{ lookup('env','USER')| lower  }}"
+          Name: "{{ item.hostname }}"
+          az_name: "{{ item.az_name }}"
+          additional_services: "{{ item.additional_services | default(omit, true) }}"
+          hosttype: "{{ item.hosttype }}"
+          env: "{{ buildenv }}"
+          cluster_name: "{{ cluster_name }}"
+          cluster_suffix: "{{ cluster_suffix }}"
+          owner: "{{ lookup('env','USER')| lower }}"
           maintenance_mode: "{%- if prometheus_set_unset_maintenance_mode|bool -%}true{%- else -%}false{%- endif -%}"
           release: "{{ release_version }}"
           lifecycle_state: "current"
-        termination_protection: "{{cluster_vars[buildenv].termination_protection}}"
+        termination_protection: "{{ cluster_vars[buildenv].termination_protection }}"
         volumes: "{{ item.auto_volumes | default([]) }}"
         count_tag:
-          Name: "{{item.hostname}}"
+          Name: "{{ item.hostname }}"
         exact_count: 1
-      with_items: "{{cluster_hosts_target}}"
+      with_items: "{{ cluster_hosts_target }}"
       async: 7200
       poll: 0
       register: aws_instances

--- a/create/tasks/gce.yml
+++ b/create/tasks/gce.yml
@@ -87,6 +87,8 @@
           ssh-keys: "{{ cliargs.remote_user }}:{{ r__gcp_ssh_pubkey.stdout }} {{ cliargs.remote_user }}"
         labels:
           hosttype: "{{item.hosttype}}"
+          az_name: "{{ item.az_name }}"
+          additional_services: "{{ item.additional_services|default(omit, true) }}"
           env: "{{buildenv}}"
           cluster_name: "{{cluster_name}}"
           cluster_suffix: "{{cluster_suffix}}"

--- a/dynamic_inventory/tasks/aws.yml
+++ b/dynamic_inventory/tasks/aws.yml
@@ -15,7 +15,7 @@
   set_fact:
     dynamic_inventory_flat: |
       {%- if cluster_vars.inventory_ip == 'private' -%}
-        {{ r__ec2_instance_info.instances | json_query('[*].{hosttype: tags.hosttype, hostname: tags.Name, private_ip: private_ip_address, public_ip: public_ip_address, inventory_ip: private_ip_address}') }}
+        {{ r__ec2_instance_info.instances | json_query('[*].{tagslabels: tags, private_ip: private_ip_address, public_ip: public_ip_address, inventory_ip: private_ip_address}') }}
       {%- else -%}
-        {{ r__ec2_instance_info.instances | json_query('[*].{hosttype: tags.hosttype, hostname: tags.Name, private_ip: private_ip_address, public_ip: public_ip_address, inventory_ip: public_ip_address}') }}
+        {{ r__ec2_instance_info.instances | json_query('[*].{tagslabels: tags, private_ip: private_ip_address, public_ip: public_ip_address, inventory_ip: public_ip_address}') }}
       {%- endif -%}

--- a/dynamic_inventory/tasks/gce.yml
+++ b/dynamic_inventory/tasks/gce.yml
@@ -22,8 +22,8 @@
   set_fact:
     dynamic_inventory_flat: |
       {%- if cluster_vars.inventory_ip == 'private' -%}
-        {{ r__gcp_compute_instance_info.results | json_query('[*].resources[].{hosttype: labels.hosttype, hostname: name, private_ip: networkInterfaces[0].networkIP, public_ip: networkInterfaces[0].accessConfigs[0].natIP, inventory_ip: networkInterfaces[0].networkIP}') }}
+        {{ r__gcp_compute_instance_info.results | json_query('[*].resources[].{hosttype: labels.hosttype, tagslabels: labels, hostname: name, private_ip: networkInterfaces[0].networkIP, public_ip: networkInterfaces[0].accessConfigs[0].natIP, inventory_ip: networkInterfaces[0].networkIP}') }}
       {%- else -%}
-        {{ r__gcp_compute_instance_info.results | json_query('[*].resources[].{hosttype: labels.hosttype, hostname: name, private_ip: networkInterfaces[0].networkIP, public_ip: networkInterfaces[0].accessConfigs[0].natIP, inventory_ip: networkInterfaces[0].accessConfigs[0].natIP}') }}
+        {{ r__gcp_compute_instance_info.results | json_query('[*].resources[].{hosttype: labels.hosttype, tagslabels: labels, hostname: name, private_ip: networkInterfaces[0].networkIP, public_ip: networkInterfaces[0].accessConfigs[0].natIP, inventory_ip: networkInterfaces[0].accessConfigs[0].natIP}') }}
       {%- endif -%}
 

--- a/dynamic_inventory/tasks/main.yml
+++ b/dynamic_inventory/tasks/main.yml
@@ -11,26 +11,29 @@
 - assert: { that: "dynamic_inventory_flat is defined", msg: "dynamic_inventory_flat is not defined" }
 
 - name: dynamic_inventory | dynamic_inventory_flat
-  debug: msg="{{dynamic_inventory_flat}}"
+  debug: msg="{{ dynamic_inventory_flat }}"
 
-# The following is using ping (instead of wait_for to check for port 22) to actually establish SSH connectivity with the destination host,
-# this is particularly useful if using a jumphost to access the destination host, and the ansible-running machine doesn't have direct access to it.
 - name: dynamic_inventory | Wait for SSH connectivity
-  ping:
+  wait_for_connection:
+    timeout: 180
   delegate_to: "{{ item.inventory_ip }}"
   with_items: "{{ dynamic_inventory_flat }}"
-  retries: 12
 
 - name: dynamic_inventory | Add hosts to dynamic inventory
   add_host:
-    name: "{{ item.hostname }}"
-    groups: ["{{ item.hosttype }}","{{ cluster_name }}","{{ clusterid }}"]
+    name: "{{ item.tagslabels.Name }}"
+    groups: "{{ [cluster_name,clusterid] + _hosttype }}"
     ansible_host: "{{ item.inventory_ip }}"
-    hosttype: "{{ item.hosttype }}"
+    hosttype: "{{ _hosttype }}"
+    az_name: "{{ item.tagslabels.az_name }}"
+    additional_services: "{{ item.tagslabels.additional_services| default('') }}"
   with_items: "{{ dynamic_inventory_flat }}"
+  vars:
+    _hosttype: "{{ [item.tagslabels.hosttype] + _additional_services }}"
+    _additional_services: "{{ item.tagslabels.additional_services.split(',') if 'additional_services' in item.tagslabels.keys() else [] }}"
 
 - name: dynamic_inventory | stat the inventory_file path
-  stat: path={{inventory_file}}
+  stat: path={{ inventory_file }}
   register: stat_inventory_file
   when: inventory_file is defined
 
@@ -41,7 +44,7 @@
       {% if groupname not in ["all", "ungrouped"] -%}
       [{{ groupname }}]
       {% for hostname in groups[groupname] %}
-      {{ hostname }} ansible_host={{hostvars[hostname].ansible_host}} hosttype={{ hostvars[hostname].hosttype }}
+      {{ hostname }} ansible_host={{hostvars[hostname].ansible_host}} hosttype={{ hostvars[hostname].hosttype|join(',') }} az_name={{ hostvars[hostname].az_name }}
       {% endfor %}
 
       {% endif %}


### PR DESCRIPTION
add additional_services to hosttype_vars.<hosttype>

Applying this PR will:

- add possibility of additional_services for hosttype_vars.<hosttype>
- add az_name as a tag
- extend dynamic_inventory with az_name 
- extend dynamic_inventory hosttype with additional_services
- extend dynamic_inventory groups with additional_services

example:
```yaml
cluster_vars:
  dev:
    hosttype_vars:
      data:
        vms_by_az:
            a: 1
            b: 1
        auto_volumes:
        ...
      index:
        vms_by_az:
            a: 1
            b: 1
        additional_services: "query"
        auto_volumes:
        ...
```

Inventory file `inventory_mike_t-dev`:

```ini
[mike_t-dev]
mike_t-dev-index-b0-1588150283 ansible_host=10.50.112.91 hosttype=index,query az_name=b
mike_t-dev-data-b0-1588150283 ansible_host=10.50.112.87 hosttype=data az_name=b
mike_t-dev-data-a0-1588150283 ansible_host=10.50.112.11 hosttype=data az_name=a
mike_t-dev-index-a0-1588150283 ansible_host=10.50.112.57 hosttype=index,query az_name=a

[mike_t]
mike_t-dev-index-b0-1588150283 ansible_host=10.50.112.91 hosttype=index,query az_name=b
mike_t-dev-data-b0-1588150283 ansible_host=10.50.112.87 hosttype=data az_name=b
mike_t-dev-data-a0-1588150283 ansible_host=10.50.112.11 hosttype=data az_name=a
mike_t-dev-index-a0-1588150283 ansible_host=10.50.112.57 hosttype=index,query az_name=a

[index]
mike_t-dev-index-b0-1588150283 ansible_host=10.50.112.91 hosttype=index,query az_name=b
mike_t-dev-index-a0-1588150283 ansible_host=10.50.112.57 hosttype=index,query az_name=a

[query]
mike_t-dev-index-b0-1588150283 ansible_host=10.50.112.91 hosttype=index,query az_name=b
mike_t-dev-index-a0-1588150283 ansible_host=10.50.112.57 hosttype=index,query az_name=a

[data]
mike_t-dev-data-b0-1588150283 ansible_host=10.50.112.87 hosttype=data az_name=b
mike_t-dev-data-a0-1588150283 ansible_host=10.50.112.11 hosttype=data az_name=a
```
