### PR TITLE
Support separate GCP 'host' and 'service' projects

### DIFF
--- a/EXAMPLE/.vaultpass-client.py
+++ b/EXAMPLE/.vaultpass-client.py
@@ -12,7 +12,7 @@ import sys
 envvar_vault_pass = "VAULT_PASSWORD_BUILDENV"
 
 if os.environ.get(envvar_vault_pass) is not None and os.environ.get(envvar_vault_pass) != "":
-    print (os.environ[envvar_vault_pass])
+    print(os.environ[envvar_vault_pass])
 else:
-    print ("ERROR: '" + envvar_vault_pass + "' is not set in environment")
+    print("ERROR: '" + envvar_vault_pass + "' is not set in environment")
     sys.exit(1)

--- a/EXAMPLE/Pipfile
+++ b/EXAMPLE/Pipfile
@@ -13,9 +13,6 @@ ansible = ">=2.9"
 jmespath = "*"
 dnspython = "*"
 google-auth = "*"
-netaddr = "*"
-passlib = "*"
-apache-libcloud = "*"
 google-api-python-client = "*"
 
 [dev-packages]

--- a/EXAMPLE/cluster.yml
+++ b/EXAMPLE/cluster.yml
@@ -19,5 +19,6 @@
 ##
 
 - name: Perform cluster readiness operations
-  hosts: all
+  hosts: localhost
+  connection: local
   roles: [ { role: clusterverse/readiness, tags: [clusterverse_readiness] } ]

--- a/EXAMPLE/clusterverse_label_upgrade_v1-v2.yml
+++ b/EXAMPLE/clusterverse_label_upgrade_v1-v2.yml
@@ -28,7 +28,7 @@
         - name: clusterverse_label_upgrade_v1-v2 | Add lifecycle_state and cluster_suffix label to GCP GCE VM
           gce_labels:
             resource_name: "{{item.name}}"
-            project_id: "{{cluster_vars.project_id}}"
+            project_id: "{{cluster_vars[buildenv].vpc_project_id}}"
             resource_location: "{{item.regionzone}}"
             credentials_file: "{{gcp_credentials_file}}"
             resource_type: instances

--- a/EXAMPLE/group_vars/_skel/cluster_vars.yml
+++ b/EXAMPLE/group_vars/_skel/cluster_vars.yml
@@ -93,7 +93,6 @@ cluster_name: "{{app_name}}-{{buildenv}}"       # Identifies the cluster within 
 #  dns_server: ""                            # Specify DNS server. nsupdate, route53 or clouddns.  If empty string is specified, no DNS will be added.
 #  assign_public_ip: "yes"
 #  inventory_ip: "public"                    # 'public' or 'private', (private in case we're operating in a private LAN).  If public, 'assign_public_ip' must be 'yes'
-#  project_id: &project_id "{{gcp_credentials_json.project_id}}"
 #  ip_forward: "false"
 #  ssh_guard_whitelist: &ssh_guard_whitelist ['10.0.0.0/8']    # Put your public-facing IPs into this (if you're going to access it via public IP), to avoid rate-limiting.
 #  custom_tagslabels: {inv_resident_id: "abc", inv_proposition_id: "def"}
@@ -115,7 +114,8 @@ cluster_name: "{{app_name}}-{{buildenv}}"       # Identifies the cluster within 
 #    hosttype_vars:
 #      sys: {vms_by_az: {b: 1, c: 1, d: 1}, flavor: f1-micro, rootvol_size: "10", version: "{{sys_version | default('')}}", auto_volumes: []}
 #      #sysdisks: {vms_by_az: {b: 1, c: 1, d: 1}, flavor: f1-micro, rootvol_size: "10", version: "{{sysdisks_version | default('')}}", auto_volumes: [{auto_delete: true, interface: "SCSI", volume_size: 2, mountpoint: "/var/log/mysvc", fstype: "ext4", perms: {owner: "root", group: "sudo", mode: "775"}}, {auto_delete: true, interface: "SCSI", volume_size: 2,  mountpoint: "/var/log/mysvc2", fstype: "ext4"}, {auto_delete: true, interface: "SCSI", volume_size: 3,  mountpoint: "/var/log/mysvc3", fstype: "ext4"}]}
-#    vpc_network_project_id: *project_id        # Set this to *project_id if no separate network project
+#    vpc_project_id: "{{gcp_credentials_json.project_id}}"             # AKA the 'service project' if Shared VPC (https://cloud.google.com/vpc/docs/shared-vpc) is in use.
+#    vpc_host_project_id: "{{gcp_credentials_json.project_id}}"        # Would differ from vpc_project_id if Shared VPC is in use, (the networking is in a separate project)
 #    vpc_network_name: "test-{{buildenv}}"
 #    vpc_subnet_name: ""
 #    preemptible: "no"

--- a/EXAMPLE/group_vars/_skel/cluster_vars.yml
+++ b/EXAMPLE/group_vars/_skel/cluster_vars.yml
@@ -86,11 +86,11 @@ cluster_name: "{{app_name}}-{{buildenv}}"       # Identifies the cluster within 
 ### GCP example
 #cluster_vars:
 #  type: &cloud_type "gcp"
-#  image: "projects/ubuntu-os-cloud/global/images/ubuntu-1804-bionic-v20200430"
+#  image: "projects/ubuntu-os-cloud/global/images/ubuntu-1804-bionic-v20200430"    # Ubuntu images can be located at https://cloud-images.ubuntu.com/locator/
 #  region: &region "europe-west1"
 #  dns_cloud_internal_domain: "c.{{gcp_credentials_json.project_id}}.internal"     # The cloud-internal zone as defined by the cloud provider (e.g. GCP, AWS)
 #  dns_nameserver_zone: &dns_nameserver_zone ""                                    # The zone that dns_server will operate on.  gcloud dns needs a trailing '.'.  Leave blank if no external DNS (use IPs only)
-#  dns_user_domain: "{%- if _dns_nameserver_zone -%}MY.OTHER.PREFIXES.{{_dns_nameserver_zone}}{%- endif -%}"         # A user-defined _domain_ part of the FDQN, (if more prefixes are required before the dns_nameserver_zone)
+#  dns_user_domain: "{%- if _dns_nameserver_zone -%}CUSTOM.PREFIXES.{{_dns_nameserver_zone}}{%- endif -%}"         # A user-defined _domain_ part of the FDQN, (if more prefixes are required before the dns_nameserver_zone)
 #  dns_server: ""                            # Specify DNS server. nsupdate, route53 or clouddns.  If empty string is specified, no DNS will be added.
 #  assign_public_ip: "yes"
 #  inventory_ip: "public"                    # 'public' or 'private', (private in case we're operating in a private LAN).  If public, 'assign_public_ip' must be 'yes'

--- a/EXAMPLE/group_vars/_skel/cluster_vars.yml
+++ b/EXAMPLE/group_vars/_skel/cluster_vars.yml
@@ -93,7 +93,7 @@ cluster_name: "{{app_name}}-{{buildenv}}"       # Identifies the cluster within 
 #  dns_server: ""                            # Specify DNS server. nsupdate, route53 or clouddns.  If empty string is specified, no DNS will be added.
 #  assign_public_ip: "yes"
 #  inventory_ip: "public"                    # 'public' or 'private', (private in case we're operating in a private LAN).  If public, 'assign_public_ip' must be 'yes'
-#  project_id: "{{gcp_credentials_json.project_id}}"
+#  project_id: &project_id "{{gcp_credentials_json.project_id}}"
 #  ip_forward: "false"
 #  ssh_guard_whitelist: &ssh_guard_whitelist ['10.0.0.0/8']    # Put your public-facing IPs into this (if you're going to access it via public IP), to avoid rate-limiting.
 #  custom_tagslabels: {inv_resident_id: "abc", inv_proposition_id: "def"}
@@ -115,6 +115,7 @@ cluster_name: "{{app_name}}-{{buildenv}}"       # Identifies the cluster within 
 #    hosttype_vars:
 #      sys: {vms_by_az: {b: 1, c: 1, d: 1}, flavor: f1-micro, rootvol_size: "10", version: "{{sys_version | default('')}}", auto_volumes: []}
 #      #sysdisks: {vms_by_az: {b: 1, c: 1, d: 1}, flavor: f1-micro, rootvol_size: "10", version: "{{sysdisks_version | default('')}}", auto_volumes: [{auto_delete: true, interface: "SCSI", volume_size: 2, mountpoint: "/var/log/mysvc", fstype: "ext4", perms: {owner: "root", group: "sudo", mode: "775"}}, {auto_delete: true, interface: "SCSI", volume_size: 2,  mountpoint: "/var/log/mysvc2", fstype: "ext4"}, {auto_delete: true, interface: "SCSI", volume_size: 3,  mountpoint: "/var/log/mysvc3", fstype: "ext4"}]}
+#    vpc_network_project_id: *project_id        # Set this to *project_id if no separate network project
 #    vpc_network_name: "test-{{buildenv}}"
 #    vpc_subnet_name: ""
 #    preemptible: "no"

--- a/EXAMPLE/group_vars/test_gcp_euw1/cluster_vars.yml
+++ b/EXAMPLE/group_vars/test_gcp_euw1/cluster_vars.yml
@@ -42,7 +42,7 @@ cluster_name: "{{app_name}}-{{buildenv}}"       # Identifies the cluster within 
 
 cluster_vars:
   type: &cloud_type "gcp"
-  image: "projects/ubuntu-os-cloud/global/images/ubuntu-1804-bionic-v20200430"
+  image: "projects/ubuntu-os-cloud/global/images/ubuntu-1804-bionic-v20200430"  # Ubuntu images can be located at https://cloud-images.ubuntu.com/locator/
   region: &region "europe-west1"
   dns_cloud_internal_domain: "c.{{gcp_credentials_json.project_id}}.internal"   # The cloud-internal zone as defined by the cloud provider (e.g. GCP, AWS)
   dns_nameserver_zone: &dns_nameserver_zone ""                                  # The zone that dns_server will operate on.  gcloud dns needs a trailing '.'.  Leave blank if no external DNS (use IPs only)

--- a/EXAMPLE/group_vars/test_gcp_euw1/cluster_vars.yml
+++ b/EXAMPLE/group_vars/test_gcp_euw1/cluster_vars.yml
@@ -45,7 +45,6 @@ cluster_vars:
   dns_server: ""                            # Specify DNS server. nsupdate, route53 or clouddns.  If empty string is specified, no DNS will be added.
   assign_public_ip: "yes"
   inventory_ip: "public"                    # 'public' or 'private', (private in case we're operating in a private LAN).  If public, 'assign_public_ip' must be 'yes'
-  project_id: &project_id "{{gcp_credentials_json.project_id}}"
   ip_forward: "false"
   ssh_guard_whitelist: &ssh_guard_whitelist ['10.0.0.0/8']    # Put your public-facing IPs into this (if you're going to access it via public IP), to avoid rate-limiting.
   custom_tagslabels:
@@ -74,7 +73,8 @@ cluster_vars:
     hosttype_vars:
       sys: {vms_by_az: {b: 1, c: 1, d: 1}, flavor: f1-micro, rootvol_size: "10", version: "{{sys_version | default('')}}", auto_volumes: []}
       #sysdisks: {vms_by_az: {b: 1, c: 1, d: 1}, flavor: f1-micro, rootvol_size: "10", version: "{{sysdisks_version | default('')}}", auto_volumes: [{auto_delete: true, interface: "SCSI", volume_size: 2, mountpoint: "/var/log/mysvc", fstype: "ext4", perms: {owner: "root", group: "sudo", mode: "775"}}, {auto_delete: true, interface: "SCSI", volume_size: 2,  mountpoint: "/var/log/mysvc2", fstype: "ext4"}, {auto_delete: true, interface: "SCSI", volume_size: 3,  mountpoint: "/var/log/mysvc3", fstype: "ext4"}]}
-    vpc_network_project_id: *project_id        # Set this to *project_id if no separate network project
+    vpc_project_id: "{{gcp_credentials_json.project_id}}"             # AKA the 'service project' if Shared VPC (https://cloud.google.com/vpc/docs/shared-vpc) is in use.
+    vpc_host_project_id: "{{gcp_credentials_json.project_id}}"        # Would differ from vpc_project_id if Shared VPC is in use, (the networking is in a separate project)
     vpc_network_name: "test-{{buildenv}}"
     vpc_subnet_name: ""
     preemptible: "no"

--- a/EXAMPLE/group_vars/test_gcp_euw1/cluster_vars.yml
+++ b/EXAMPLE/group_vars/test_gcp_euw1/cluster_vars.yml
@@ -45,7 +45,7 @@ cluster_vars:
   dns_server: ""                            # Specify DNS server. nsupdate, route53 or clouddns.  If empty string is specified, no DNS will be added.
   assign_public_ip: "yes"
   inventory_ip: "public"                    # 'public' or 'private', (private in case we're operating in a private LAN).  If public, 'assign_public_ip' must be 'yes'
-  project_id: "{{gcp_credentials_json.project_id}}"
+  project_id: &project_id "{{gcp_credentials_json.project_id}}"
   ip_forward: "false"
   ssh_guard_whitelist: &ssh_guard_whitelist ['10.0.0.0/8']    # Put your public-facing IPs into this (if you're going to access it via public IP), to avoid rate-limiting.
   custom_tagslabels:
@@ -74,6 +74,7 @@ cluster_vars:
     hosttype_vars:
       sys: {vms_by_az: {b: 1, c: 1, d: 1}, flavor: f1-micro, rootvol_size: "10", version: "{{sys_version | default('')}}", auto_volumes: []}
       #sysdisks: {vms_by_az: {b: 1, c: 1, d: 1}, flavor: f1-micro, rootvol_size: "10", version: "{{sysdisks_version | default('')}}", auto_volumes: [{auto_delete: true, interface: "SCSI", volume_size: 2, mountpoint: "/var/log/mysvc", fstype: "ext4", perms: {owner: "root", group: "sudo", mode: "775"}}, {auto_delete: true, interface: "SCSI", volume_size: 2,  mountpoint: "/var/log/mysvc2", fstype: "ext4"}, {auto_delete: true, interface: "SCSI", volume_size: 3,  mountpoint: "/var/log/mysvc3", fstype: "ext4"}]}
+    vpc_network_project_id: *project_id        # Set this to *project_id if no separate network project
     vpc_network_name: "test-{{buildenv}}"
     vpc_subnet_name: ""
     preemptible: "no"

--- a/EXAMPLE/jenkinsfiles/Jenkinsfile_exec_release
+++ b/EXAMPLE/jenkinsfiles/Jenkinsfile_exec_release
@@ -50,6 +50,6 @@ pipeline {
     //       build job: "clusterverse-release-deploy", wait: false, parameters: [string(name: 'GENUINE_BUILD', value: "true"), string(name: 'DEPLOY_ENV', value: "sandbox"), string(name: 'RELEASE', value: "${VERSION_TO_DEPLOY}")]
     //     }
     //   }
-    // }        
+    // }
   }
 }

--- a/clean/tasks/clean_dns.yml
+++ b/clean/tasks/clean_dns.yml
@@ -97,7 +97,7 @@
           gcp_dns_managed_zone_info:
             auth_kind: serviceaccount
             dns_name: "{{dns_tld_external}}"
-            project: "{{cluster_vars.project_id}}"
+            project: "{{cluster_vars[buildenv].vpc_network_project_id}}"
             service_account_file: "{{gcp_credentials_file}}"
           register: r__gcp_dns_managed_zone_info
 
@@ -107,7 +107,7 @@
             managed_zone:
               name: "{{r__gcp_dns_managed_zone_info.resources.0.name}}"
               dnsName: "{{r__gcp_dns_managed_zone_info.resources.0.dnsName}}"
-            project: "{{cluster_vars.project_id}}"
+            project: "{{cluster_vars[buildenv].vpc_network_project_id}}"
             service_account_file: "{{gcp_credentials_file}}"
           register: r__gcp_dns_resource_record_set_info
 
@@ -118,7 +118,7 @@
               name: "{{r__gcp_dns_managed_zone_info.resources.0.name}}"
               dnsName: "{{r__gcp_dns_managed_zone_info.resources.0.dnsName}}"
             name: "{{ item.1.name }}"
-            project: "{{cluster_vars.project_id}}"
+            project: "{{cluster_vars[buildenv].vpc_network_project_id}}"
             service_account_file: "{{gcp_credentials_file}}"
             state: absent
             target: "{{ item.1.rrdatas }}"
@@ -135,7 +135,7 @@
               name: "{{r__gcp_dns_managed_zone_info.resources.0.name}}"
               dnsName: "{{r__gcp_dns_managed_zone_info.resources.0.dnsName}}"
             name: "{{ item.1.name }}"
-            project: "{{cluster_vars.project_id}}"
+            project: "{{cluster_vars[buildenv].vpc_network_project_id}}"
             service_account_file: "{{gcp_credentials_file}}"
             state: absent
             target: "{{ item.1.rrdatas[0] }}"

--- a/clean/tasks/clean_dns.yml
+++ b/clean/tasks/clean_dns.yml
@@ -102,7 +102,7 @@
           register: r__gcp_dns_managed_zone_info
 
         - block:
-            - assert: { that: "r__gcp_dns_managed_zone_info__non_peered | length <= 1", msg: "Multiple non-peered managed zones with the same DNS is not supported ({{cluster_suffixes_current | json_query(\"[].name\") }}) - abort" }
+            - assert: { that: "r__gcp_dns_managed_zone_info__non_peered | length <= 1", msg: "Multiple non-peered managed zones with the same DNS is not supported ({{r__gcp_dns_managed_zone_info__non_peered | json_query(\"[].name\") }}) - abort" }
 
             - name: clean/dns/clouddns | Get DNS entries
               gcp_dns_resource_record_set_info:

--- a/clean/tasks/clean_dns.yml
+++ b/clean/tasks/clean_dns.yml
@@ -101,48 +101,53 @@
             service_account_file: "{{gcp_credentials_file}}"
           register: r__gcp_dns_managed_zone_info
 
-        - name: clean/dns/clouddns | Get DNS entries
-          gcp_dns_resource_record_set_info:
-            auth_kind: serviceaccount
-            managed_zone:
-              name: "{{r__gcp_dns_managed_zone_info.resources.0.name}}"
-              dnsName: "{{r__gcp_dns_managed_zone_info.resources.0.dnsName}}"
-            project: "{{cluster_vars[buildenv].vpc_host_project_id}}"
-            service_account_file: "{{gcp_credentials_file}}"
-          register: r__gcp_dns_resource_record_set_info
+        - block:
+            - assert: { that: "r__gcp_dns_managed_zone_info__non_peered | length <= 1", msg: "Multiple non-peered managed zones with the same DNS is not supported ({{cluster_suffixes_current | json_query(\"[].name\") }}) - abort" }
 
-        - name: clean/dns/clouddns | Delete A records
-          gcp_dns_resource_record_set:
-            auth_kind: serviceaccount
-            managed_zone:
-              name: "{{r__gcp_dns_managed_zone_info.resources.0.name}}"
-              dnsName: "{{r__gcp_dns_managed_zone_info.resources.0.dnsName}}"
-            name: "{{ item.1.name }}"
-            project: "{{cluster_vars[buildenv].vpc_host_project_id}}"
-            service_account_file: "{{gcp_credentials_file}}"
-            state: absent
-            target: "{{ item.1.rrdatas }}"
-            type: A
-          with_nested:
-            - "{{ hosts_to_clean }}"
-            - "{{ r__gcp_dns_resource_record_set_info.resources | json_query(\"[?type=='A']\") }}"
-          when: item.0.name == (item.1.name | regex_replace('^(.*?)\\..*$', '\\1'))
+            - name: clean/dns/clouddns | Get DNS entries
+              gcp_dns_resource_record_set_info:
+                auth_kind: serviceaccount
+                managed_zone:
+                  name: "{{r__gcp_dns_managed_zone_info__non_peered.0.name}}"
+                  dnsName: "{{r__gcp_dns_managed_zone_info__non_peered.0.dnsName}}"
+                project: "{{cluster_vars[buildenv].vpc_host_project_id}}"
+                service_account_file: "{{gcp_credentials_file}}"
+              register: r__gcp_dns_resource_record_set_info
 
-        - name: clean/dns/clouddns | Delete CNAME records
-          gcp_dns_resource_record_set:
-            auth_kind: serviceaccount
-            managed_zone:
-              name: "{{r__gcp_dns_managed_zone_info.resources.0.name}}"
-              dnsName: "{{r__gcp_dns_managed_zone_info.resources.0.dnsName}}"
-            name: "{{ item.1.name }}"
-            project: "{{cluster_vars[buildenv].vpc_host_project_id}}"
-            service_account_file: "{{gcp_credentials_file}}"
-            state: absent
-            target: "{{ item.1.rrdatas[0] }}"
-            type: CNAME
-          with_nested:
-            - "{{ hosts_to_clean }}"
-            - "{{ r__gcp_dns_resource_record_set_info.resources | json_query(\"[?type=='CNAME']\") }}"
-          when: ((item.0.name |regex_replace('-(?!.*-).*')) == (item.1.name | regex_replace('^(.*?)\\..*$', '\\1')))  and  (item.0.name == item.1.rrdatas[0] | regex_replace('^(.*?)\\..*$', '\\1'))
+            - name: clean/dns/clouddns | Delete A records
+              gcp_dns_resource_record_set:
+                auth_kind: serviceaccount
+                managed_zone:
+                  name: "{{r__gcp_dns_managed_zone_info__non_peered.0.name}}"
+                  dnsName: "{{r__gcp_dns_managed_zone_info__non_peered.0.dnsName}}"
+                name: "{{ item.1.name }}"
+                project: "{{cluster_vars[buildenv].vpc_host_project_id}}"
+                service_account_file: "{{gcp_credentials_file}}"
+                state: absent
+                target: "{{ item.1.rrdatas }}"
+                type: A
+              with_nested:
+                - "{{ hosts_to_clean }}"
+                - "{{ r__gcp_dns_resource_record_set_info.resources | json_query(\"[?type=='A']\") }}"
+              when: item.0.name == (item.1.name | regex_replace('^(.*?)\\..*$', '\\1'))
+
+            - name: clean/dns/clouddns | Delete CNAME records
+              gcp_dns_resource_record_set:
+                auth_kind: serviceaccount
+                managed_zone:
+                  name: "{{r__gcp_dns_managed_zone_info__non_peered.0.name}}"
+                  dnsName: "{{r__gcp_dns_managed_zone_info__non_peered.0.dnsName}}"
+                name: "{{ item.1.name }}"
+                project: "{{cluster_vars[buildenv].vpc_host_project_id}}"
+                service_account_file: "{{gcp_credentials_file}}"
+                state: absent
+                target: "{{ item.1.rrdatas[0] }}"
+                type: CNAME
+              with_nested:
+                - "{{ hosts_to_clean }}"
+                - "{{ r__gcp_dns_resource_record_set_info.resources | json_query(\"[?type=='CNAME']\") }}"
+              when: ((item.0.name |regex_replace('-(?!.*-).*')) == (item.1.name | regex_replace('^(.*?)\\..*$', '\\1')))  and  (item.0.name == item.1.rrdatas[0] | regex_replace('^(.*?)\\..*$', '\\1'))
+          vars:
+            r__gcp_dns_managed_zone_info__non_peered: "{{r__gcp_dns_managed_zone_info.resources | json_query(\"[?dnsName==`\" + cluster_vars.dns_nameserver_zone + \"` && !(peeringConfig)]\") }}"
       when: cluster_vars.dns_server=="clouddns"
   when: hosts_to_clean | length

--- a/clean/tasks/clean_dns.yml
+++ b/clean/tasks/clean_dns.yml
@@ -97,7 +97,7 @@
           gcp_dns_managed_zone_info:
             auth_kind: serviceaccount
             dns_name: "{{dns_tld_external}}"
-            project: "{{cluster_vars[buildenv].vpc_network_project_id}}"
+            project: "{{cluster_vars[buildenv].vpc_host_project_id}}"
             service_account_file: "{{gcp_credentials_file}}"
           register: r__gcp_dns_managed_zone_info
 
@@ -107,7 +107,7 @@
             managed_zone:
               name: "{{r__gcp_dns_managed_zone_info.resources.0.name}}"
               dnsName: "{{r__gcp_dns_managed_zone_info.resources.0.dnsName}}"
-            project: "{{cluster_vars[buildenv].vpc_network_project_id}}"
+            project: "{{cluster_vars[buildenv].vpc_host_project_id}}"
             service_account_file: "{{gcp_credentials_file}}"
           register: r__gcp_dns_resource_record_set_info
 
@@ -118,7 +118,7 @@
               name: "{{r__gcp_dns_managed_zone_info.resources.0.name}}"
               dnsName: "{{r__gcp_dns_managed_zone_info.resources.0.dnsName}}"
             name: "{{ item.1.name }}"
-            project: "{{cluster_vars[buildenv].vpc_network_project_id}}"
+            project: "{{cluster_vars[buildenv].vpc_host_project_id}}"
             service_account_file: "{{gcp_credentials_file}}"
             state: absent
             target: "{{ item.1.rrdatas }}"
@@ -135,7 +135,7 @@
               name: "{{r__gcp_dns_managed_zone_info.resources.0.name}}"
               dnsName: "{{r__gcp_dns_managed_zone_info.resources.0.dnsName}}"
             name: "{{ item.1.name }}"
-            project: "{{cluster_vars[buildenv].vpc_network_project_id}}"
+            project: "{{cluster_vars[buildenv].vpc_host_project_id}}"
             service_account_file: "{{gcp_credentials_file}}"
             state: absent
             target: "{{ item.1.rrdatas[0] }}"

--- a/clean/tasks/clean_networking.yml
+++ b/clean/tasks/clean_networking.yml
@@ -17,7 +17,7 @@
         state: "absent"
         auth_kind: "serviceaccount"
         service_account_file: "{{gcp_credentials_file}}"
-        project: "{{cluster_vars[buildenv].vpc_network_project_id}}"
+        project: "{{cluster_vars[buildenv].vpc_host_project_id}}"
       with_items: "{{ cluster_vars.firewall_rules }}"
 
     - name: clean/networking/gcp | Delete the GCP network (if -e create_gcp_network=true)
@@ -25,7 +25,7 @@
         name: "{{cluster_vars[buildenv].vpc_network_name}}"
         auth_kind: "serviceaccount"
         service_account_file: "{{gcp_credentials_file}}"
-        project: "{{cluster_vars[buildenv].vpc_network_project_id}}"
+        project: "{{cluster_vars[buildenv].vpc_host_project_id}}"
         state: absent
       when: create_gcp_network is defined and create_gcp_network|bool
   when: cluster_vars.type == "gcp"

--- a/clean/tasks/clean_networking.yml
+++ b/clean/tasks/clean_networking.yml
@@ -17,7 +17,7 @@
         state: "absent"
         auth_kind: "serviceaccount"
         service_account_file: "{{gcp_credentials_file}}"
-        project: "{{cluster_vars.project_id}}"
+        project: "{{cluster_vars[buildenv].vpc_network_project}}"
       with_items: "{{ cluster_vars.firewall_rules }}"
 
     - name: clean/networking/gcp | Delete the GCP network (if -e create_gcp_network=true)

--- a/clean/tasks/clean_networking.yml
+++ b/clean/tasks/clean_networking.yml
@@ -17,7 +17,7 @@
         state: "absent"
         auth_kind: "serviceaccount"
         service_account_file: "{{gcp_credentials_file}}"
-        project: "{{cluster_vars[buildenv].vpc_network_project}}"
+        project: "{{cluster_vars[buildenv].vpc_network_project_id}}"
       with_items: "{{ cluster_vars.firewall_rules }}"
 
     - name: clean/networking/gcp | Delete the GCP network (if -e create_gcp_network=true)
@@ -25,7 +25,7 @@
         name: "{{cluster_vars[buildenv].vpc_network_name}}"
         auth_kind: "serviceaccount"
         service_account_file: "{{gcp_credentials_file}}"
-        project: "{{cluster_vars.project_id}}"
+        project: "{{cluster_vars[buildenv].vpc_network_project_id}}"
         state: absent
       when: create_gcp_network is defined and create_gcp_network|bool
   when: cluster_vars.type == "gcp"

--- a/clean/tasks/clean_vms.yml
+++ b/clean/tasks/clean_vms.yml
@@ -34,7 +34,7 @@
 #        - name: clean/del_vms/gcp | Remove deletion protection (broken until https://github.com/ansible-collections/ansible_collections_google/pull/163 gets into a release)
 #          gcp_compute_instance:
 #            name: "{{item.name}}"
-#            project: "{{cluster_vars.project_id}}"
+#            project: "{{cluster_vars[buildenv].vpc_project_id}}"
 #            zone: "{{ item.regionzone }}"
 #            auth_kind: "serviceaccount"
 #            service_account_file: "{{gcp_credentials_file}}"
@@ -44,7 +44,7 @@
         - name: clean/del_vms/gcp | Delete GCE VM
           gcp_compute_instance:
             name: "{{item.name}}"
-            project: "{{cluster_vars.project_id}}"
+            project: "{{cluster_vars[buildenv].vpc_project_id}}"
             zone: "{{ item.regionzone }}"
             auth_kind: "serviceaccount"
             service_account_file: "{{gcp_credentials_file}}"

--- a/cluster_hosts/tasks/get_cluster_hosts_state.yml
+++ b/cluster_hosts/tasks/get_cluster_hosts_state.yml
@@ -26,7 +26,7 @@
         zone: "{{cluster_vars.region}}-{{item}}"
         filters:
           - "labels.cluster_name = {{cluster_name}}"
-        project: "{{cluster_vars.project_id}}"
+        project: "{{cluster_vars[buildenv].vpc_project_id}}"
         auth_kind: "serviceaccount"
         service_account_file: "{{gcp_credentials_file}}"
         scopes: ["https://www.googleapis.com/auth/compute.readonly"]

--- a/config/tasks/create_dns_a.yml
+++ b/config/tasks/create_dns_a.yml
@@ -37,7 +37,7 @@
   poll: 0
   register: route53_records
 
-- name: config/dns/a/route53 | Wait for records to bereplicated to all Amazon Route 53 DNS servers
+- name: config/dns/a/route53 | Wait for records to be replicated to all Amazon Route 53 DNS servers
   async_status:
     jid: "{{ item.ansible_job_id }}"
   register: route53_jobs
@@ -47,6 +47,7 @@
   run_once: true
   with_items: "{{route53_records.results}}"
   delegate_to: localhost
+  when: cluster_vars.dns_server=="route53"
 
 - name: config/dns/a/clouddns | create/update A records in GCP (clouddns)
   block:
@@ -79,7 +80,7 @@
       run_once: true
       with_nested:
         - "{{ cluster_hosts_target }}"
-        - "{{ r__gcp_dns_managed_zone_info.resources | json_query(\"[?dnsName==`\" + dns_tld_external + \"` && !(peeringConfig)]\") }}"
+        - "{{ r__gcp_dns_managed_zone_info.resources | json_query(\"[?dnsName==`\" + cluster_vars.dns_nameserver_zone + \"` && !(peeringConfig)]\") }}"
   when: cluster_vars.dns_server=="clouddns"
 
 - block:

--- a/config/tasks/create_dns_a.yml
+++ b/config/tasks/create_dns_a.yml
@@ -39,7 +39,7 @@
       gcp_dns_managed_zone_info:
         auth_kind: serviceaccount
         dns_name: "{{dns_tld_external}}"
-        project: "{{cluster_vars[buildenv].vpc_network_project_id}}"
+        project: "{{cluster_vars[buildenv].vpc_host_project_id}}"
         service_account_file: "{{gcp_credentials_file}}"
       register: r__gcp_dns_managed_zone_info
       become: false
@@ -53,7 +53,7 @@
           name: "{{item.1.name}}"
           dnsName: "{{item.1.dnsName}}"
         name: "{{item.0.hostname}}.{{cluster_vars.dns_zone_external}}"
-        project: "{{cluster_vars[buildenv].vpc_network_project_id}}"
+        project: "{{cluster_vars[buildenv].vpc_host_project_id}}"
         service_account_file: "{{gcp_credentials_file}}"
         state: present
         target: "{%- if item.1.visibility == 'private' -%} {{ hostvars[item.0.hostname]['ansible_default_ipv4']['address'] }} {%- else -%} {{ hostvars[item.0.hostname]['ansible_host'] }} {%- endif -%}"

--- a/config/tasks/create_dns_a.yml
+++ b/config/tasks/create_dns_a.yml
@@ -38,31 +38,33 @@
     - name: config/dns/a/clouddns | Gather info for a pre-existing GCP Managed Zone and store as dict
       gcp_dns_managed_zone_info:
         auth_kind: serviceaccount
-        dns_name: "{{cluster_vars.dns_zone_external}}"
-        project: "{{cluster_vars[buildenv].vpc_network_project}}"
+        dns_name: "{{dns_tld_external}}"
+        project: "{{cluster_vars[buildenv].vpc_network_project_id}}"
         service_account_file: "{{gcp_credentials_file}}"
       register: r__gcp_dns_managed_zone_info
       become: false
       delegate_to: localhost
       run_once: true
 
-    - name: config/dns/a/clouddns | create/update A records in GCP (clouddns)
+    - name: config/dns/a/clouddns | create/update A records for all matching zones, (could be multiple, e.g. public/ private) in GCP (clouddns)
       gcp_dns_resource_record_set:
         auth_kind: serviceaccount
         managed_zone:
-          name: "{{r__gcp_dns_managed_zone_info.resources.1.name}}"
-          dnsName: "{{r__gcp_dns_managed_zone_info.resources.1.dnsName}}"
-        name: "{{item.hostname}}.{{cluster_vars.dns_zone_external}}"
-        project: "{{cluster_vars[buildenv].vpc_network_project}}"
+          name: "{{item.1.name}}"
+          dnsName: "{{item.1.dnsName}}"
+        name: "{{item.0.hostname}}.{{cluster_vars.dns_zone_external}}"
+        project: "{{cluster_vars[buildenv].vpc_network_project_id}}"
         service_account_file: "{{gcp_credentials_file}}"
         state: present
-        target: "{%- if r__gcp_dns_managed_zone_info.resources.1.visibility == 'private' -%} {{ hostvars[item.hostname]['ansible_default_ipv4']['address'] }} {%- else -%} {{ hostvars[item.hostname]['ansible_host'] }} {%- endif -%}"
+        target: "{%- if item.1.visibility == 'private' -%} {{ hostvars[item.0.hostname]['ansible_default_ipv4']['address'] }} {%- else -%} {{ hostvars[item.0.hostname]['ansible_host'] }} {%- endif -%}"
         type: A
         ttl: 60
       become: false
       delegate_to: localhost
       run_once: true
-      with_items: "{{ cluster_hosts_target }}"
+      with_nested:
+        - "{{ cluster_hosts_target }}"
+        - "{{ r__gcp_dns_managed_zone_info.resources | json_query(\"[?dnsName==`\" + dns_tld_external + \"`]\") }}"
   when: cluster_vars.dns_server=="clouddns"
 
 - block:

--- a/config/tasks/create_dns_a.yml
+++ b/config/tasks/create_dns_a.yml
@@ -38,8 +38,8 @@
     - name: config/dns/a/clouddns | Gather info for a pre-existing GCP Managed Zone and store as dict
       gcp_dns_managed_zone_info:
         auth_kind: serviceaccount
-        dns_name: "{{dns_tld_external}}"
-        project: "{{cluster_vars.project_id}}"
+        dns_name: "{{cluster_vars.dns_zone_external}}"
+        project: "{{cluster_vars[buildenv].vpc_network_project}}"
         service_account_file: "{{gcp_credentials_file}}"
       register: r__gcp_dns_managed_zone_info
       become: false
@@ -50,13 +50,13 @@
       gcp_dns_resource_record_set:
         auth_kind: serviceaccount
         managed_zone:
-          name: "{{r__gcp_dns_managed_zone_info.resources.0.name}}"
-          dnsName: "{{r__gcp_dns_managed_zone_info.resources.0.dnsName}}"
+          name: "{{r__gcp_dns_managed_zone_info.resources.1.name}}"
+          dnsName: "{{r__gcp_dns_managed_zone_info.resources.1.dnsName}}"
         name: "{{item.hostname}}.{{cluster_vars.dns_zone_external}}"
-        project: "{{cluster_vars.project_id}}"
+        project: "{{cluster_vars[buildenv].vpc_network_project}}"
         service_account_file: "{{gcp_credentials_file}}"
         state: present
-        target: "{%- if r__gcp_dns_managed_zone_info.resources.0.visibility == 'private' -%} {{ hostvars[item.hostname]['ansible_default_ipv4']['address'] }} {%- else -%} {{ hostvars[item.hostname]['ansible_host'] }} {%- endif -%}"
+        target: "{%- if r__gcp_dns_managed_zone_info.resources.1.visibility == 'private' -%} {{ hostvars[item.hostname]['ansible_default_ipv4']['address'] }} {%- else -%} {{ hostvars[item.hostname]['ansible_host'] }} {%- endif -%}"
         type: A
         ttl: 60
       become: false

--- a/config/tasks/create_dns_a.yml
+++ b/config/tasks/create_dns_a.yml
@@ -64,7 +64,7 @@
       run_once: true
       with_nested:
         - "{{ cluster_hosts_target }}"
-        - "{{ r__gcp_dns_managed_zone_info.resources | json_query(\"[?dnsName==`\" + dns_tld_external + \"`]\") }}"
+        - "{{ r__gcp_dns_managed_zone_info.resources | json_query(\"[?dnsName==`\" + dns_tld_external + \"` && !(peeringConfig)]\") }}"
   when: cluster_vars.dns_server=="clouddns"
 
 - block:

--- a/create/tasks/gcp.yml
+++ b/create/tasks/gcp.yml
@@ -6,7 +6,7 @@
       gcp_compute_network:
         name: "{{cluster_vars[buildenv].vpc_network_name}}"
         auto_create_subnetworks: "{%- if cluster_vars[buildenv].vpc_subnet_name is defined and cluster_vars[buildenv].vpc_subnet_name != '' -%} false {%- else -%} true {%- endif -%}"
-        project: "{{cluster_vars.project_id}}"
+        project: "{{cluster_vars[buildenv].vpc_network_project_id}}"
         auth_kind: "serviceaccount"
         service_account_file: "{{gcp_credentials_file}}"
       register: r__gcp_compute_network
@@ -15,7 +15,7 @@
       gcp_compute_subnetwork:
         name: "{{cluster_vars[buildenv].vpc_subnet_name}}"
         network: "{{r__gcp_compute_network}}"
-        project: "{{cluster_vars.project_id}}"
+        project: "{{cluster_vars[buildenv].vpc_network_project_id}}"
         auth_kind: "serviceaccount"
         service_account_file: "{{gcp_credentials_file}}"
       when: (cluster_vars[buildenv].vpc_subnet_name is defined) and (cluster_vars[buildenv].vpc_subnet_name != "")
@@ -24,35 +24,35 @@
 
 - name: create/gcp | Create GCP firewalls
   block:
-    # - name: create/gcp | Get GCP network facts
-    #   gcp_compute_network_info:
-    #     filters:
-    #       - "name = {{cluster_vars[buildenv].vpc_network_name}}"
-    #     project: "{{cluster_vars.project_id}}"
-    #     auth_kind: "serviceaccount"
-    #     service_account_file: "{{gcp_credentials_file}}"
-    #     scopes: ["https://www.googleapis.com/auth/compute.readonly"]
-    #   register: r__gcp_compute_network_info
+    - name: create/gcp | Get GCP network facts
+      gcp_compute_network_info:
+        filters:
+          - "name = {{cluster_vars[buildenv].vpc_network_name}}"
+        project: "{{cluster_vars[buildenv].vpc_network_project_id}}"
+        auth_kind: "serviceaccount"
+        service_account_file: "{{gcp_credentials_file}}"
+        scopes: ["https://www.googleapis.com/auth/compute.readonly"]
+      register: r__gcp_compute_network_info
 
-    # - name: "Assert that {{cluster_vars[buildenv].vpc_network_name}} network exists"
-    #   assert: { that: "r__gcp_compute_network_info['resources'] | length > 0", msg: "The {{cluster_vars[buildenv].vpc_network_name}} network must exist (create with ' -e create_gce_network=true')" }
+    - name: "Assert that {{cluster_vars[buildenv].vpc_network_name}} network exists"
+      assert: { that: "r__gcp_compute_network_info['resources'] | length > 0", msg: "The {{cluster_vars[buildenv].vpc_network_name}} network must exist (create with ' -e create_gcp_network=true')" }
 
-    # - name: create/gcp | Get GCP subnetwork facts
-    #   gcp_compute_subnetwork_info:
-    #     filters:
-    #       - "name = {{cluster_vars[buildenv].vpc_subnet_name}}"
-    #     project: "{{cluster_vars.project_id}}"
-    #     auth_kind: "serviceaccount"
-    #     service_account_file: "{{gcp_credentials_file}}"
-    #     scopes: ["https://www.googleapis.com/auth/compute.readonly"]
-    #     region: "{{cluster_vars.region}}"
-    #   register: gcp_compute_subnetwork_info
-    #   when: (cluster_vars[buildenv].vpc_subnet_name is defined) and (cluster_vars[buildenv].vpc_subnet_name != "")
+    - name: create/gcp | Get GCP subnetwork facts
+      gcp_compute_subnetwork_info:
+        filters:
+          - "name = {{cluster_vars[buildenv].vpc_subnet_name}}"
+        project: "{{cluster_vars[buildenv].vpc_network_project_id}}"
+        auth_kind: "serviceaccount"
+        service_account_file: "{{gcp_credentials_file}}"
+        scopes: ["https://www.googleapis.com/auth/compute.readonly"]
+        region: "{{cluster_vars.region}}"
+      register: r__gcp_compute_subnetwork_info
+      when: (cluster_vars[buildenv].vpc_subnet_name is defined) and (cluster_vars[buildenv].vpc_subnet_name != "")
 
-    # - name: "Assert that {{cluster_vars[buildenv].vpc_subnet_name}} subnet exists"
-    #   assert: { that: "gcp_compute_subnetwork_info['resources'] | length > 0", msg: "The {{cluster_vars[buildenv].vpc_subnet_name}} subnet must exist" }
-    #   when: (cluster_vars[buildenv].vpc_subnet_name is defined) and (cluster_vars[buildenv].vpc_subnet_name != "")
-    
+    - name: "Assert that {{cluster_vars[buildenv].vpc_subnet_name}} subnet exists"
+      assert: { that: "r__gcp_compute_subnetwork_info['resources'] | length > 0", msg: "The {{cluster_vars[buildenv].vpc_subnet_name}} subnet must exist" }
+      when: (cluster_vars[buildenv].vpc_subnet_name is defined) and (cluster_vars[buildenv].vpc_subnet_name != "")
+
     - name: create/gcp | Create GCP cluster firewalls
       gcp_compute_firewall:
         name: "{{ item.name }}"
@@ -61,12 +61,12 @@
         description: "{{ item.description }}"
         source_ranges: "{{ item.source_ranges | default([]) }}"
         source_tags: "{{ item.source_tags | default([]) }}"
-        network: 
-          selfLink: "{{cluster_vars[buildenv].vpc_network_dict}}"
+        network: "{{r__gcp_compute_network_info['resources'][0]}}"
         auth_kind: "serviceaccount"
         service_account_file: "{{gcp_credentials_file}}"
-        project: "{{cluster_vars[buildenv].vpc_network_project}}"
+        project: "{{cluster_vars[buildenv].vpc_network_project_id}}"
       with_items: "{{ cluster_vars.firewall_rules }}"
+
 
 - name: create/gcp | Generate GCE ssh public key from the private key provided on the command line
   shell: ssh-keygen -y -f "{{ ansible_ssh_private_key_file }}"
@@ -88,17 +88,12 @@
           ssh-keys: "{{ cliargs.remote_user }}:{{ r__gcp_ssh_pubkey.stdout }}"
           # ssh-keys: "{{ cliargs.remote_user }}:{{ r__gcp_ssh_pubkey.stdout }} {{ cliargs.remote_user }}"
         labels: "{{ _labels | combine(cluster_vars.custom_tagslabels | default({})) }}"
-        # network_interfaces:
-        #   - network: "{{ r__gcp_compute_network_info['resources'][0] | default({}) }}"
-        #     subnetwork: "{{ gcp_compute_subnetwork_info['resources'][0] | default({}) }}"
         network_interfaces:
-          - network: 
-              selfLink: "https://www.googleapis.com/compute/v1/projects/{{cluster_vars[buildenv].vpc_network_project}}/global/networks/{{cluster_vars[buildenv].vpc_network_name}}"
-            subnetwork: 
-              selfLink: "https://www.googleapis.com/compute/v1/projects/{{cluster_vars[buildenv].vpc_network_project}}/regions/{{_region}}/subnetworks/{{cluster_vars[buildenv].vpc_subnet_name}}"
+          - network: "{{ r__gcp_compute_network_info['resources'][0] | default({}) }}"
+            subnetwork: "{{ r__gcp_compute_subnetwork_info['resources'][0] | default({}) }}"
             access_configs: "{%- if cluster_vars.assign_public_ip == 'yes' -%}[{\"name\": \"External NAT\", \"type\": \"ONE_TO_ONE_NAT\"}]{%- else -%}[]{%- endif -%}"
         tags: { items: "{{cluster_vars.network_fw_tags}}" }
-        can_ip_forward : "{{cluster_vars.ip_forward}}"
+        can_ip_forward: "{{cluster_vars.ip_forward}}"
         scheduling: { automatic_restart: yes, preemptible: "{{cluster_vars[buildenv].preemptible}}" }
         state: present
         deletion_protection: "{{cluster_vars[buildenv].deletion_protection}}"

--- a/create/tasks/gcp.yml
+++ b/create/tasks/gcp.yml
@@ -6,7 +6,7 @@
       gcp_compute_network:
         name: "{{cluster_vars[buildenv].vpc_network_name}}"
         auto_create_subnetworks: "{%- if cluster_vars[buildenv].vpc_subnet_name is defined and cluster_vars[buildenv].vpc_subnet_name != '' -%} false {%- else -%} true {%- endif -%}"
-        project: "{{cluster_vars[buildenv].vpc_network_project_id}}"
+        project: "{{cluster_vars[buildenv].vpc_host_project_id}}"
         auth_kind: "serviceaccount"
         service_account_file: "{{gcp_credentials_file}}"
       register: r__gcp_compute_network
@@ -15,7 +15,7 @@
       gcp_compute_subnetwork:
         name: "{{cluster_vars[buildenv].vpc_subnet_name}}"
         network: "{{r__gcp_compute_network}}"
-        project: "{{cluster_vars[buildenv].vpc_network_project_id}}"
+        project: "{{cluster_vars[buildenv].vpc_host_project_id}}"
         auth_kind: "serviceaccount"
         service_account_file: "{{gcp_credentials_file}}"
       when: (cluster_vars[buildenv].vpc_subnet_name is defined) and (cluster_vars[buildenv].vpc_subnet_name != "")
@@ -28,7 +28,7 @@
       gcp_compute_network_info:
         filters:
           - "name = {{cluster_vars[buildenv].vpc_network_name}}"
-        project: "{{cluster_vars[buildenv].vpc_network_project_id}}"
+        project: "{{cluster_vars[buildenv].vpc_host_project_id}}"
         auth_kind: "serviceaccount"
         service_account_file: "{{gcp_credentials_file}}"
         scopes: ["https://www.googleapis.com/auth/compute.readonly"]
@@ -41,7 +41,7 @@
       gcp_compute_subnetwork_info:
         filters:
           - "name = {{cluster_vars[buildenv].vpc_subnet_name}}"
-        project: "{{cluster_vars[buildenv].vpc_network_project_id}}"
+        project: "{{cluster_vars[buildenv].vpc_host_project_id}}"
         auth_kind: "serviceaccount"
         service_account_file: "{{gcp_credentials_file}}"
         scopes: ["https://www.googleapis.com/auth/compute.readonly"]
@@ -64,7 +64,7 @@
         network: "{{r__gcp_compute_network_info['resources'][0]}}"
         auth_kind: "serviceaccount"
         service_account_file: "{{gcp_credentials_file}}"
-        project: "{{cluster_vars[buildenv].vpc_network_project_id}}"
+        project: "{{cluster_vars[buildenv].vpc_host_project_id}}"
       with_items: "{{ cluster_vars.firewall_rules }}"
 
 
@@ -78,7 +78,7 @@
       gcp_compute_instance:
         auth_kind: "serviceaccount"
         service_account_file: "{{gcp_credentials_file}}"
-        project: "{{cluster_vars.project_id}}"
+        project: "{{cluster_vars[buildenv].vpc_project_id}}"
         zone: "{{cluster_vars.region}}-{{item.az_name}}"
         name: "{{item.hostname}}"
         machine_type: "{{item.flavor}}"

--- a/create/tasks/gcp.yml
+++ b/create/tasks/gcp.yml
@@ -24,35 +24,35 @@
 
 - name: create/gcp | Create GCP firewalls
   block:
-    - name: create/gcp | Get GCP network facts
-      gcp_compute_network_info:
-        filters:
-          - "name = {{cluster_vars[buildenv].vpc_network_name}}"
-        project: "{{cluster_vars.project_id}}"
-        auth_kind: "serviceaccount"
-        service_account_file: "{{gcp_credentials_file}}"
-        scopes: ["https://www.googleapis.com/auth/compute.readonly"]
-      register: r__gcp_compute_network_info
+    # - name: create/gcp | Get GCP network facts
+    #   gcp_compute_network_info:
+    #     filters:
+    #       - "name = {{cluster_vars[buildenv].vpc_network_name}}"
+    #     project: "{{cluster_vars.project_id}}"
+    #     auth_kind: "serviceaccount"
+    #     service_account_file: "{{gcp_credentials_file}}"
+    #     scopes: ["https://www.googleapis.com/auth/compute.readonly"]
+    #   register: r__gcp_compute_network_info
 
-    - name: "Assert that {{cluster_vars[buildenv].vpc_network_name}} network exists"
-      assert: { that: "r__gcp_compute_network_info['resources'] | length > 0", msg: "The {{cluster_vars[buildenv].vpc_network_name}} network must exist (create with ' -e create_gcp_network=true')" }
+    # - name: "Assert that {{cluster_vars[buildenv].vpc_network_name}} network exists"
+    #   assert: { that: "r__gcp_compute_network_info['resources'] | length > 0", msg: "The {{cluster_vars[buildenv].vpc_network_name}} network must exist (create with ' -e create_gce_network=true')" }
 
-    - name: create/gcp | Get GCP subnetwork facts
-      gcp_compute_subnetwork_info:
-        filters:
-          - "name = {{cluster_vars[buildenv].vpc_subnet_name}}"
-        project: "{{cluster_vars.project_id}}"
-        auth_kind: "serviceaccount"
-        service_account_file: "{{gcp_credentials_file}}"
-        scopes: ["https://www.googleapis.com/auth/compute.readonly"]
-        region: "{{cluster_vars.region}}"
-      register: gcp_compute_subnetwork_info
-      when: (cluster_vars[buildenv].vpc_subnet_name is defined) and (cluster_vars[buildenv].vpc_subnet_name != "")
+    # - name: create/gcp | Get GCP subnetwork facts
+    #   gcp_compute_subnetwork_info:
+    #     filters:
+    #       - "name = {{cluster_vars[buildenv].vpc_subnet_name}}"
+    #     project: "{{cluster_vars.project_id}}"
+    #     auth_kind: "serviceaccount"
+    #     service_account_file: "{{gcp_credentials_file}}"
+    #     scopes: ["https://www.googleapis.com/auth/compute.readonly"]
+    #     region: "{{cluster_vars.region}}"
+    #   register: gcp_compute_subnetwork_info
+    #   when: (cluster_vars[buildenv].vpc_subnet_name is defined) and (cluster_vars[buildenv].vpc_subnet_name != "")
 
-    - name: "Assert that {{cluster_vars[buildenv].vpc_subnet_name}} subnet exists"
-      assert: { that: "gcp_compute_subnetwork_info['resources'] | length > 0", msg: "The {{cluster_vars[buildenv].vpc_subnet_name}} subnet must exist" }
-      when: (cluster_vars[buildenv].vpc_subnet_name is defined) and (cluster_vars[buildenv].vpc_subnet_name != "")
-
+    # - name: "Assert that {{cluster_vars[buildenv].vpc_subnet_name}} subnet exists"
+    #   assert: { that: "gcp_compute_subnetwork_info['resources'] | length > 0", msg: "The {{cluster_vars[buildenv].vpc_subnet_name}} subnet must exist" }
+    #   when: (cluster_vars[buildenv].vpc_subnet_name is defined) and (cluster_vars[buildenv].vpc_subnet_name != "")
+    
     - name: create/gcp | Create GCP cluster firewalls
       gcp_compute_firewall:
         name: "{{ item.name }}"
@@ -61,10 +61,11 @@
         description: "{{ item.description }}"
         source_ranges: "{{ item.source_ranges | default([]) }}"
         source_tags: "{{ item.source_tags | default([]) }}"
-        network: "{{r__gcp_compute_network_info['resources'][0]}}"
+        network: 
+          selfLink: "{{cluster_vars[buildenv].vpc_network_dict}}"
         auth_kind: "serviceaccount"
         service_account_file: "{{gcp_credentials_file}}"
-        project: "{{cluster_vars.project_id}}"
+        project: "{{cluster_vars[buildenv].vpc_network_project}}"
       with_items: "{{ cluster_vars.firewall_rules }}"
 
 - name: create/gcp | Generate GCE ssh public key from the private key provided on the command line
@@ -84,11 +85,17 @@
         disks: "{{_host_disks}}"
         metadata:
           startup-script: "{%- if cluster_vars.ssh_guard_whitelist is defined and cluster_vars.ssh_guard_whitelist | length > 0 -%}#! /bin/bash\n\n#Whitelist my inbound IPs\n[ -f /etc/sshguard/whitelist ] && echo \"{{cluster_vars.ssh_guard_whitelist | join ('\n')}}\" >>/etc/sshguard/whitelist && /bin/systemctl restart sshguard{%- endif -%}"
-          ssh-keys: "{{ cliargs.remote_user }}:{{ r__gcp_ssh_pubkey.stdout }} {{ cliargs.remote_user }}"
+          ssh-keys: "{{ cliargs.remote_user }}:{{ r__gcp_ssh_pubkey.stdout }}"
+          # ssh-keys: "{{ cliargs.remote_user }}:{{ r__gcp_ssh_pubkey.stdout }} {{ cliargs.remote_user }}"
         labels: "{{ _labels | combine(cluster_vars.custom_tagslabels | default({})) }}"
+        # network_interfaces:
+        #   - network: "{{ r__gcp_compute_network_info['resources'][0] | default({}) }}"
+        #     subnetwork: "{{ gcp_compute_subnetwork_info['resources'][0] | default({}) }}"
         network_interfaces:
-          - network: "{{ r__gcp_compute_network_info['resources'][0] | default({}) }}"
-            subnetwork: "{{ gcp_compute_subnetwork_info['resources'][0] | default({}) }}"
+          - network: 
+              selfLink: "https://www.googleapis.com/compute/v1/projects/{{cluster_vars[buildenv].vpc_network_project}}/global/networks/{{cluster_vars[buildenv].vpc_network_name}}"
+            subnetwork: 
+              selfLink: "https://www.googleapis.com/compute/v1/projects/{{cluster_vars[buildenv].vpc_network_project}}/regions/{{_region}}/subnetworks/{{cluster_vars[buildenv].vpc_subnet_name}}"
             access_configs: "{%- if cluster_vars.assign_public_ip == 'yes' -%}[{\"name\": \"External NAT\", \"type\": \"ONE_TO_ONE_NAT\"}]{%- else -%}[]{%- endif -%}"
         tags: { items: "{{cluster_vars.network_fw_tags}}" }
         can_ip_forward : "{{cluster_vars.ip_forward}}"

--- a/dynamic_inventory/tasks/gcp.yml
+++ b/dynamic_inventory/tasks/gcp.yml
@@ -7,7 +7,7 @@
     filters:
       - "name = {{cluster_name}}*"
       - "status = RUNNING"            # gcloud compute instances list --filter="status=RUNNING"
-    project: "{{cluster_vars.project_id}}"
+    project: "{{cluster_vars[buildenv].vpc_project_id}}"
     auth_kind: "serviceaccount"
     service_account_file: "{{gcp_credentials_file}}"
     scopes: ["https://www.googleapis.com/auth/compute.readonly"]

--- a/readiness/tasks/config_dns_cname.yml
+++ b/readiness/tasks/config_dns_cname.yml
@@ -40,7 +40,7 @@
       gcp_dns_managed_zone_info:
         auth_kind: serviceaccount
         dns_name: "{{dns_tld_external}}"
-        project: "{{cluster_vars.project_id}}"
+        project: "{{cluster_vars[buildenv].vpc_network_project_id}}"
         service_account_file: "{{gcp_credentials_file}}"
       register: gcp_dns_managed_zone_info
       become: false
@@ -54,7 +54,7 @@
           name: "{{gcp_dns_managed_zone_info.resources.0.name}}"
           dnsName: "{{gcp_dns_managed_zone_info.resources.0.dnsName}}"
         name: "{{item.hostname | regex_replace('-(?!.*-).*')}}.{{cluster_vars.dns_zone_external}}"
-        project: "{{cluster_vars.project_id}}"
+        project: "{{cluster_vars[buildenv].vpc_network_project_id}}"
         service_account_file: "{{gcp_credentials_file}}"
         state: present
         target: "{{item.hostname}}.{{cluster_vars.dns_zone_external}}"

--- a/readiness/tasks/config_dns_cname.yml
+++ b/readiness/tasks/config_dns_cname.yml
@@ -40,7 +40,7 @@
       gcp_dns_managed_zone_info:
         auth_kind: serviceaccount
         dns_name: "{{dns_tld_external}}"
-        project: "{{cluster_vars[buildenv].vpc_network_project_id}}"
+        project: "{{cluster_vars[buildenv].vpc_host_project_id}}"
         service_account_file: "{{gcp_credentials_file}}"
       register: gcp_dns_managed_zone_info
       become: false
@@ -54,7 +54,7 @@
           name: "{{gcp_dns_managed_zone_info.resources.0.name}}"
           dnsName: "{{gcp_dns_managed_zone_info.resources.0.dnsName}}"
         name: "{{item.hostname | regex_replace('-(?!.*-).*')}}.{{cluster_vars.dns_zone_external}}"
-        project: "{{cluster_vars[buildenv].vpc_network_project_id}}"
+        project: "{{cluster_vars[buildenv].vpc_host_project_id}}"
         service_account_file: "{{gcp_credentials_file}}"
         state: present
         target: "{{item.hostname}}.{{cluster_vars.dns_zone_external}}"

--- a/readiness/tasks/config_dns_cname.yml
+++ b/readiness/tasks/config_dns_cname.yml
@@ -62,7 +62,7 @@
         ttl: 60
       with_nested:
         - "{{ cluster_hosts_target }}"
-        - "{{ r__gcp_dns_managed_zone_info.resources | json_query(\"[?dnsName==`\" + dns_tld_external + \"` && !(peeringConfig)]\") }}"
+        - "{{ r__gcp_dns_managed_zone_info.resources | json_query(\"[?dnsName==`\" + cluster_vars.dns_nameserver_zone + \"` && !(peeringConfig)]\") }}"
       become: false
       delegate_to: localhost
       run_once: true

--- a/readiness/tasks/config_dns_cname.yml
+++ b/readiness/tasks/config_dns_cname.yml
@@ -42,7 +42,7 @@
         dns_name: "{{dns_tld_external}}"
         project: "{{cluster_vars[buildenv].vpc_host_project_id}}"
         service_account_file: "{{gcp_credentials_file}}"
-      register: gcp_dns_managed_zone_info
+      register: r__gcp_dns_managed_zone_info
       become: false
       delegate_to: localhost
       run_once: true
@@ -51,16 +51,18 @@
       gcp_dns_resource_record_set:
         auth_kind: serviceaccount
         managed_zone:
-          name: "{{gcp_dns_managed_zone_info.resources.0.name}}"
-          dnsName: "{{gcp_dns_managed_zone_info.resources.0.dnsName}}"
-        name: "{{item.hostname | regex_replace('-(?!.*-).*')}}.{{cluster_vars.dns_zone_external}}"
+          name: "{{item.1.name}}"
+          dnsName: "{{item.1.dnsName}}"
+        name: "{{item.0.hostname | regex_replace('-(?!.*-).*')}}.{{cluster_vars.dns_zone_external}}"
         project: "{{cluster_vars[buildenv].vpc_host_project_id}}"
         service_account_file: "{{gcp_credentials_file}}"
         state: present
-        target: "{{item.hostname}}.{{cluster_vars.dns_zone_external}}"
+        target: "{{item.0.hostname}}.{{cluster_vars.dns_zone_external}}"
         type: CNAME
         ttl: 60
-      with_items: "{{ cluster_hosts_target }}"
+      with_nested:
+        - "{{ cluster_hosts_target }}"
+        - "{{ r__gcp_dns_managed_zone_info.resources | json_query(\"[?dnsName==`\" + dns_tld_external + \"` && !(peeringConfig)]\") }}"
       become: false
       delegate_to: localhost
       run_once: true

--- a/readiness/tasks/remove_maintenance_mode.yml
+++ b/readiness/tasks/remove_maintenance_mode.yml
@@ -32,7 +32,7 @@
         zone: "{{cluster_vars.region}}-{{item}}"
         filters:
           - "labels.cluster_name = {{cluster_name}}"
-        project: "{{cluster_vars.project_id}}"
+        project: "{{cluster_vars[buildenv].vpc_project_id}}"
         auth_kind: "serviceaccount"
         service_account_file: "{{gcp_credentials_file}}"
         scopes: ["https://www.googleapis.com/auth/compute.readonly"]
@@ -45,7 +45,7 @@
     - name: remove_maintenance_mode/gcp | Set maintenance_mode to false
       gcp_compute_instance:
         name: "{{item.name}}"
-        project: "{{cluster_vars.project_id}}"
+        project: "{{cluster_vars[buildenv].vpc_project_id}}"
         zone: "{{ item.zone | regex_replace('^.*/(.*)$', '\\1') }}"
         auth_kind: "serviceaccount"
         service_account_file: "{{gcp_credentials_file}}"

--- a/redeploy/__common/tasks/poweroff_vms.yml
+++ b/redeploy/__common/tasks/poweroff_vms.yml
@@ -34,7 +34,7 @@
         - name: poweroff_vms | Power-off GCP GCE VM(s) and set maintenance_mode=true
           gcp_compute_instance:
             name: "{{item.name}}"
-            project: "{{cluster_vars.project_id}}"
+            project: "{{cluster_vars[buildenv].vpc_project_id}}"
             zone: "{{ item.regionzone }}"
             auth_kind: "serviceaccount"
             service_account_file: "{{gcp_credentials_file}}"

--- a/redeploy/__common/tasks/poweron_vms.yml
+++ b/redeploy/__common/tasks/poweron_vms.yml
@@ -24,7 +24,7 @@
         - name: poweron_vms | Power-on GCP GCE VM(s)
           gcp_compute_instance:
             name: "{{item.name}}"
-            project: "{{cluster_vars.project_id}}"
+            project: "{{cluster_vars[buildenv].vpc_project_id}}"
             zone: "{{ item.regionzone }}"
             auth_kind: "serviceaccount"
             service_account_file: "{{gcp_credentials_file}}"

--- a/redeploy/__common/tasks/set_lifecycle_state_label.yml
+++ b/redeploy/__common/tasks/set_lifecycle_state_label.yml
@@ -18,7 +18,7 @@
     - name: set_lifecycle_state_label | Change lifecycle_state label on GCP GCE VM
       gcp_compute_instance:
         name: "{{item.name}}"
-        project: "{{cluster_vars.project_id}}"
+        project: "{{cluster_vars[buildenv].vpc_project_id}}"
         zone: "{{ item.regionzone }}"
         auth_kind: "serviceaccount"
         service_account_file: "{{gcp_credentials_file}}"


### PR DESCRIPTION
When GCP is configured with 'Shared VPCs' (https://cloud.google.com/vpc/docs/shared-vpc), the network resources are no longer in the same VPC as the compute resources.  

This change splits out the 'vpc_project_id' (the 'service project', with the VMs in it), from the 'vpc_host_project_id' (the 'service project', where the networking is located).