### PR TITLE
Rename poorly-named DNS variables

### DIFF
--- a/EXAMPLE/README.md
+++ b/EXAMPLE/README.md
@@ -66,7 +66,6 @@ ansible-playbook -u <username> --private-key=/home/<user>/.ssh/<rsa key> cluster
 + `-e app_name=<nginx>` - Normally defined in `group_vars/<clusterid>/cluster_vars.yml`.  The name of the application cluster (e.g. 'couchbase', 'nginx'); becomes part of cluster_name
 + `-e app_class=<proxy>` - Normally defined in `group_vars/<clusterid>/cluster_vars.yml`.  The class of application (e.g. 'database', 'webserver'); becomes part of the fqdn
 + `-e release_version=<v1.0.1>` - Identifies the application version that is being deployed.
-+ `-e dns_tld_external=<test.example.com>` - Normally defined in `group_vars/<clusterid>/cluster_vars.yml`.
 + `-e clean=[current|retiring|redeployfail|_all_]` - Deletes VMs in `lifecycle_state`, or `_all_`, as well as networking and security groups
 + `-e do_package_upgrade=true` - Upgrade the OS packages (not good for determinism)
 + `-e reboot_on_package_upgrade=true` - After updating packages, performs a reboot on all nodes.

--- a/EXAMPLE/group_vars/_skel/cluster_vars.yml
+++ b/EXAMPLE/group_vars/_skel/cluster_vars.yml
@@ -7,8 +7,6 @@ gcp_credentials_json: "{{ lookup('file', gcp_credentials_file) | default({'proje
 app_name: "test"                  # The name of the application cluster (e.g. 'couchbase', 'nginx'); becomes part of cluster_name.
 app_class: "test"                 # The class of application (e.g. 'database', 'webserver'); becomes part of the fqdn
 
-dns_tld_external: ""              # Top-level domain for external access.  gcloud dns needs a trailing '.'.  Leave blank if no external DNS (use IPs only)
-
 beats_target_hosts: []            # The destination hosts for e.g. filebeat/ metricbeat logs
 
 ## Vulnerability scanners - Tenable and/ or Qualys cloud agents:
@@ -42,14 +40,15 @@ cluster_name: "{{app_name}}-{{buildenv}}"       # Identifies the cluster within 
 #cluster_vars:
 #  type: &cloud_type "aws"
 #  image: "ami-0964eb2dc8b836eb6"    # eu-west-1, 18.04, amd64, hvm-ssd, 20200430.  Ubuntu images can be located at https://cloud-images.ubuntu.com/locator/
-#  region: &region "eu-west-1"
-#  dns_zone_internal: "{{_region}}.compute.internal"         # eu-west-1, us-west-2
-#  dns_zone_external: "{%- if dns_tld_external -%}{{_cloud_type}}-{{_region}}.{{app_class}}.{{buildenv}}.{{dns_tld_external}} {%- endif -%}"
+#  region: &region "eu-west-1"       # eu-west-1, us-west-2
+#  dns_cloud_internal_domain: "{{_region}}.compute.internal"
+#  dns_nameserver_zone: &dns_nameserver_zone ""              # The zone that dns_server will operate on.  gcloud dns needs a trailing '.'.  Leave blank if no external DNS (use IPs only)
+#  dns_fqdn_domain: "{{_cloud_type}}-{{_region}}.{{app_class}}.{{buildenv}}.{{_dns_nameserver_zone}}"         # The _domain_ part of the FDQN, (if more prefixes are required before the dns_nameserver_zone)
 #  dns_server: ""                    # Specify DNS server. nsupdate, route53 or clouddns.  If empty string is specified, no DNS will be added.
+#  route53_private_zone: true        # Only used when cluster_vars.type == 'aws'. Defaults to true if not set.
 #  assign_public_ip: "yes"
 #  inventory_ip: "public"            # 'public' or 'private', (private in case we're operating in a private LAN).  If public, 'assign_public_ip' must be 'yes'
 #  instance_profile_name: ""
-#  route53_private_zone: true        # Only used when cluster_vars.type == 'aws'. Defaults to true if not set.
 #  custom_tagslabels: {inv_resident_id: "abc", inv_proposition_id: "def"}
 #  secgroups_existing: []
 #  secgroup_new:
@@ -67,12 +66,13 @@ cluster_name: "{{app_name}}-{{buildenv}}"       # Identifies the cluster within 
 #  sandbox:
 #    hosttype_vars:
 #      sys: {vms_by_az: {a: 1, b: 1, c: 1}, flavor: t3a.nano, version: "{{sys_version | default('')}}", auto_volumes: []}
-#      #sysnobeats: {vms_by_az: {a: 1, b: 1, c: 1}, skip_beat_install:true, flavor: t3a.nano, version: "{{sysnobeats_version | default('')}}", auto_volumes: []
-#      #sysdisks: {vms_by_az: {a: 1, b: 1, c: 1}, flavor: t3a.nano, version: "{{sysdisks_version | default('')}}", auto_volumes: [{"device_name": "/dev/sdb", mountpoint: "/var/log/mysvc", fstype: "ext4", "volume_type": "gp2", "volume_size": 2, ephemeral: False, encrypted: True, "delete_on_termination": true, perms: {owner: "root", group: "sudo", mode: "775"} }, {"device_name": "/dev/sdc", mountpoint: "/var/log/mysvc2", fstype: "ext4", "volume_type": "gp2", "volume_size": 2, ephemeral: False, encrypted: True, "delete_on_termination": true}, {"device_name": "/dev/sdd", mountpoint: "/var/log/mysvc3", fstype: "ext4", "volume_type": "gp2", "volume_size": 2, ephemeral: False, encrypted: True, "delete_on_termination": true}]}
-#      #hostnvme_multi: {vms_by_az: {a: 1, b: 1, c: 1}, flavor: i3en.2xlarge, auto_volumes: [], nvme: {volumes: [{mountpoint: "/var/log/mysvc", fstype: ext4, volume_size: 2500}, {mountpoint: "/var/log/mysvc2", fstype: ext4, volume_size: 2500}]} } }
-#      #hostnvme_lvm: {vms_by_az: {a: 1, b: 1, c: 1}, flavor: i3en.2xlarge, auto_volumes: [], nvme: {volumes: [{mountpoint: "/var/log/mysvc", fstype: ext4, volume_size: 2500}, {mountpoint: "/var/log/mysvc", fstype: ext4, volume_size: 2500}], lvmparams: {vg_name: "vg0", lv_name: "lv0", lv_size: "+100%FREE"} } }
-#      #hostssd: {vms_by_az: {a: 1, b: 1, c: 0}, flavor: c3.large, auto_volumes: [{device_name: "/dev/sdb", mountpoint: "/var/log/mysvc", fstype: "ext4", "volume_type": "gp2", "volume_size": 2, ephemeral: False, encrypted: True, "delete_on_termination": true}]}
-#      #hosthdd: {vms_by_az: {a: 1, b: 1, c: 0}, flavor: h1.2xlarge, auto_volumes: [{device_name: "/dev/sdb", mountpoint: "/var/log/mysvc", fstype: "ext4", "volume_type": "gp2", "volume_size": 2, ephemeral: False, encrypted: True, "delete_on_termination": true}]}
+#      # sysnobeats: {vms_by_az: {a: 1, b: 0, c: 0}, skip_beat_install:true, flavor: t3a.nano, version: "{{sysnobeats_version | default('')}}", auto_volumes: []
+#      # sysdisks: {vms_by_az: {a: 1, b: 0, c: 0}, flavor: t3a.nano, version: "{{sysdisks_version | default('')}}", auto_volumes: [{"device_name": "/dev/sdb", mountpoint: "/var/log/mysvc", fstype: "ext4", "volume_type": "gp2", "volume_size": 2, ephemeral: False, encrypted: True, "delete_on_termination": true, perms: {owner: "root", group: "sudo", mode: "775"} }, {"device_name": "/dev/sdc", mountpoint: "/var/log/mysvc2", fstype: "ext4", "volume_type": "gp2", "volume_size": 3, ephemeral: False, encrypted: True, "delete_on_termination": true}, {"device_name": "/dev/sdd", mountpoint: "/var/log/mysvc3", fstype: "ext4", "volume_type": "gp2", "volume_size": 2, ephemeral: False, encrypted: True, "delete_on_termination": true}]}
+#      # sysdisks_snapshot: {vms_by_az: {a: 1, b: 1, c: 0}, flavor: t3a.nano, auto_volumes: [{"snapshot_tags": {"tag:backup_id": "57180566894481854905"}, "device_name": "/dev/sdb", mountpoint: "/data", fstype: "ext4", "volume_type": "gp2", "volume_size": 2, ephemeral: False, encrypted: True, "delete_on_termination": true }]}
+#      # hostnvme_multi: {vms_by_az: {a: 1, b: 0, c: 0}, flavor: i3en.2xlarge, auto_volumes: [], nvme: {volumes: [{mountpoint: "/var/log/mysvc", fstype: ext4, volume_size: 2500}, {mountpoint: "/var/log/mysvc2", fstype: ext4, volume_size: 2500}]} }
+#      # hostnvme_lvm: {vms_by_az: {a: 1, b: 0, c: 0}, flavor: i3en.2xlarge, auto_volumes: [], nvme: {volumes: [{mountpoint: "/var/log/mysvc", fstype: ext4, volume_size: 2500}, {mountpoint: "/var/log/mysvc", fstype: ext4, volume_size: 2500}], lvmparams: {vg_name: "vg0", lv_name: "lv0", lv_size: "+100%FREE"} } }
+#      # hostssd: {vms_by_az: {a: 1, b: 0, c: 0}, flavor: c3.large, auto_volumes: [{device_name: "/dev/sdb", mountpoint: "/var/log/mysvc", fstype: "ext4", "volume_type": "gp2", "volume_size": 2, ephemeral: False, encrypted: True, "delete_on_termination": true}]}
+#      # hosthdd: {vms_by_az: {a: 1, b: 0, c: 0}, flavor: h1.2xlarge, auto_volumes: [{device_name: "/dev/sdb", mountpoint: "/var/log/mysvc", fstype: "ext4", "volume_type": "gp2", "volume_size": 2, ephemeral: False, encrypted: True, "delete_on_termination": true}]}
 #    aws_access_key: ""
 #    aws_secret_key: ""
 #    vpc_name: "test{{buildenv}}"
@@ -81,15 +81,16 @@ cluster_name: "{{app_name}}-{{buildenv}}"       # Identifies the cluster within 
 #    termination_protection: "no"
 #_cloud_type: *cloud_type
 #_region: *region
-
+#_dns_nameserver_zone: *dns_nameserver_zone
 
 ### GCP example
 #cluster_vars:
 #  type: &cloud_type "gcp"
 #  image: "projects/ubuntu-os-cloud/global/images/ubuntu-1804-bionic-v20200430"
 #  region: &region "europe-west1"
-#  dns_zone_internal: "c.{{gcp_credentials_json.project_id}}.internal"
-#  dns_zone_external: "{%- if dns_tld_external -%}{{_cloud_type}}-{{_region}}.{{app_class}}.{{buildenv}}.{{dns_tld_external}} {%- endif -%}"
+#  dns_cloud_internal_domain: "c.{{gcp_credentials_json.project_id}}.internal"
+#  dns_nameserver_zone: &dns_nameserver_zone ""              # The zone that dns_server will operate on.  gcloud dns needs a trailing '.'.  Leave blank if no external DNS (use IPs only)
+#  dns_fqdn_domain: "{{_cloud_type}}-{{_region}}.{{app_class}}.{{buildenv}}.{{_dns_nameserver_zone}}"         # The _domain_ part of the FDQN, (if more prefixes are required before the dns_nameserver_zone)
 #  dns_server: ""                            # Specify DNS server. nsupdate, route53 or clouddns.  If empty string is specified, no DNS will be added.
 #  assign_public_ip: "yes"
 #  inventory_ip: "public"                    # 'public' or 'private', (private in case we're operating in a private LAN).  If public, 'assign_public_ip' must be 'yes'
@@ -122,3 +123,4 @@ cluster_name: "{{app_name}}-{{buildenv}}"       # Identifies the cluster within 
 #_cloud_type: *cloud_type
 #_region: *region
 #_ssh_guard_whitelist: *ssh_guard_whitelist
+#_dns_nameserver_zone: *dns_nameserver_zone

--- a/EXAMPLE/group_vars/_skel/cluster_vars.yml
+++ b/EXAMPLE/group_vars/_skel/cluster_vars.yml
@@ -41,9 +41,9 @@ cluster_name: "{{app_name}}-{{buildenv}}"       # Identifies the cluster within 
 #  type: &cloud_type "aws"
 #  image: "ami-0964eb2dc8b836eb6"    # eu-west-1, 18.04, amd64, hvm-ssd, 20200430.  Ubuntu images can be located at https://cloud-images.ubuntu.com/locator/
 #  region: &region "eu-west-1"       # eu-west-1, us-west-2
-#  dns_cloud_internal_domain: "{{_region}}.compute.internal"
-#  dns_nameserver_zone: &dns_nameserver_zone ""              # The zone that dns_server will operate on.  gcloud dns needs a trailing '.'.  Leave blank if no external DNS (use IPs only)
-#  dns_fqdn_domain: "{{_cloud_type}}-{{_region}}.{{app_class}}.{{buildenv}}.{{_dns_nameserver_zone}}"         # The _domain_ part of the FDQN, (if more prefixes are required before the dns_nameserver_zone)
+#  dns_cloud_internal_domain: "{{_region}}.compute.internal"                       # The cloud-internal zone as defined by the cloud provider (e.g. GCP, AWS)
+#  dns_nameserver_zone: &dns_nameserver_zone ""                                    # The zone that dns_server will operate on.  gcloud dns needs a trailing '.'.  Leave blank if no external DNS (use IPs only)
+#  dns_user_domain: "{%- if _dns_nameserver_zone -%}MY.OTHER.PREFIXES.{{_dns_nameserver_zone}}{%- endif -%}"         # A user-defined _domain_ part of the FDQN, (if more prefixes are required before the dns_nameserver_zone)
 #  dns_server: ""                    # Specify DNS server. nsupdate, route53 or clouddns.  If empty string is specified, no DNS will be added.
 #  route53_private_zone: true        # Only used when cluster_vars.type == 'aws'. Defaults to true if not set.
 #  assign_public_ip: "yes"
@@ -88,9 +88,9 @@ cluster_name: "{{app_name}}-{{buildenv}}"       # Identifies the cluster within 
 #  type: &cloud_type "gcp"
 #  image: "projects/ubuntu-os-cloud/global/images/ubuntu-1804-bionic-v20200430"
 #  region: &region "europe-west1"
-#  dns_cloud_internal_domain: "c.{{gcp_credentials_json.project_id}}.internal"
-#  dns_nameserver_zone: &dns_nameserver_zone ""              # The zone that dns_server will operate on.  gcloud dns needs a trailing '.'.  Leave blank if no external DNS (use IPs only)
-#  dns_fqdn_domain: "{{_cloud_type}}-{{_region}}.{{app_class}}.{{buildenv}}.{{_dns_nameserver_zone}}"         # The _domain_ part of the FDQN, (if more prefixes are required before the dns_nameserver_zone)
+#  dns_cloud_internal_domain: "c.{{gcp_credentials_json.project_id}}.internal"     # The cloud-internal zone as defined by the cloud provider (e.g. GCP, AWS)
+#  dns_nameserver_zone: &dns_nameserver_zone ""                                    # The zone that dns_server will operate on.  gcloud dns needs a trailing '.'.  Leave blank if no external DNS (use IPs only)
+#  dns_user_domain: "{%- if _dns_nameserver_zone -%}MY.OTHER.PREFIXES.{{_dns_nameserver_zone}}{%- endif -%}"         # A user-defined _domain_ part of the FDQN, (if more prefixes are required before the dns_nameserver_zone)
 #  dns_server: ""                            # Specify DNS server. nsupdate, route53 or clouddns.  If empty string is specified, no DNS will be added.
 #  assign_public_ip: "yes"
 #  inventory_ip: "public"                    # 'public' or 'private', (private in case we're operating in a private LAN).  If public, 'assign_public_ip' must be 'yes'

--- a/EXAMPLE/group_vars/test_aws_euw1/cluster_vars.yml
+++ b/EXAMPLE/group_vars/test_aws_euw1/cluster_vars.yml
@@ -1,9 +1,13 @@
 ---
 
+redeploy_scheme: _scheme_addallnew_rmdisk_rollback
+#redeploy_scheme: _scheme_addnewvm_rmdisk_rollback
+#redeploy_scheme: _scheme_rmvm_rmdisks_only
+
 app_name: "test"                  # The name of the application cluster (e.g. 'couchbase', 'nginx'); becomes part of cluster_name.
 app_class: "test"                 # The class of application (e.g. 'database', 'webserver'); becomes part of the fqdn
 
-dns_tld_external: ""              # Top-level domain for external access.  gcloud dns needs a trailing '.'.  Leave blank if no external DNS (use IPs only)
+beats_target_hosts: []            # The destination hosts for e.g. filebeat/ metricbeat logs
 
 ## Vulnerability scanners - Tenable and/ or Qualys cloud agents:
 cloud_agent:
@@ -35,14 +39,15 @@ cluster_name: "{{app_name}}-{{buildenv}}"       # Identifies the cluster within 
 cluster_vars:
   type: &cloud_type "aws"
   image: "ami-0964eb2dc8b836eb6"    # eu-west-1, 18.04, amd64, hvm-ssd, 20200430.  Ubuntu images can be located at https://cloud-images.ubuntu.com/locator/
-  region: &region "eu-west-1"
-  dns_zone_internal: "{{_region}}.compute.internal"         # eu-west-1, us-west-2
-  dns_zone_external: "{%- if dns_tld_external -%}{{_cloud_type}}-{{_region}}.{{app_class}}.{{buildenv}}.{{dns_tld_external}} {%- endif -%}"
+  region: &region "eu-west-1"       # eu-west-1, us-west-2
+  dns_cloud_internal_domain: "{{_region}}.compute.internal"
+  dns_nameserver_zone: &dns_nameserver_zone ""              # The zone that dns_server will operate on.  gcloud dns needs a trailing '.'.  Leave blank if no external DNS (use IPs only)
+  dns_fqdn_domain: "{{_cloud_type}}-{{_region}}.{{app_class}}.{{buildenv}}.{{_dns_nameserver_zone}}"         # The _domain_ part of the FDQN, (if more prefixes are required before the dns_nameserver_zone)
   dns_server: ""                    # Specify DNS server. nsupdate, route53 or clouddns.  If empty string is specified, no DNS will be added.
+  route53_private_zone: true        # Only used when cluster_vars.type == 'aws'. Defaults to true if not set.
   assign_public_ip: "yes"
   inventory_ip: "public"            # 'public' or 'private', (private in case we're operating in a private LAN).  If public, 'assign_public_ip' must be 'yes'
   instance_profile_name: ""
-  route53_private_zone: true        # Only used when cluster_vars.type == 'aws'. Defaults to true if not set.
   custom_tagslabels:
     inv_resident_id: "myresident"
     inv_proposition_id: "myproposition"
@@ -68,6 +73,7 @@ cluster_vars:
     hosttype_vars:
       sys: {vms_by_az: {a: 1, b: 1, c: 1}, flavor: t3a.nano, version: "{{sys_version | default('')}}", auto_volumes: []}
 #      sysdisks: {vms_by_az: {a: 1, b: 0, c: 0}, flavor: t3a.nano, version: "{{sysdisks_version | default('')}}", auto_volumes: [{"device_name": "/dev/sdb", mountpoint: "/var/log/mysvc", fstype: "ext4", "volume_type": "gp2", "volume_size": 2, ephemeral: False, encrypted: True, "delete_on_termination": true, perms: {owner: "root", group: "sudo", mode: "775"} }, {"device_name": "/dev/sdc", mountpoint: "/var/log/mysvc2", fstype: "ext4", "volume_type": "gp2", "volume_size": 3, ephemeral: False, encrypted: True, "delete_on_termination": true}, {"device_name": "/dev/sdd", mountpoint: "/var/log/mysvc3", fstype: "ext4", "volume_type": "gp2", "volume_size": 2, ephemeral: False, encrypted: True, "delete_on_termination": true}]}
+#      sysdisks_snapshot: {vms_by_az: {a: 1, b: 1, c: 0}, flavor: t3a.nano, auto_volumes: [{"snapshot_tags": {"tag:backup_id": "57180566894481854905"}, "device_name": "/dev/sdb", mountpoint: "/data", fstype: "ext4", "volume_type": "gp2", "volume_size": 2, ephemeral: False, encrypted: True, "delete_on_termination": true }]}
 #      hostnvme_multi: {vms_by_az: {a: 1, b: 0, c: 0}, flavor: i3en.2xlarge, auto_volumes: [], nvme: {volumes: [{mountpoint: "/var/log/mysvc", fstype: ext4, volume_size: 2500}, {mountpoint: "/var/log/mysvc2", fstype: ext4, volume_size: 2500}]} }
 #      hostnvme_lvm: {vms_by_az: {a: 1, b: 0, c: 0}, flavor: i3en.2xlarge, auto_volumes: [], nvme: {volumes: [{mountpoint: "/var/log/mysvc", fstype: ext4, volume_size: 2500}, {mountpoint: "/var/log/mysvc", fstype: ext4, volume_size: 2500}], lvmparams: {vg_name: "vg0", lv_name: "lv0", lv_size: "+100%FREE"} } }
 #      hostssd: {vms_by_az: {a: 1, b: 0, c: 0}, flavor: c3.large, auto_volumes: [{device_name: "/dev/sdb", mountpoint: "/var/log/mysvc", fstype: "ext4", "volume_type": "gp2", "volume_size": 2, ephemeral: False, encrypted: True, "delete_on_termination": true}]}
@@ -80,3 +86,4 @@ cluster_vars:
     termination_protection: "no"
 _cloud_type: *cloud_type
 _region: *region
+_dns_nameserver_zone: *dns_nameserver_zone

--- a/EXAMPLE/group_vars/test_aws_euw1/cluster_vars.yml
+++ b/EXAMPLE/group_vars/test_aws_euw1/cluster_vars.yml
@@ -40,9 +40,9 @@ cluster_vars:
   type: &cloud_type "aws"
   image: "ami-0964eb2dc8b836eb6"    # eu-west-1, 18.04, amd64, hvm-ssd, 20200430.  Ubuntu images can be located at https://cloud-images.ubuntu.com/locator/
   region: &region "eu-west-1"       # eu-west-1, us-west-2
-  dns_cloud_internal_domain: "{{_region}}.compute.internal"
-  dns_nameserver_zone: &dns_nameserver_zone ""              # The zone that dns_server will operate on.  gcloud dns needs a trailing '.'.  Leave blank if no external DNS (use IPs only)
-  dns_fqdn_domain: "{{_cloud_type}}-{{_region}}.{{app_class}}.{{buildenv}}.{{_dns_nameserver_zone}}"         # The _domain_ part of the FDQN, (if more prefixes are required before the dns_nameserver_zone)
+  dns_cloud_internal_domain: "{{_region}}.compute.internal"   # The cloud-internal zone as defined by the cloud provider (e.g. GCP, AWS)
+  dns_nameserver_zone: &dns_nameserver_zone ""                # The zone that dns_server will operate on.  gcloud dns needs a trailing '.'.  Leave blank if no external DNS (use IPs only)
+  dns_user_domain: "{%- if _dns_nameserver_zone -%}{{_cloud_type}}-{{_region}}.{{app_class}}.{{buildenv}}.{{_dns_nameserver_zone}}{%- endif -%}"         # A user-defined _domain_ part of the FDQN, (if more prefixes are required before the dns_nameserver_zone)
   dns_server: ""                    # Specify DNS server. nsupdate, route53 or clouddns.  If empty string is specified, no DNS will be added.
   route53_private_zone: true        # Only used when cluster_vars.type == 'aws'. Defaults to true if not set.
   assign_public_ip: "yes"

--- a/EXAMPLE/group_vars/test_gcp_euw1/app_vars.yml
+++ b/EXAMPLE/group_vars/test_gcp_euw1/app_vars.yml
@@ -1,1 +1,4 @@
 ---
+
+sys_version: "1_0_0"
+sysdisks_version: "1_0_1"

--- a/EXAMPLE/group_vars/test_gcp_euw1/cluster_vars.yml
+++ b/EXAMPLE/group_vars/test_gcp_euw1/cluster_vars.yml
@@ -4,10 +4,14 @@
 gcp_credentials_file: "{{ lookup('env','GCP_CREDENTIALS') | default('/dev/null', true) }}"
 gcp_credentials_json: "{{ lookup('file', gcp_credentials_file) | default({'project_id': 'GCP_CREDENTIALS__NOT_SET','client_email': 'GCP_CREDENTIALS__NOT_SET'}, true) }}"
 
+redeploy_scheme: _scheme_addallnew_rmdisk_rollback
+#redeploy_scheme: _scheme_addnewvm_rmdisk_rollback
+#redeploy_scheme: _scheme_rmvm_rmdisks_only
+
 app_name: "test"                  # The name of the application cluster (e.g. 'couchbase', 'nginx'); becomes part of cluster_name.
 app_class: "test"                 # The class of application (e.g. 'database', 'webserver'); becomes part of the fqdn
 
-dns_tld_external: ""              # Top-level domain for external access.  gcloud dns needs a trailing '.'.  Leave blank if no external DNS (use IPs only)
+beats_target_hosts: []            # The destination hosts for e.g. filebeat/ metricbeat logs
 
 ## Vulnerability scanners - Tenable and/ or Qualys cloud agents:
 cloud_agent:
@@ -40,8 +44,9 @@ cluster_vars:
   type: &cloud_type "gcp"
   image: "projects/ubuntu-os-cloud/global/images/ubuntu-1804-bionic-v20200430"
   region: &region "europe-west1"
-  dns_zone_internal: "c.{{gcp_credentials_json.project_id}}.internal"
-  dns_zone_external: "{%- if dns_tld_external -%}{{_cloud_type}}-{{_region}}.{{app_class}}.{{buildenv}}.{{dns_tld_external}} {%- endif -%}"
+  dns_cloud_internal_domain: "c.{{gcp_credentials_json.project_id}}.internal"
+  dns_nameserver_zone: &dns_nameserver_zone ""              # The zone that dns_server will operate on.  gcloud dns needs a trailing '.'.  Leave blank if no external DNS (use IPs only)
+  dns_fqdn_domain: "{{_cloud_type}}-{{_region}}.{{app_class}}.{{buildenv}}.{{_dns_nameserver_zone}}"         # The _domain_ part of the FDQN, (if more prefixes are required before the dns_nameserver_zone)
   dns_server: ""                            # Specify DNS server. nsupdate, route53 or clouddns.  If empty string is specified, no DNS will be added.
   assign_public_ip: "yes"
   inventory_ip: "public"                    # 'public' or 'private', (private in case we're operating in a private LAN).  If public, 'assign_public_ip' must be 'yes'
@@ -81,3 +86,4 @@ cluster_vars:
 _cloud_type: *cloud_type
 _region: *region
 _ssh_guard_whitelist: *ssh_guard_whitelist
+_dns_nameserver_zone: *dns_nameserver_zone

--- a/EXAMPLE/group_vars/test_gcp_euw1/cluster_vars.yml
+++ b/EXAMPLE/group_vars/test_gcp_euw1/cluster_vars.yml
@@ -44,9 +44,9 @@ cluster_vars:
   type: &cloud_type "gcp"
   image: "projects/ubuntu-os-cloud/global/images/ubuntu-1804-bionic-v20200430"
   region: &region "europe-west1"
-  dns_cloud_internal_domain: "c.{{gcp_credentials_json.project_id}}.internal"
-  dns_nameserver_zone: &dns_nameserver_zone ""              # The zone that dns_server will operate on.  gcloud dns needs a trailing '.'.  Leave blank if no external DNS (use IPs only)
-  dns_fqdn_domain: "{{_cloud_type}}-{{_region}}.{{app_class}}.{{buildenv}}.{{_dns_nameserver_zone}}"         # The _domain_ part of the FDQN, (if more prefixes are required before the dns_nameserver_zone)
+  dns_cloud_internal_domain: "c.{{gcp_credentials_json.project_id}}.internal"   # The cloud-internal zone as defined by the cloud provider (e.g. GCP, AWS)
+  dns_nameserver_zone: &dns_nameserver_zone ""                                  # The zone that dns_server will operate on.  gcloud dns needs a trailing '.'.  Leave blank if no external DNS (use IPs only)
+  dns_user_domain: "{%- if _dns_nameserver_zone -%}{{_cloud_type}}-{{_region}}.{{app_class}}.{{buildenv}}.{{_dns_nameserver_zone}}{%- endif -%}"         # A user-defined _domain_ part of the FDQN, (if more prefixes are required before the dns_nameserver_zone)
   dns_server: ""                            # Specify DNS server. nsupdate, route53 or clouddns.  If empty string is specified, no DNS will be added.
   assign_public_ip: "yes"
   inventory_ip: "public"                    # 'public' or 'private', (private in case we're operating in a private LAN).  If public, 'assign_public_ip' must be 'yes'

--- a/clean/tasks/clean_dns.yml
+++ b/clean/tasks/clean_dns.yml
@@ -13,7 +13,7 @@
             server: "{{bind9[buildenv].server}}"
             zone: "{{cluster_vars.dns_nameserver_zone}}"
             state: "absent"
-            record: "{{item.name}}.{{cluster_vars.dns_fqdn_domain | regex_replace('^(.*?)\\.' + cluster_vars.dns_nameserver_zone, '\\1')}}"
+            record: "{{item.name}}.{{cluster_vars.dns_user_domain | regex_replace('^(.*?)\\.' + cluster_vars.dns_nameserver_zone, '\\1')}}"
           with_items: "{{ hosts_to_clean }}"
 
         - name: clean/dns/nsupdate | Delete CNAME records
@@ -22,15 +22,15 @@
             key_secret: "{{bind9[buildenv].key_secret}}"
             server: "{{bind9[buildenv].server}}"
             zone: "{{cluster_vars.dns_nameserver_zone}}"
-            record: "{{item.name | regex_replace('-(?!.*-).*')}}.{{cluster_vars.dns_fqdn_domain | regex_replace('^(.*?)\\.' + cluster_vars.dns_nameserver_zone, '\\1')}}"
-            value:  "{{item.name}}.{{cluster_vars.dns_fqdn_domain | regex_replace('^(.*?)\\.' + cluster_vars.dns_nameserver_zone, '\\1')}}"
+            record: "{{item.name | regex_replace('-(?!.*-).*')}}.{{cluster_vars.dns_user_domain | regex_replace('^(.*?)\\.' + cluster_vars.dns_nameserver_zone, '\\1')}}"
+            value:  "{{item.name}}.{{cluster_vars.dns_user_domain | regex_replace('^(.*?)\\.' + cluster_vars.dns_nameserver_zone, '\\1')}}"
             type: CNAME
             state: absent
           with_items: "{{ hosts_to_clean }}"
           vars:
-            cname_to_check: "{{ item.name | regex_replace('-(?!.*-).*') }}.{{cluster_vars.dns_fqdn_domain}}."
+            cname_to_check: "{{ item.name | regex_replace('-(?!.*-).*') }}.{{cluster_vars.dns_user_domain}}."
             cname_value: "{{ lookup('dig', cname_to_check, 'qtype=CNAME', '@'+bind9[buildenv].server) }}"
-          when: (item.name + '.' + cluster_vars.dns_fqdn_domain + "." == cname_value)
+          when: (item.name + '.' + cluster_vars.dns_user_domain + "." == cname_value)
       when: cluster_vars.dns_server == "nsupdate"
 
     - name: clean/dns/route53 | Delete DNS entries from route53
@@ -41,7 +41,7 @@
             aws_secret_key: "{{cluster_vars[buildenv].aws_secret_key}}"
             state: "get"
             zone: "{{cluster_vars.dns_nameserver_zone}}"
-            record: "{{item.name}}.{{cluster_vars.dns_fqdn_domain}}"
+            record: "{{item.name}}.{{cluster_vars.dns_user_domain}}"
             type: "A"
             private_zone: "{{cluster_vars.route53_private_zone | default(true)}}"
           register: r__route53_a
@@ -67,7 +67,7 @@
             aws_secret_key: "{{cluster_vars[buildenv].aws_secret_key}}"
             state: "get"
             zone: "{{cluster_vars.dns_nameserver_zone}}"
-            record: "{{item.name | regex_replace('-(?!.*-).*')}}.{{cluster_vars.dns_fqdn_domain}}"
+            record: "{{item.name | regex_replace('-(?!.*-).*')}}.{{cluster_vars.dns_user_domain}}"
             type: "CNAME"
             private_zone: "{{cluster_vars.route53_private_zone | default(true)}}"
           register: r__route53_cname

--- a/clean/tasks/clean_dns.yml
+++ b/clean/tasks/clean_dns.yml
@@ -11,9 +11,9 @@
             key_name: "{{bind9[buildenv].key_name}}"
             key_secret: "{{bind9[buildenv].key_secret}}"
             server: "{{bind9[buildenv].server}}"
-            zone: "{{dns_tld_external}}"
+            zone: "{{cluster_vars.dns_nameserver_zone}}"
             state: "absent"
-            record: "{{item.name}}.{{cluster_vars.dns_zone_external | regex_replace('^(.*?)\\.' + dns_tld_external, '\\1')}}"
+            record: "{{item.name}}.{{cluster_vars.dns_fqdn_domain | regex_replace('^(.*?)\\.' + cluster_vars.dns_nameserver_zone, '\\1')}}"
           with_items: "{{ hosts_to_clean }}"
 
         - name: clean/dns/nsupdate | Delete CNAME records
@@ -21,16 +21,16 @@
             key_name: "{{bind9[buildenv].key_name}}"
             key_secret: "{{bind9[buildenv].key_secret}}"
             server: "{{bind9[buildenv].server}}"
-            zone: "{{dns_tld_external}}"
-            record: "{{item.name | regex_replace('-(?!.*-).*')}}.{{cluster_vars.dns_zone_external | regex_replace('^(.*?)\\.' + dns_tld_external, '\\1')}}"
-            value:  "{{item.name}}.{{cluster_vars.dns_zone_external | regex_replace('^(.*?)\\.' + dns_tld_external, '\\1')}}"
+            zone: "{{cluster_vars.dns_nameserver_zone}}"
+            record: "{{item.name | regex_replace('-(?!.*-).*')}}.{{cluster_vars.dns_fqdn_domain | regex_replace('^(.*?)\\.' + cluster_vars.dns_nameserver_zone, '\\1')}}"
+            value:  "{{item.name}}.{{cluster_vars.dns_fqdn_domain | regex_replace('^(.*?)\\.' + cluster_vars.dns_nameserver_zone, '\\1')}}"
             type: CNAME
             state: absent
           with_items: "{{ hosts_to_clean }}"
           vars:
-            cname_to_check: "{{ item.name | regex_replace('-(?!.*-).*') }}.{{cluster_vars.dns_zone_external}}."
+            cname_to_check: "{{ item.name | regex_replace('-(?!.*-).*') }}.{{cluster_vars.dns_fqdn_domain}}."
             cname_value: "{{ lookup('dig', cname_to_check, 'qtype=CNAME', '@'+bind9[buildenv].server) }}"
-          when: (item.name + '.' + cluster_vars.dns_zone_external + "." == cname_value)
+          when: (item.name + '.' + cluster_vars.dns_fqdn_domain + "." == cname_value)
       when: cluster_vars.dns_server == "nsupdate"
 
     - name: clean/dns/route53 | Delete DNS entries from route53
@@ -40,8 +40,8 @@
             aws_access_key: "{{cluster_vars[buildenv].aws_access_key}}"
             aws_secret_key: "{{cluster_vars[buildenv].aws_secret_key}}"
             state: "get"
-            zone: "{{dns_tld_external}}"
-            record: "{{item.name}}.{{cluster_vars.dns_zone_external}}"
+            zone: "{{cluster_vars.dns_nameserver_zone}}"
+            record: "{{item.name}}.{{cluster_vars.dns_fqdn_domain}}"
             type: "A"
             private_zone: "{{cluster_vars.route53_private_zone | default(true)}}"
           register: r__route53_a
@@ -66,8 +66,8 @@
             aws_access_key: "{{cluster_vars[buildenv].aws_access_key}}"
             aws_secret_key: "{{cluster_vars[buildenv].aws_secret_key}}"
             state: "get"
-            zone: "{{dns_tld_external}}"
-            record: "{{item.name | regex_replace('-(?!.*-).*')}}.{{cluster_vars.dns_zone_external}}"
+            zone: "{{cluster_vars.dns_nameserver_zone}}"
+            record: "{{item.name | regex_replace('-(?!.*-).*')}}.{{cluster_vars.dns_fqdn_domain}}"
             type: "CNAME"
             private_zone: "{{cluster_vars.route53_private_zone | default(true)}}"
           register: r__route53_cname
@@ -96,7 +96,7 @@
         - name: clean/dns/clouddns | Get GCP Managed Zone
           gcp_dns_managed_zone_info:
             auth_kind: serviceaccount
-            dns_name: "{{dns_tld_external}}"
+            dns_name: "{{cluster_vars.dns_nameserver_zone}}"
             project: "{{cluster_vars.project_id}}"
             service_account_file: "{{gcp_credentials_file}}"
           register: r__gcp_dns_managed_zone_info

--- a/clean/tasks/main.yml
+++ b/clean/tasks/main.yml
@@ -4,7 +4,7 @@
   block:
     - name: clean | Delete DNS
       include_tasks: clean_dns.yml
-      when: (cluster_vars.dns_server is defined and cluster_vars.dns_server != "") and (cluster_vars.dns_nameserver_zone is defined and cluster_vars.dns_nameserver_zone != "")
+      when: (cluster_vars.dns_server is defined and cluster_vars.dns_server != "") and (cluster_vars.dns_user_domain is defined and cluster_vars.dns_user_domain != "")
 
     - name: clean | Delete VMs
       include_tasks: clean_vms.yml

--- a/clean/tasks/main.yml
+++ b/clean/tasks/main.yml
@@ -4,7 +4,7 @@
   block:
     - name: clean | Delete DNS
       include_tasks: clean_dns.yml
-      when: (cluster_vars.dns_server is defined and cluster_vars.dns_server != "") and (cluster_vars.dns_zone_external is defined and cluster_vars.dns_zone_external != "")
+      when: (cluster_vars.dns_server is defined and cluster_vars.dns_server != "") and (cluster_vars.dns_nameserver_zone is defined and cluster_vars.dns_nameserver_zone != "")
 
     - name: clean | Delete VMs
       include_tasks: clean_vms.yml

--- a/config/tasks/create_dns_a.yml
+++ b/config/tasks/create_dns_a.yml
@@ -6,8 +6,8 @@
     key_secret: "{{bind9[buildenv].key_secret}}"
     server: "{{bind9[buildenv].server}}"
     ttl: 60
-    zone: "{{dns_tld_external}}"
-    record: "{{item.hostname}}.{{cluster_vars.dns_zone_external | regex_replace('^(.*?)\\.' + dns_tld_external, '\\1')}}"
+    zone: "{{cluster_vars.dns_nameserver_zone}}"
+    record: "{{item.hostname}}.{{cluster_vars.dns_fqdn_domain | regex_replace('^(.*?)\\.' + cluster_vars.dns_nameserver_zone, '\\1')}}"
     value: "{{ hostvars[item.hostname]['ansible_host'] }}"
   become: false
   delegate_to: localhost
@@ -20,8 +20,8 @@
     aws_access_key: "{{cluster_vars[buildenv].aws_access_key}}"
     aws_secret_key: "{{cluster_vars[buildenv].aws_secret_key}}"
     state: present
-    zone: "{{dns_tld_external}}"
-    record: "{{item.hostname}}.{{cluster_vars.dns_zone_external}}"
+    zone: "{{cluster_vars.dns_nameserver_zone}}"
+    record: "{{item.hostname}}.{{cluster_vars.dns_fqdn_domain}}"
     type: A
     ttl: 60
     value: "{{ hostvars[item.hostname]['ansible_host'] }}"
@@ -38,7 +38,7 @@
     - name: config/dns/a/clouddns | Gather info for a pre-existing GCP Managed Zone and store as dict
       gcp_dns_managed_zone_info:
         auth_kind: serviceaccount
-        dns_name: "{{dns_tld_external}}"
+        dns_name: "{{cluster_vars.dns_nameserver_zone}}"
         project: "{{cluster_vars.project_id}}"
         service_account_file: "{{gcp_credentials_file}}"
       register: r__gcp_dns_managed_zone_info
@@ -52,7 +52,7 @@
         managed_zone:
           name: "{{r__gcp_dns_managed_zone_info.resources.0.name}}"
           dnsName: "{{r__gcp_dns_managed_zone_info.resources.0.dnsName}}"
-        name: "{{item.hostname}}.{{cluster_vars.dns_zone_external}}"
+        name: "{{item.hostname}}.{{cluster_vars.dns_fqdn_domain}}"
         project: "{{cluster_vars.project_id}}"
         service_account_file: "{{gcp_credentials_file}}"
         state: present
@@ -86,7 +86,7 @@
       delay: 10
       with_items: "{{ cluster_hosts_target }}"
       vars:
-        new_fqdn: "{{item.hostname}}.{{cluster_vars.dns_zone_external | regex_replace('^(.*?)\\.?$','\\1')}}."      # Add a '.' to the fadn, (but only if there's not one already)
+        new_fqdn: "{{item.hostname}}.{{cluster_vars.dns_fqdn_domain | regex_replace('^(.*?)\\.?$','\\1')}}."      # Add a '.' to the fadn, (but only if there's not one already)
         new_ip: "{{hostvars[item.hostname].ansible_host}}"
       become: false
       run_once: true

--- a/config/tasks/create_dns_a.yml
+++ b/config/tasks/create_dns_a.yml
@@ -7,7 +7,7 @@
     server: "{{bind9[buildenv].server}}"
     ttl: 60
     zone: "{{cluster_vars.dns_nameserver_zone}}"
-    record: "{{item.hostname}}.{{cluster_vars.dns_fqdn_domain | regex_replace('^(.*?)\\.' + cluster_vars.dns_nameserver_zone, '\\1')}}"
+    record: "{{item.hostname}}.{{cluster_vars.dns_user_domain | regex_replace('^(.*?)\\.' + cluster_vars.dns_nameserver_zone, '\\1')}}"
     value: "{{ hostvars[item.hostname]['ansible_host'] }}"
   become: false
   delegate_to: localhost
@@ -21,7 +21,7 @@
     aws_secret_key: "{{cluster_vars[buildenv].aws_secret_key}}"
     state: present
     zone: "{{cluster_vars.dns_nameserver_zone}}"
-    record: "{{item.hostname}}.{{cluster_vars.dns_fqdn_domain}}"
+    record: "{{item.hostname}}.{{cluster_vars.dns_user_domain}}"
     type: A
     ttl: 60
     value: "{{ hostvars[item.hostname]['ansible_host'] }}"
@@ -52,7 +52,7 @@
         managed_zone:
           name: "{{r__gcp_dns_managed_zone_info.resources.0.name}}"
           dnsName: "{{r__gcp_dns_managed_zone_info.resources.0.dnsName}}"
-        name: "{{item.hostname}}.{{cluster_vars.dns_fqdn_domain}}"
+        name: "{{item.hostname}}.{{cluster_vars.dns_user_domain}}"
         project: "{{cluster_vars.project_id}}"
         service_account_file: "{{gcp_credentials_file}}"
         state: present
@@ -86,7 +86,7 @@
       delay: 10
       with_items: "{{ cluster_hosts_target }}"
       vars:
-        new_fqdn: "{{item.hostname}}.{{cluster_vars.dns_fqdn_domain | regex_replace('^(.*?)\\.?$','\\1')}}."      # Add a '.' to the fadn, (but only if there's not one already)
+        new_fqdn: "{{item.hostname}}.{{cluster_vars.dns_user_domain | regex_replace('^(.*?)\\.?$','\\1')}}."      # Add a '.' to the fadn, (but only if there's not one already)
         new_ip: "{{hostvars[item.hostname].ansible_host}}"
       become: false
       run_once: true

--- a/config/tasks/main.yml
+++ b/config/tasks/main.yml
@@ -39,7 +39,7 @@
   lineinfile:
     path: /etc/hosts
     regexp: '^{{ansible_default_ipv4.address}}'
-    line: '{{ansible_default_ipv4.address}} {{inventory_hostname}}.{{cluster_vars.dns_zone_external}} {{inventory_hostname}}'
+    line: '{{ansible_default_ipv4.address}} {{inventory_hostname}}.{{cluster_vars.dns_fqdn_domain}} {{inventory_hostname}}'
 #    regexp: '^127\.0\.1\.1'
 #    line: '127.0.1.1 {{inventory_hostname}}'
     insertbefore: "BOF"
@@ -91,4 +91,4 @@
 
 - name: create DNS A records
   include_tasks: create_dns_a.yml
-  when: (cluster_vars.dns_server is defined and cluster_vars.dns_server != "") and (cluster_vars.dns_zone_external is defined and cluster_vars.dns_zone_external != "")
+  when: (cluster_vars.dns_server is defined and cluster_vars.dns_server != "") and (cluster_vars.dns_nameserver_zone is defined and cluster_vars.dns_nameserver_zone != "")

--- a/config/tasks/main.yml
+++ b/config/tasks/main.yml
@@ -39,7 +39,7 @@
   lineinfile:
     path: /etc/hosts
     regexp: '^{{ansible_default_ipv4.address}}'
-    line: '{{ansible_default_ipv4.address}} {{inventory_hostname}}.{{cluster_vars.dns_fqdn_domain}} {{inventory_hostname}}'
+    line: '{{ansible_default_ipv4.address}} {{inventory_hostname}}.{{cluster_vars.dns_user_domain}} {{inventory_hostname}}'
 #    regexp: '^127\.0\.1\.1'
 #    line: '127.0.1.1 {{inventory_hostname}}'
     insertbefore: "BOF"
@@ -91,4 +91,4 @@
 
 - name: create DNS A records
   include_tasks: create_dns_a.yml
-  when: (cluster_vars.dns_server is defined and cluster_vars.dns_server != "") and (cluster_vars.dns_nameserver_zone is defined and cluster_vars.dns_nameserver_zone != "")
+  when: (cluster_vars.dns_server is defined and cluster_vars.dns_server != "") and (cluster_vars.dns_user_domain is defined and cluster_vars.dns_user_domain != "")

--- a/readiness/tasks/config_dns_cname.yml
+++ b/readiness/tasks/config_dns_cname.yml
@@ -6,8 +6,8 @@
     key_secret: "{{bind9[buildenv].key_secret}}"
     server: "{{bind9[buildenv].server}}"
     zone: "{{cluster_vars.dns_nameserver_zone}}"
-    record: "{{item.hostname | regex_replace('-(?!.*-).*')}}.{{cluster_vars.dns_fqdn_domain | regex_replace('^(.*?)\\.' + cluster_vars.dns_nameserver_zone, '\\1')}}"
-    value:  "{{item.hostname}}.{{cluster_vars.dns_fqdn_domain | regex_replace('^(.*?)\\.' + cluster_vars.dns_nameserver_zone, '\\1')}}"
+    record: "{{item.hostname | regex_replace('-(?!.*-).*')}}.{{cluster_vars.dns_user_domain | regex_replace('^(.*?)\\.' + cluster_vars.dns_nameserver_zone, '\\1')}}"
+    value:  "{{item.hostname}}.{{cluster_vars.dns_user_domain | regex_replace('^(.*?)\\.' + cluster_vars.dns_nameserver_zone, '\\1')}}"
     type: CNAME
     state: present
     ttl: 30
@@ -22,10 +22,10 @@
     aws_secret_key: "{{cluster_vars[buildenv].aws_secret_key}}"
     state: present
     zone: "{{cluster_vars.dns_nameserver_zone}}"
-    record: "{{item.hostname | regex_replace('-(?!.*-).*')}}.{{cluster_vars.dns_fqdn_domain}}"
+    record: "{{item.hostname | regex_replace('-(?!.*-).*')}}.{{cluster_vars.dns_user_domain}}"
     type: CNAME
     ttl: 30
-    value: "{{item.hostname}}.{{cluster_vars.dns_fqdn_domain}}"
+    value: "{{item.hostname}}.{{cluster_vars.dns_user_domain}}"
     private_zone: "{{cluster_vars.route53_private_zone | default(true)}}"
     overwrite: true
   with_items: "{{ cluster_hosts_target }}"
@@ -53,11 +53,11 @@
         managed_zone:
           name: "{{gcp_dns_managed_zone_info.resources.0.name}}"
           dnsName: "{{gcp_dns_managed_zone_info.resources.0.dnsName}}"
-        name: "{{item.hostname | regex_replace('-(?!.*-).*')}}.{{cluster_vars.dns_fqdn_domain}}"
+        name: "{{item.hostname | regex_replace('-(?!.*-).*')}}.{{cluster_vars.dns_user_domain}}"
         project: "{{cluster_vars.project_id}}"
         service_account_file: "{{gcp_credentials_file}}"
         state: present
-        target: "{{item.hostname}}.{{cluster_vars.dns_fqdn_domain}}"
+        target: "{{item.hostname}}.{{cluster_vars.dns_user_domain}}"
         type: CNAME
         ttl: 60
       with_items: "{{ cluster_hosts_target }}"

--- a/readiness/tasks/config_dns_cname.yml
+++ b/readiness/tasks/config_dns_cname.yml
@@ -5,9 +5,9 @@
     key_name: "{{bind9[buildenv].key_name}}"
     key_secret: "{{bind9[buildenv].key_secret}}"
     server: "{{bind9[buildenv].server}}"
-    zone: "{{dns_tld_external}}"
-    record: "{{item.hostname | regex_replace('-(?!.*-).*')}}.{{cluster_vars.dns_zone_external | regex_replace('^(.*?)\\.' + dns_tld_external, '\\1')}}"
-    value:  "{{item.hostname}}.{{cluster_vars.dns_zone_external | regex_replace('^(.*?)\\.' + dns_tld_external, '\\1')}}"
+    zone: "{{cluster_vars.dns_nameserver_zone}}"
+    record: "{{item.hostname | regex_replace('-(?!.*-).*')}}.{{cluster_vars.dns_fqdn_domain | regex_replace('^(.*?)\\.' + cluster_vars.dns_nameserver_zone, '\\1')}}"
+    value:  "{{item.hostname}}.{{cluster_vars.dns_fqdn_domain | regex_replace('^(.*?)\\.' + cluster_vars.dns_nameserver_zone, '\\1')}}"
     type: CNAME
     state: present
     ttl: 30
@@ -21,11 +21,11 @@
     aws_access_key: "{{cluster_vars[buildenv].aws_access_key}}"
     aws_secret_key: "{{cluster_vars[buildenv].aws_secret_key}}"
     state: present
-    zone: "{{dns_tld_external}}"
-    record: "{{item.hostname | regex_replace('-(?!.*-).*')}}.{{cluster_vars.dns_zone_external}}"
+    zone: "{{cluster_vars.dns_nameserver_zone}}"
+    record: "{{item.hostname | regex_replace('-(?!.*-).*')}}.{{cluster_vars.dns_fqdn_domain}}"
     type: CNAME
     ttl: 30
-    value: "{{item.hostname}}.{{cluster_vars.dns_zone_external}}"
+    value: "{{item.hostname}}.{{cluster_vars.dns_fqdn_domain}}"
     private_zone: "{{cluster_vars.route53_private_zone | default(true)}}"
     overwrite: true
   with_items: "{{ cluster_hosts_target }}"
@@ -39,7 +39,7 @@
     - name: create/dns/cname/clouddns | Gather info for a pre-existing GCP Managed Zone and store as dict
       gcp_dns_managed_zone_info:
         auth_kind: serviceaccount
-        dns_name: "{{dns_tld_external}}"
+        dns_name: "{{cluster_vars.dns_nameserver_zone}}"
         project: "{{cluster_vars.project_id}}"
         service_account_file: "{{gcp_credentials_file}}"
       register: gcp_dns_managed_zone_info
@@ -53,11 +53,11 @@
         managed_zone:
           name: "{{gcp_dns_managed_zone_info.resources.0.name}}"
           dnsName: "{{gcp_dns_managed_zone_info.resources.0.dnsName}}"
-        name: "{{item.hostname | regex_replace('-(?!.*-).*')}}.{{cluster_vars.dns_zone_external}}"
+        name: "{{item.hostname | regex_replace('-(?!.*-).*')}}.{{cluster_vars.dns_fqdn_domain}}"
         project: "{{cluster_vars.project_id}}"
         service_account_file: "{{gcp_credentials_file}}"
         state: present
-        target: "{{item.hostname}}.{{cluster_vars.dns_zone_external}}"
+        target: "{{item.hostname}}.{{cluster_vars.dns_fqdn_domain}}"
         type: CNAME
         ttl: 60
       with_items: "{{ cluster_hosts_target }}"

--- a/readiness/tasks/main.yml
+++ b/readiness/tasks/main.yml
@@ -6,4 +6,4 @@
 
 - name: readiness | create/update DNS CNAME records
   include_tasks: config_dns_cname.yml
-  when: (cluster_vars.dns_server is defined and cluster_vars.dns_server != "") and (cluster_vars.dns_nameserver_zone is defined and cluster_vars.dns_nameserver_zone != "")
+  when: (cluster_vars.dns_server is defined and cluster_vars.dns_server != "") and (cluster_vars.dns_user_domain is defined and cluster_vars.dns_user_domain != "")

--- a/readiness/tasks/main.yml
+++ b/readiness/tasks/main.yml
@@ -6,4 +6,4 @@
 
 - name: readiness | create/update DNS CNAME records
   include_tasks: config_dns_cname.yml
-  when: (cluster_vars.dns_server is defined and cluster_vars.dns_server != "") and (cluster_vars.dns_zone_external is defined and cluster_vars.dns_zone_external != "")
+  when: (cluster_vars.dns_server is defined and cluster_vars.dns_server != "") and (cluster_vars.dns_nameserver_zone is defined and cluster_vars.dns_nameserver_zone != "")

--- a/redeploy/_scheme_addallnew_rmdisk_rollback/tasks/main.yml
+++ b/redeploy/_scheme_addallnew_rmdisk_rollback/tasks/main.yml
@@ -28,7 +28,7 @@
     - import_role:
         name: clusterverse/clean
         tasks_from: clean_dns.yml
-      when: (hosts_to_clean | length)  and  (cluster_vars.dns_server is defined and cluster_vars.dns_server != "") and (cluster_vars.dns_zone_external is defined and cluster_vars.dns_zone_external != "")
+      when: (hosts_to_clean | length)  and  (cluster_vars.dns_server is defined and cluster_vars.dns_server != "") and (cluster_vars.dns_nameserver_zone is defined and cluster_vars.dns_nameserver_zone != "")
 
     - import_role:
         name: clusterverse/clean

--- a/redeploy/_scheme_addallnew_rmdisk_rollback/tasks/main.yml
+++ b/redeploy/_scheme_addallnew_rmdisk_rollback/tasks/main.yml
@@ -28,7 +28,7 @@
     - import_role:
         name: clusterverse/clean
         tasks_from: clean_dns.yml
-      when: (hosts_to_clean | length)  and  (cluster_vars.dns_server is defined and cluster_vars.dns_server != "") and (cluster_vars.dns_nameserver_zone is defined and cluster_vars.dns_nameserver_zone != "")
+      when: (hosts_to_clean | length)  and  (cluster_vars.dns_server is defined and cluster_vars.dns_server != "") and (cluster_vars.dns_user_domain is defined and cluster_vars.dns_user_domain != "")
 
     - import_role:
         name: clusterverse/clean

--- a/redeploy/_scheme_addnewvm_rmdisk_rollback/tasks/main.yml
+++ b/redeploy/_scheme_addnewvm_rmdisk_rollback/tasks/main.yml
@@ -72,7 +72,7 @@
     - import_role:
         name: clusterverse/clean
         tasks_from: clean_dns.yml
-      when: (hosts_to_clean | length)  and  (cluster_vars.dns_server is defined and cluster_vars.dns_server != "") and (cluster_vars.dns_nameserver_zone is defined and cluster_vars.dns_nameserver_zone != "")
+      when: (hosts_to_clean | length)  and  (cluster_vars.dns_server is defined and cluster_vars.dns_server != "") and (cluster_vars.dns_user_domain is defined and cluster_vars.dns_user_domain != "")
 
     - import_role:
         name: clusterverse/clean

--- a/redeploy/_scheme_addnewvm_rmdisk_rollback/tasks/main.yml
+++ b/redeploy/_scheme_addnewvm_rmdisk_rollback/tasks/main.yml
@@ -72,7 +72,7 @@
     - import_role:
         name: clusterverse/clean
         tasks_from: clean_dns.yml
-      when: (hosts_to_clean | length)  and  (cluster_vars.dns_server is defined and cluster_vars.dns_server != "") and (cluster_vars.dns_zone_external is defined and cluster_vars.dns_zone_external != "")
+      when: (hosts_to_clean | length)  and  (cluster_vars.dns_server is defined and cluster_vars.dns_server != "") and (cluster_vars.dns_nameserver_zone is defined and cluster_vars.dns_nameserver_zone != "")
 
     - import_role:
         name: clusterverse/clean


### PR DESCRIPTION
The naming of the variables that describe the DNS zone to which we're adding records (`dns_tld_external`), the name of the domain part of the FQDN (`cluster_vars.dns_zone_external`), and the name of the domain part of the cloud-internal FQDN (`cluster_vars.dns_zone_internal`) is very poor, and leads to misunderstandings.

```
dns_tld_external  --> cluster_vars.dns_nameserver_zone
dns_zone_internal --> cluster_vars.dns_cloud_internal_domain
dns_zone_external --> cluster_vars.dns_fqdn_domain
```