### PR TITLE
[FEATURE] Parametrised logging paths for FileBeat

### DIFF
--- a/EXAMPLE/.vaultpass-client.py
+++ b/EXAMPLE/.vaultpass-client.py
@@ -12,7 +12,7 @@ import sys
 envvar_vault_pass = "VAULT_PASSWORD_BUILDENV"
 
 if os.environ.get(envvar_vault_pass) is not None and os.environ.get(envvar_vault_pass) != "":
-    print (os.environ[envvar_vault_pass])
+    print(os.environ[envvar_vault_pass])
 else:
-    print ("ERROR: '" + envvar_vault_pass + "' is not set in environment")
+    print("ERROR: '" + envvar_vault_pass + "' is not set in environment")
     sys.exit(1)

--- a/EXAMPLE/Pipfile
+++ b/EXAMPLE/Pipfile
@@ -13,9 +13,6 @@ ansible = ">=2.9"
 jmespath = "*"
 dnspython = "*"
 google-auth = "*"
-netaddr = "*"
-passlib = "*"
-apache-libcloud = "*"
 google-api-python-client = "*"
 
 [dev-packages]

--- a/EXAMPLE/cluster.yml
+++ b/EXAMPLE/cluster.yml
@@ -19,5 +19,6 @@
 ##
 
 - name: Perform cluster readiness operations
-  hosts: all
+  hosts: localhost
+  connection: local
   roles: [ { role: clusterverse/readiness, tags: [clusterverse_readiness] } ]

--- a/EXAMPLE/clusterverse_label_upgrade_v1-v2.yml
+++ b/EXAMPLE/clusterverse_label_upgrade_v1-v2.yml
@@ -28,7 +28,7 @@
         - name: clusterverse_label_upgrade_v1-v2 | Add lifecycle_state and cluster_suffix label to GCP GCE VM
           gce_labels:
             resource_name: "{{item.name}}"
-            project_id: "{{cluster_vars.project_id}}"
+            project_id: "{{cluster_vars[buildenv].vpc_project_id}}"
             resource_location: "{{item.regionzone}}"
             credentials_file: "{{gcp_credentials_file}}"
             resource_type: instances

--- a/EXAMPLE/group_vars/_skel/cluster_vars.yml
+++ b/EXAMPLE/group_vars/_skel/cluster_vars.yml
@@ -86,15 +86,14 @@ cluster_name: "{{app_name}}-{{buildenv}}"       # Identifies the cluster within 
 ### GCP example
 #cluster_vars:
 #  type: &cloud_type "gcp"
-#  image: "projects/ubuntu-os-cloud/global/images/ubuntu-1804-bionic-v20200430"
+#  image: "projects/ubuntu-os-cloud/global/images/ubuntu-1804-bionic-v20200430"    # Ubuntu images can be located at https://cloud-images.ubuntu.com/locator/
 #  region: &region "europe-west1"
 #  dns_cloud_internal_domain: "c.{{gcp_credentials_json.project_id}}.internal"     # The cloud-internal zone as defined by the cloud provider (e.g. GCP, AWS)
 #  dns_nameserver_zone: &dns_nameserver_zone ""                                    # The zone that dns_server will operate on.  gcloud dns needs a trailing '.'.  Leave blank if no external DNS (use IPs only)
-#  dns_user_domain: "{%- if _dns_nameserver_zone -%}MY.OTHER.PREFIXES.{{_dns_nameserver_zone}}{%- endif -%}"         # A user-defined _domain_ part of the FDQN, (if more prefixes are required before the dns_nameserver_zone)
+#  dns_user_domain: "{%- if _dns_nameserver_zone -%}CUSTOM.PREFIXES.{{_dns_nameserver_zone}}{%- endif -%}"         # A user-defined _domain_ part of the FDQN, (if more prefixes are required before the dns_nameserver_zone)
 #  dns_server: ""                            # Specify DNS server. nsupdate, route53 or clouddns.  If empty string is specified, no DNS will be added.
 #  assign_public_ip: "yes"
 #  inventory_ip: "public"                    # 'public' or 'private', (private in case we're operating in a private LAN).  If public, 'assign_public_ip' must be 'yes'
-#  project_id: "{{gcp_credentials_json.project_id}}"
 #  ip_forward: "false"
 #  ssh_guard_whitelist: &ssh_guard_whitelist ['10.0.0.0/8']    # Put your public-facing IPs into this (if you're going to access it via public IP), to avoid rate-limiting.
 #  custom_tagslabels: {inv_resident_id: "abc", inv_proposition_id: "def"}
@@ -116,6 +115,8 @@ cluster_name: "{{app_name}}-{{buildenv}}"       # Identifies the cluster within 
 #    hosttype_vars:
 #      sys: {vms_by_az: {b: 1, c: 1, d: 1}, flavor: f1-micro, rootvol_size: "10", version: "{{sys_version | default('')}}", auto_volumes: []}
 #      #sysdisks: {vms_by_az: {b: 1, c: 1, d: 1}, flavor: f1-micro, rootvol_size: "10", version: "{{sysdisks_version | default('')}}", auto_volumes: [{auto_delete: true, interface: "SCSI", volume_size: 2, mountpoint: "/var/log/mysvc", fstype: "ext4", perms: {owner: "root", group: "sudo", mode: "775"}}, {auto_delete: true, interface: "SCSI", volume_size: 2,  mountpoint: "/var/log/mysvc2", fstype: "ext4"}, {auto_delete: true, interface: "SCSI", volume_size: 3,  mountpoint: "/var/log/mysvc3", fstype: "ext4"}]}
+#    vpc_project_id: "{{gcp_credentials_json.project_id}}"             # AKA the 'service project' if Shared VPC (https://cloud.google.com/vpc/docs/shared-vpc) is in use.
+#    vpc_host_project_id: "{{gcp_credentials_json.project_id}}"        # Would differ from vpc_project_id if Shared VPC is in use, (the networking is in a separate project)
 #    vpc_network_name: "test-{{buildenv}}"
 #    vpc_subnet_name: ""
 #    preemptible: "no"

--- a/EXAMPLE/group_vars/_skel/cluster_vars.yml
+++ b/EXAMPLE/group_vars/_skel/cluster_vars.yml
@@ -7,7 +7,13 @@ gcp_credentials_json: "{{ lookup('file', gcp_credentials_file) | default({'proje
 app_name: "test"                  # The name of the application cluster (e.g. 'couchbase', 'nginx'); becomes part of cluster_name.
 app_class: "test"                 # The class of application (e.g. 'database', 'webserver'); becomes part of the fqdn
 
-beats_target_hosts: []            # The destination hosts for e.g. filebeat/ metricbeat logs
+beats_config:
+  filebeat:
+#    output_logstash_hosts: ["localhost:5044"]   # The destination hosts for filebeat-gathered logs
+#    extra_logs_paths: # The array is optional, if you need to add more paths or files to scrape for logs
+#      - /var/log/myapp/*.log 
+  metricbeat:
+#    output_logstash_hosts: ["localhost:5044"]   # The destination hosts for metricbeat-gathered metrics
 
 ## Vulnerability scanners - Tenable and/ or Qualys cloud agents:
 cloud_agent:

--- a/EXAMPLE/group_vars/test_aws_euw1/cluster_vars.yml
+++ b/EXAMPLE/group_vars/test_aws_euw1/cluster_vars.yml
@@ -7,7 +7,13 @@ redeploy_scheme: _scheme_addallnew_rmdisk_rollback
 app_name: "test"                  # The name of the application cluster (e.g. 'couchbase', 'nginx'); becomes part of cluster_name.
 app_class: "test"                 # The class of application (e.g. 'database', 'webserver'); becomes part of the fqdn
 
-beats_target_hosts: []            # The destination hosts for e.g. filebeat/ metricbeat logs
+beats_config:
+  filebeat:
+#    output_logstash_hosts: ["localhost:5044"]   # The destination hosts for filebeat-gathered logs
+#    extra_logs_paths: # The array is optional, if you need to add more paths or files to scrape for logs
+#      - /var/log/myapp/*.log 
+  metricbeat:
+#    output_logstash_hosts: ["localhost:5044"]   # The destination hosts for metricbeat-gathered metrics
 
 ## Vulnerability scanners - Tenable and/ or Qualys cloud agents:
 cloud_agent:

--- a/EXAMPLE/group_vars/test_gcp_euw1/cluster_vars.yml
+++ b/EXAMPLE/group_vars/test_gcp_euw1/cluster_vars.yml
@@ -42,7 +42,7 @@ cluster_name: "{{app_name}}-{{buildenv}}"       # Identifies the cluster within 
 
 cluster_vars:
   type: &cloud_type "gcp"
-  image: "projects/ubuntu-os-cloud/global/images/ubuntu-1804-bionic-v20200430"
+  image: "projects/ubuntu-os-cloud/global/images/ubuntu-1804-bionic-v20200430"  # Ubuntu images can be located at https://cloud-images.ubuntu.com/locator/
   region: &region "europe-west1"
   dns_cloud_internal_domain: "c.{{gcp_credentials_json.project_id}}.internal"   # The cloud-internal zone as defined by the cloud provider (e.g. GCP, AWS)
   dns_nameserver_zone: &dns_nameserver_zone ""                                  # The zone that dns_server will operate on.  gcloud dns needs a trailing '.'.  Leave blank if no external DNS (use IPs only)
@@ -50,7 +50,6 @@ cluster_vars:
   dns_server: ""                            # Specify DNS server. nsupdate, route53 or clouddns.  If empty string is specified, no DNS will be added.
   assign_public_ip: "yes"
   inventory_ip: "public"                    # 'public' or 'private', (private in case we're operating in a private LAN).  If public, 'assign_public_ip' must be 'yes'
-  project_id: "{{gcp_credentials_json.project_id}}"
   ip_forward: "false"
   ssh_guard_whitelist: &ssh_guard_whitelist ['10.0.0.0/8']    # Put your public-facing IPs into this (if you're going to access it via public IP), to avoid rate-limiting.
   custom_tagslabels:
@@ -79,6 +78,8 @@ cluster_vars:
     hosttype_vars:
       sys: {vms_by_az: {b: 1, c: 1, d: 1}, flavor: f1-micro, rootvol_size: "10", version: "{{sys_version | default('')}}", auto_volumes: []}
       #sysdisks: {vms_by_az: {b: 1, c: 1, d: 1}, flavor: f1-micro, rootvol_size: "10", version: "{{sysdisks_version | default('')}}", auto_volumes: [{auto_delete: true, interface: "SCSI", volume_size: 2, mountpoint: "/var/log/mysvc", fstype: "ext4", perms: {owner: "root", group: "sudo", mode: "775"}}, {auto_delete: true, interface: "SCSI", volume_size: 2,  mountpoint: "/var/log/mysvc2", fstype: "ext4"}, {auto_delete: true, interface: "SCSI", volume_size: 3,  mountpoint: "/var/log/mysvc3", fstype: "ext4"}]}
+    vpc_project_id: "{{gcp_credentials_json.project_id}}"             # AKA the 'service project' if Shared VPC (https://cloud.google.com/vpc/docs/shared-vpc) is in use.
+    vpc_host_project_id: "{{gcp_credentials_json.project_id}}"        # Would differ from vpc_project_id if Shared VPC is in use, (the networking is in a separate project)
     vpc_network_name: "test-{{buildenv}}"
     vpc_subnet_name: ""
     preemptible: "no"

--- a/EXAMPLE/group_vars/test_gcp_euw1/cluster_vars.yml
+++ b/EXAMPLE/group_vars/test_gcp_euw1/cluster_vars.yml
@@ -11,7 +11,13 @@ redeploy_scheme: _scheme_addallnew_rmdisk_rollback
 app_name: "test"                  # The name of the application cluster (e.g. 'couchbase', 'nginx'); becomes part of cluster_name.
 app_class: "test"                 # The class of application (e.g. 'database', 'webserver'); becomes part of the fqdn
 
-beats_target_hosts: []            # The destination hosts for e.g. filebeat/ metricbeat logs
+beats_config:
+  filebeat:
+#    output_logstash_hosts: ["localhost:5044"]   # The destination hosts for filebeat-gathered logs
+#    extra_logs_paths: # The array is optional, if you need to add more paths or files to scrape for logs
+#      - /var/log/myapp/*.log 
+  metricbeat:
+#    output_logstash_hosts: ["localhost:5044"]   # The destination hosts for metricbeat-gathered metrics
 
 ## Vulnerability scanners - Tenable and/ or Qualys cloud agents:
 cloud_agent:

--- a/EXAMPLE/jenkinsfiles/Jenkinsfile_exec_release
+++ b/EXAMPLE/jenkinsfiles/Jenkinsfile_exec_release
@@ -50,6 +50,6 @@ pipeline {
     //       build job: "clusterverse-release-deploy", wait: false, parameters: [string(name: 'GENUINE_BUILD', value: "true"), string(name: 'DEPLOY_ENV', value: "sandbox"), string(name: 'RELEASE', value: "${VERSION_TO_DEPLOY}")]
     //     }
     //   }
-    // }        
+    // }
   }
 }

--- a/clean/tasks/clean_dns.yml
+++ b/clean/tasks/clean_dns.yml
@@ -90,10 +90,9 @@
           when: (item.1.set.value is defined)  and  ((item.0.name | regex_replace('-(?!.*-).*')) == (item.1.set.record | regex_replace('^(.*?)\\..*$', '\\1')))  and  (item.0.name == item.1.set.value | regex_replace('^(.*?)\\..*$', '\\1'))
       when: cluster_vars.dns_server == "route53"
 
-
     - name: clean/dns/clouddns | Delete DNS entries from clouddns
       block:
-        - name: clean/dns/clouddns | Get GCP Managed Zone
+        - name: clean/dns/clouddns | Get managed zone(s)
           gcp_dns_managed_zone_info:
             auth_kind: serviceaccount
             dns_name: "{{cluster_vars.dns_nameserver_zone}}"
@@ -101,53 +100,66 @@
             service_account_file: "{{gcp_credentials_file}}"
           register: r__gcp_dns_managed_zone_info
 
-        - block:
-            - assert: { that: "r__gcp_dns_managed_zone_info__non_peered | length <= 1", msg: "Multiple non-peered managed zones with the same DNS is not supported ({{r__gcp_dns_managed_zone_info__non_peered | json_query(\"[].name\") }}) - abort" }
+#        - debug: msg={{r__gcp_dns_managed_zone_info}}
 
-            - name: clean/dns/clouddns | Get DNS entries
-              gcp_dns_resource_record_set_info:
-                auth_kind: serviceaccount
-                managed_zone:
-                  name: "{{r__gcp_dns_managed_zone_info__non_peered.0.name}}"
-                  dnsName: "{{r__gcp_dns_managed_zone_info__non_peered.0.dnsName}}"
-                project: "{{cluster_vars[buildenv].vpc_host_project_id}}"
-                service_account_file: "{{gcp_credentials_file}}"
-              register: r__gcp_dns_resource_record_set_info
+        - name: clean/dns/clouddns | Get all non-peered DNS records for managed zones that match cluster_vars.dns_nameserver_zone
+          gcp_dns_resource_record_set_info:
+            auth_kind: serviceaccount
+            managed_zone:
+              name: "{{item.name}}"
+              dnsName: "{{item.dnsName}}"
+            project: "{{cluster_vars[buildenv].vpc_host_project_id}}"
+            service_account_file: "{{gcp_credentials_file}}"
+          register: r__gcp_dns_resource_record_set_info
+          with_items: "{{r__gcp_dns_managed_zone_info.resources | json_query(\"[?dnsName==`\" + cluster_vars.dns_nameserver_zone + \"` && !(peeringConfig)]\") }}"
+
+#        - debug: msg={{r__gcp_dns_resource_record_set_info}}
+
+        - name: clean/dns/clouddns | Delete A and CNAME records
+          block:
+#            - debug: msg={{gcp_dns_resource_record_set_info__and__gcp_dns_managed_zone_info}}
 
             - name: clean/dns/clouddns | Delete A records
               gcp_dns_resource_record_set:
                 auth_kind: serviceaccount
                 managed_zone:
-                  name: "{{r__gcp_dns_managed_zone_info__non_peered.0.name}}"
-                  dnsName: "{{r__gcp_dns_managed_zone_info__non_peered.0.dnsName}}"
-                name: "{{ item.1.name }}"
+                  name: "{{item.1.managed_zone.name}}"
+                  dnsName: "{{item.1.managed_zone.dnsName}}"
+                name: "{{ item.1.record.name }}"
                 project: "{{cluster_vars[buildenv].vpc_host_project_id}}"
                 service_account_file: "{{gcp_credentials_file}}"
                 state: absent
-                target: "{{ item.1.rrdatas }}"
+                target: "{{ item.1.record.rrdatas }}"
                 type: A
               with_nested:
                 - "{{ hosts_to_clean }}"
-                - "{{ r__gcp_dns_resource_record_set_info.resources | json_query(\"[?type=='A']\") }}"
-              when: item.0.name == (item.1.name | regex_replace('^(.*?)\\..*$', '\\1'))
+                - "{{ gcp_dns_resource_record_set_info__and__gcp_dns_managed_zone_info | json_query(\"[?record.type=='A']\") }}"
+              when: item.0.name == (item.1.record.name | regex_replace('^(.*?)\\..*$', '\\1'))
 
             - name: clean/dns/clouddns | Delete CNAME records
               gcp_dns_resource_record_set:
                 auth_kind: serviceaccount
                 managed_zone:
-                  name: "{{r__gcp_dns_managed_zone_info__non_peered.0.name}}"
-                  dnsName: "{{r__gcp_dns_managed_zone_info__non_peered.0.dnsName}}"
-                name: "{{ item.1.name }}"
+                  name: "{{item.1.managed_zone.name}}"
+                  dnsName: "{{item.1.managed_zone.dnsName}}"
+                name: "{{ item.1.record.name }}"
                 project: "{{cluster_vars[buildenv].vpc_host_project_id}}"
                 service_account_file: "{{gcp_credentials_file}}"
                 state: absent
-                target: "{{ item.1.rrdatas[0] }}"
+                target: "{{ item.1.record.rrdatas[0] }}"
                 type: CNAME
               with_nested:
                 - "{{ hosts_to_clean }}"
-                - "{{ r__gcp_dns_resource_record_set_info.resources | json_query(\"[?type=='CNAME']\") }}"
-              when: ((item.0.name |regex_replace('-(?!.*-).*')) == (item.1.name | regex_replace('^(.*?)\\..*$', '\\1')))  and  (item.0.name == item.1.rrdatas[0] | regex_replace('^(.*?)\\..*$', '\\1'))
+                - "{{ gcp_dns_resource_record_set_info__and__gcp_dns_managed_zone_info | json_query(\"[?record.type=='CNAME']\") }}"
+              when: ((item.0.name |regex_replace('-(?!.*-).*')) == (item.1.record.name | regex_replace('^(.*?)\\..*$', '\\1')))  and  (item.0.name == item.1.record.rrdatas[0] | regex_replace('^(.*?)\\..*$', '\\1'))
           vars:
-            r__gcp_dns_managed_zone_info__non_peered: "{{r__gcp_dns_managed_zone_info.resources | json_query(\"[?dnsName==`\" + cluster_vars.dns_nameserver_zone + \"` && !(peeringConfig)]\") }}"
+            gcp_dns_resource_record_set_info__and__gcp_dns_managed_zone_info: |
+              {%- set res = [] -%}
+              {%- for managed_zone in r__gcp_dns_resource_record_set_info.results -%}
+                {%- for record in managed_zone.resources -%}
+                  {%- set _dummy = res.extend([{ 'managed_zone': {'dnsName': managed_zone.item.dnsName, 'name': managed_zone.item.name}, 'record': record }]) -%}
+                {%- endfor -%}
+              {%- endfor -%}
+              {{ res }}
       when: cluster_vars.dns_server=="clouddns"
   when: hosts_to_clean | length

--- a/clean/tasks/clean_dns.yml
+++ b/clean/tasks/clean_dns.yml
@@ -97,52 +97,57 @@
           gcp_dns_managed_zone_info:
             auth_kind: serviceaccount
             dns_name: "{{cluster_vars.dns_nameserver_zone}}"
-            project: "{{cluster_vars.project_id}}"
+            project: "{{cluster_vars[buildenv].vpc_host_project_id}}"
             service_account_file: "{{gcp_credentials_file}}"
           register: r__gcp_dns_managed_zone_info
 
-        - name: clean/dns/clouddns | Get DNS entries
-          gcp_dns_resource_record_set_info:
-            auth_kind: serviceaccount
-            managed_zone:
-              name: "{{r__gcp_dns_managed_zone_info.resources.0.name}}"
-              dnsName: "{{r__gcp_dns_managed_zone_info.resources.0.dnsName}}"
-            project: "{{cluster_vars.project_id}}"
-            service_account_file: "{{gcp_credentials_file}}"
-          register: r__gcp_dns_resource_record_set_info
+        - block:
+            - assert: { that: "r__gcp_dns_managed_zone_info__non_peered | length <= 1", msg: "Multiple non-peered managed zones with the same DNS is not supported ({{r__gcp_dns_managed_zone_info__non_peered | json_query(\"[].name\") }}) - abort" }
 
-        - name: clean/dns/clouddns | Delete A records
-          gcp_dns_resource_record_set:
-            auth_kind: serviceaccount
-            managed_zone:
-              name: "{{r__gcp_dns_managed_zone_info.resources.0.name}}"
-              dnsName: "{{r__gcp_dns_managed_zone_info.resources.0.dnsName}}"
-            name: "{{ item.1.name }}"
-            project: "{{cluster_vars.project_id}}"
-            service_account_file: "{{gcp_credentials_file}}"
-            state: absent
-            target: "{{ item.1.rrdatas }}"
-            type: A
-          with_nested:
-            - "{{ hosts_to_clean }}"
-            - "{{ r__gcp_dns_resource_record_set_info.resources | json_query(\"[?type=='A']\") }}"
-          when: item.0.name == (item.1.name | regex_replace('^(.*?)\\..*$', '\\1'))
+            - name: clean/dns/clouddns | Get DNS entries
+              gcp_dns_resource_record_set_info:
+                auth_kind: serviceaccount
+                managed_zone:
+                  name: "{{r__gcp_dns_managed_zone_info__non_peered.0.name}}"
+                  dnsName: "{{r__gcp_dns_managed_zone_info__non_peered.0.dnsName}}"
+                project: "{{cluster_vars[buildenv].vpc_host_project_id}}"
+                service_account_file: "{{gcp_credentials_file}}"
+              register: r__gcp_dns_resource_record_set_info
 
-        - name: clean/dns/clouddns | Delete CNAME records
-          gcp_dns_resource_record_set:
-            auth_kind: serviceaccount
-            managed_zone:
-              name: "{{r__gcp_dns_managed_zone_info.resources.0.name}}"
-              dnsName: "{{r__gcp_dns_managed_zone_info.resources.0.dnsName}}"
-            name: "{{ item.1.name }}"
-            project: "{{cluster_vars.project_id}}"
-            service_account_file: "{{gcp_credentials_file}}"
-            state: absent
-            target: "{{ item.1.rrdatas[0] }}"
-            type: CNAME
-          with_nested:
-            - "{{ hosts_to_clean }}"
-            - "{{ r__gcp_dns_resource_record_set_info.resources | json_query(\"[?type=='CNAME']\") }}"
-          when: ((item.0.name |regex_replace('-(?!.*-).*')) == (item.1.name | regex_replace('^(.*?)\\..*$', '\\1')))  and  (item.0.name == item.1.rrdatas[0] | regex_replace('^(.*?)\\..*$', '\\1'))
+            - name: clean/dns/clouddns | Delete A records
+              gcp_dns_resource_record_set:
+                auth_kind: serviceaccount
+                managed_zone:
+                  name: "{{r__gcp_dns_managed_zone_info__non_peered.0.name}}"
+                  dnsName: "{{r__gcp_dns_managed_zone_info__non_peered.0.dnsName}}"
+                name: "{{ item.1.name }}"
+                project: "{{cluster_vars[buildenv].vpc_host_project_id}}"
+                service_account_file: "{{gcp_credentials_file}}"
+                state: absent
+                target: "{{ item.1.rrdatas }}"
+                type: A
+              with_nested:
+                - "{{ hosts_to_clean }}"
+                - "{{ r__gcp_dns_resource_record_set_info.resources | json_query(\"[?type=='A']\") }}"
+              when: item.0.name == (item.1.name | regex_replace('^(.*?)\\..*$', '\\1'))
+
+            - name: clean/dns/clouddns | Delete CNAME records
+              gcp_dns_resource_record_set:
+                auth_kind: serviceaccount
+                managed_zone:
+                  name: "{{r__gcp_dns_managed_zone_info__non_peered.0.name}}"
+                  dnsName: "{{r__gcp_dns_managed_zone_info__non_peered.0.dnsName}}"
+                name: "{{ item.1.name }}"
+                project: "{{cluster_vars[buildenv].vpc_host_project_id}}"
+                service_account_file: "{{gcp_credentials_file}}"
+                state: absent
+                target: "{{ item.1.rrdatas[0] }}"
+                type: CNAME
+              with_nested:
+                - "{{ hosts_to_clean }}"
+                - "{{ r__gcp_dns_resource_record_set_info.resources | json_query(\"[?type=='CNAME']\") }}"
+              when: ((item.0.name |regex_replace('-(?!.*-).*')) == (item.1.name | regex_replace('^(.*?)\\..*$', '\\1')))  and  (item.0.name == item.1.rrdatas[0] | regex_replace('^(.*?)\\..*$', '\\1'))
+          vars:
+            r__gcp_dns_managed_zone_info__non_peered: "{{r__gcp_dns_managed_zone_info.resources | json_query(\"[?dnsName==`\" + cluster_vars.dns_nameserver_zone + \"` && !(peeringConfig)]\") }}"
       when: cluster_vars.dns_server=="clouddns"
   when: hosts_to_clean | length

--- a/clean/tasks/clean_networking.yml
+++ b/clean/tasks/clean_networking.yml
@@ -17,7 +17,7 @@
         state: "absent"
         auth_kind: "serviceaccount"
         service_account_file: "{{gcp_credentials_file}}"
-        project: "{{cluster_vars.project_id}}"
+        project: "{{cluster_vars[buildenv].vpc_host_project_id}}"
       with_items: "{{ cluster_vars.firewall_rules }}"
 
     - name: clean/networking/gcp | Delete the GCP network (if -e create_gcp_network=true)
@@ -25,7 +25,7 @@
         name: "{{cluster_vars[buildenv].vpc_network_name}}"
         auth_kind: "serviceaccount"
         service_account_file: "{{gcp_credentials_file}}"
-        project: "{{cluster_vars.project_id}}"
+        project: "{{cluster_vars[buildenv].vpc_host_project_id}}"
         state: absent
       when: create_gcp_network is defined and create_gcp_network|bool
   when: cluster_vars.type == "gcp"

--- a/clean/tasks/clean_vms.yml
+++ b/clean/tasks/clean_vms.yml
@@ -34,7 +34,7 @@
 #        - name: clean/del_vms/gcp | Remove deletion protection (broken until https://github.com/ansible-collections/ansible_collections_google/pull/163 gets into a release)
 #          gcp_compute_instance:
 #            name: "{{item.name}}"
-#            project: "{{cluster_vars.project_id}}"
+#            project: "{{cluster_vars[buildenv].vpc_project_id}}"
 #            zone: "{{ item.regionzone }}"
 #            auth_kind: "serviceaccount"
 #            service_account_file: "{{gcp_credentials_file}}"
@@ -44,7 +44,7 @@
         - name: clean/del_vms/gcp | Delete GCE VM
           gcp_compute_instance:
             name: "{{item.name}}"
-            project: "{{cluster_vars.project_id}}"
+            project: "{{cluster_vars[buildenv].vpc_project_id}}"
             zone: "{{ item.regionzone }}"
             auth_kind: "serviceaccount"
             service_account_file: "{{gcp_credentials_file}}"

--- a/cluster_hosts/tasks/get_cluster_hosts_state.yml
+++ b/cluster_hosts/tasks/get_cluster_hosts_state.yml
@@ -26,7 +26,7 @@
         zone: "{{cluster_vars.region}}-{{item}}"
         filters:
           - "labels.cluster_name = {{cluster_name}}"
-        project: "{{cluster_vars.project_id}}"
+        project: "{{cluster_vars[buildenv].vpc_project_id}}"
         auth_kind: "serviceaccount"
         service_account_file: "{{gcp_credentials_file}}"
         scopes: ["https://www.googleapis.com/auth/compute.readonly"]

--- a/config/tasks/create_dns_a.yml
+++ b/config/tasks/create_dns_a.yml
@@ -37,7 +37,7 @@
   poll: 0
   register: route53_records
 
-- name: config/dns/a/route53 | Wait for records to bereplicated to all Amazon Route 53 DNS servers
+- name: config/dns/a/route53 | Wait for records to be replicated to all Amazon Route 53 DNS servers
   async_status:
     jid: "{{ item.ansible_job_id }}"
   register: route53_jobs
@@ -47,6 +47,7 @@
   run_once: true
   with_items: "{{route53_records.results}}"
   delegate_to: localhost
+  when: cluster_vars.dns_server=="route53"
 
 - name: config/dns/a/clouddns | create/update A records in GCP (clouddns)
   block:
@@ -54,30 +55,32 @@
       gcp_dns_managed_zone_info:
         auth_kind: serviceaccount
         dns_name: "{{cluster_vars.dns_nameserver_zone}}"
-        project: "{{cluster_vars.project_id}}"
+        project: "{{cluster_vars[buildenv].vpc_host_project_id}}"
         service_account_file: "{{gcp_credentials_file}}"
       register: r__gcp_dns_managed_zone_info
       become: false
       delegate_to: localhost
       run_once: true
 
-    - name: config/dns/a/clouddns | create/update A records in GCP (clouddns)
+    - name: config/dns/a/clouddns | create/update A records for all matching zones, (could be multiple, e.g. public/ private) in GCP (clouddns)
       gcp_dns_resource_record_set:
         auth_kind: serviceaccount
         managed_zone:
-          name: "{{r__gcp_dns_managed_zone_info.resources.0.name}}"
-          dnsName: "{{r__gcp_dns_managed_zone_info.resources.0.dnsName}}"
-        name: "{{item.hostname}}.{{cluster_vars.dns_user_domain}}"
-        project: "{{cluster_vars.project_id}}"
+          name: "{{item.1.name}}"
+          dnsName: "{{item.1.dnsName}}"
+        name: "{{item.0.hostname}}.{{cluster_vars.dns_user_domain}}"
+        project: "{{cluster_vars[buildenv].vpc_host_project_id}}"
         service_account_file: "{{gcp_credentials_file}}"
         state: present
-        target: "{%- if r__gcp_dns_managed_zone_info.resources.0.visibility == 'private' -%} {{ hostvars[item.hostname]['ansible_default_ipv4']['address'] }} {%- else -%} {{ hostvars[item.hostname]['ansible_host'] }} {%- endif -%}"
+        target: "{%- if item.1.visibility == 'private' -%} {{ hostvars[item.0.hostname]['ansible_default_ipv4']['address'] }} {%- else -%} {{ hostvars[item.0.hostname]['ansible_host'] }} {%- endif -%}"
         type: A
         ttl: 60
       become: false
       delegate_to: localhost
       run_once: true
-      with_items: "{{ cluster_hosts_target }}"
+      with_nested:
+        - "{{ cluster_hosts_target }}"
+        - "{{ r__gcp_dns_managed_zone_info.resources | json_query(\"[?dnsName==`\" + cluster_vars.dns_nameserver_zone + \"` && !(peeringConfig)]\") }}"
   when: cluster_vars.dns_server=="clouddns"
 
 - block:

--- a/config/tasks/filebeat.yml
+++ b/config/tasks/filebeat.yml
@@ -17,7 +17,8 @@
   until: yum_jobs is success
   retries: 5
   when: ansible_os_family == 'RedHat'
-  
+
+# the variable "beats_target_hosts" will be deprecated in Clusterverse 4.0
 - name: Filebeat | Configure filebeat
   block:
     - name: Filebeat | Copy filebeat configuration
@@ -33,4 +34,4 @@
         src: lib/systemd/system//filebeat.service.j2
         dest: "/lib/systemd/system/filebeat.service"
       notify: Filebeat | Restart and enable filebeat
-  when: beats_target_hosts is defined and (beats_target_hosts | length)
+  when: (beats_target_hosts is defined and (beats_target_hosts | length)) or (beats_config.filebeat.output_logstash_hosts is defined and (beats_config.filebeat.output_logstash_hosts | length))

--- a/config/tasks/metricbeat.yml
+++ b/config/tasks/metricbeat.yml
@@ -17,7 +17,8 @@
   until: yum_jobs is success
   retries: 5
   when: ansible_os_family == 'RedHat'
-  
+
+# the variable "beats_target_hosts" will be deprecated in Clusterverse 4.0  
 - name: Metricbeat | Configure metricbeat
   block:
     - name: Metricbeat | Copy metricbeat configuration
@@ -33,4 +34,4 @@
         src: lib/systemd/system//metricbeat.service.j2
         dest: "/lib/systemd/system/metricbeat.service"
       notify: Metricbeat | Restart and enable metricbeat
-  when: beats_target_hosts is defined and (beats_target_hosts | length)
+  when: (beats_target_hosts is defined and (beats_target_hosts | length)) or (beats_config.metricbeat.output_logstash_hosts is defined and (beats_config.metricbeat.output_logstash_hosts | length))

--- a/config/templates/etc/filebeat/filebeat.yml.j2
+++ b/config/templates/etc/filebeat/filebeat.yml.j2
@@ -30,7 +30,11 @@ filebeat.inputs:
     - /var/log/messages
     - /var/log/secure
     - /var/log/dmesg
-
+{% if filebeat_extra_logs_paths %}
+{% for logpath in filebeat_extra_logs_paths %}
+    - {{ logpath }}
+{% endfor %}
+{% endif %}
     #- c:\programdata\elasticsearch\logs\*
 
   # Exclude lines. A list of regular expressions to match. It drops the lines that are

--- a/config/templates/etc/filebeat/filebeat.yml.j2
+++ b/config/templates/etc/filebeat/filebeat.yml.j2
@@ -30,8 +30,8 @@ filebeat.inputs:
     - /var/log/messages
     - /var/log/secure
     - /var/log/dmesg
-{% if filebeat_extra_logs_paths %}
-{% for logpath in filebeat_extra_logs_paths %}
+{% if beats_config.filebeat.extra_logs_paths %}
+{% for logpath in beats_config.filebeat.extra_logs_paths %}
     - {{ logpath }}
 {% endfor %}
 {% endif %}
@@ -154,20 +154,23 @@ setup.kibana:
 # Configure what output to use when sending the data collected by the beat.
 
 #-------------------------- Elasticsearch output ------------------------------
-#output.elasticsearch:
+{% if beats_config.filebeat.elasticsearch_output_hosts %}
+output.elasticsearch:
   # Array of hosts to connect to.
-  #hosts: ["localhost:9200"]
-
+  hosts: {{ beats_config.filebeat.output_elasticsearch_hosts | default(beats_target_hosts) }}
+{% endif %}
   # Optional protocol and basic auth credentials.
   #protocol: "https"
   #username: "elastic"
   #password: "changeme"
 
 #----------------------------- Logstash output --------------------------------
+{% if beats_config.filebeat.logstash_output_hosts %}
 output.logstash:
   # The Logstash hosts
-  hosts: {{ beats_target_hosts }}
-
+  # "beats_target_hosts" below refers to a previous Clusterverse release variable, it will be deprecated in Clusterverse 4.0
+  hosts: {{ beats_config.filebeat.output_logstash_hosts | default(beats_target_hosts) }}
+{% endif %}
   # Optional SSL. By default is off.
   # List of root certificates for HTTPS server verifications
   #ssl.certificate_authorities: ["/etc/pki/root/ca.pem"]

--- a/config/templates/etc/metricbeat/metricbeat.yml.j2
+++ b/config/templates/etc/metricbeat/metricbeat.yml.j2
@@ -90,9 +90,11 @@ setup.kibana:
 # Configure what output to use when sending the data collected by the beat.
 
 #-------------------------- Elasticsearch output ------------------------------
-# output.elasticsearch:
+{% if beats_config.metricbeat.elasticsearch_output_hosts %}
+output.elasticsearch:
   # Array of hosts to connect to.
-  # hosts: ["localhost:9200"]
+  hosts: {{ beats_config.metricbeat.output_elasticsearch_hosts | default(beats_target_hosts) }}
+{% endif %}
 
   # Optional protocol and basic auth credentials.
   #protocol: "https"
@@ -100,9 +102,12 @@ setup.kibana:
   #password: "changeme"
 
 #----------------------------- Logstash output --------------------------------
+{% if beats_config.metricbeat.logstash_output_hosts %}
 output.logstash:
   # The Logstash hosts
-  hosts: {{ beats_target_hosts }}
+  # "beats_target_hosts" below refers to a previous Clusterverse release variable, it will be deprecated in Clusterverse 4.0
+  hosts: {{ beats_config.metricbeat.output_logstash_hosts | default(beats_target_hosts) }}
+{% endif %}
 
   # Optional SSL. By default is off.
   # List of root certificates for HTTPS server verifications

--- a/create/tasks/gcp.yml
+++ b/create/tasks/gcp.yml
@@ -6,7 +6,7 @@
       gcp_compute_network:
         name: "{{cluster_vars[buildenv].vpc_network_name}}"
         auto_create_subnetworks: "{%- if cluster_vars[buildenv].vpc_subnet_name is defined and cluster_vars[buildenv].vpc_subnet_name != '' -%} false {%- else -%} true {%- endif -%}"
-        project: "{{cluster_vars.project_id}}"
+        project: "{{cluster_vars[buildenv].vpc_host_project_id}}"
         auth_kind: "serviceaccount"
         service_account_file: "{{gcp_credentials_file}}"
       register: r__gcp_compute_network
@@ -15,7 +15,7 @@
       gcp_compute_subnetwork:
         name: "{{cluster_vars[buildenv].vpc_subnet_name}}"
         network: "{{r__gcp_compute_network}}"
-        project: "{{cluster_vars.project_id}}"
+        project: "{{cluster_vars[buildenv].vpc_host_project_id}}"
         auth_kind: "serviceaccount"
         service_account_file: "{{gcp_credentials_file}}"
       when: (cluster_vars[buildenv].vpc_subnet_name is defined) and (cluster_vars[buildenv].vpc_subnet_name != "")
@@ -28,7 +28,7 @@
       gcp_compute_network_info:
         filters:
           - "name = {{cluster_vars[buildenv].vpc_network_name}}"
-        project: "{{cluster_vars.project_id}}"
+        project: "{{cluster_vars[buildenv].vpc_host_project_id}}"
         auth_kind: "serviceaccount"
         service_account_file: "{{gcp_credentials_file}}"
         scopes: ["https://www.googleapis.com/auth/compute.readonly"]
@@ -41,16 +41,16 @@
       gcp_compute_subnetwork_info:
         filters:
           - "name = {{cluster_vars[buildenv].vpc_subnet_name}}"
-        project: "{{cluster_vars.project_id}}"
+        project: "{{cluster_vars[buildenv].vpc_host_project_id}}"
         auth_kind: "serviceaccount"
         service_account_file: "{{gcp_credentials_file}}"
         scopes: ["https://www.googleapis.com/auth/compute.readonly"]
         region: "{{cluster_vars.region}}"
-      register: gcp_compute_subnetwork_info
+      register: r__gcp_compute_subnetwork_info
       when: (cluster_vars[buildenv].vpc_subnet_name is defined) and (cluster_vars[buildenv].vpc_subnet_name != "")
 
     - name: "Assert that {{cluster_vars[buildenv].vpc_subnet_name}} subnet exists"
-      assert: { that: "gcp_compute_subnetwork_info['resources'] | length > 0", msg: "The {{cluster_vars[buildenv].vpc_subnet_name}} subnet must exist" }
+      assert: { that: "r__gcp_compute_subnetwork_info['resources'] | length > 0", msg: "The {{cluster_vars[buildenv].vpc_subnet_name}} subnet must exist" }
       when: (cluster_vars[buildenv].vpc_subnet_name is defined) and (cluster_vars[buildenv].vpc_subnet_name != "")
 
     - name: create/gcp | Create GCP cluster firewalls
@@ -64,8 +64,9 @@
         network: "{{r__gcp_compute_network_info['resources'][0]}}"
         auth_kind: "serviceaccount"
         service_account_file: "{{gcp_credentials_file}}"
-        project: "{{cluster_vars.project_id}}"
+        project: "{{cluster_vars[buildenv].vpc_host_project_id}}"
       with_items: "{{ cluster_vars.firewall_rules }}"
+
 
 - name: create/gcp | Generate GCE ssh public key from the private key provided on the command line
   shell: ssh-keygen -y -f "{{ ansible_ssh_private_key_file }}"
@@ -77,21 +78,22 @@
       gcp_compute_instance:
         auth_kind: "serviceaccount"
         service_account_file: "{{gcp_credentials_file}}"
-        project: "{{cluster_vars.project_id}}"
+        project: "{{cluster_vars[buildenv].vpc_project_id}}"
         zone: "{{cluster_vars.region}}-{{item.az_name}}"
         name: "{{item.hostname}}"
         machine_type: "{{item.flavor}}"
         disks: "{{_host_disks}}"
         metadata:
           startup-script: "{%- if cluster_vars.ssh_guard_whitelist is defined and cluster_vars.ssh_guard_whitelist | length > 0 -%}#! /bin/bash\n\n#Whitelist my inbound IPs\n[ -f /etc/sshguard/whitelist ] && echo \"{{cluster_vars.ssh_guard_whitelist | join ('\n')}}\" >>/etc/sshguard/whitelist && /bin/systemctl restart sshguard{%- endif -%}"
-          ssh-keys: "{{ cliargs.remote_user }}:{{ r__gcp_ssh_pubkey.stdout }} {{ cliargs.remote_user }}"
+          ssh-keys: "{{ cliargs.remote_user }}:{{ r__gcp_ssh_pubkey.stdout }}"
+          # ssh-keys: "{{ cliargs.remote_user }}:{{ r__gcp_ssh_pubkey.stdout }} {{ cliargs.remote_user }}"
         labels: "{{ _labels | combine(cluster_vars.custom_tagslabels | default({})) }}"
         network_interfaces:
           - network: "{{ r__gcp_compute_network_info['resources'][0] | default({}) }}"
-            subnetwork: "{{ gcp_compute_subnetwork_info['resources'][0] | default({}) }}"
+            subnetwork: "{{ r__gcp_compute_subnetwork_info['resources'][0] | default({}) }}"
             access_configs: "{%- if cluster_vars.assign_public_ip == 'yes' -%}[{\"name\": \"External NAT\", \"type\": \"ONE_TO_ONE_NAT\"}]{%- else -%}[]{%- endif -%}"
         tags: { items: "{{cluster_vars.network_fw_tags}}" }
-        can_ip_forward : "{{cluster_vars.ip_forward}}"
+        can_ip_forward: "{{cluster_vars.ip_forward}}"
         scheduling: { automatic_restart: yes, preemptible: "{{cluster_vars[buildenv].preemptible}}" }
         state: present
         deletion_protection: "{{cluster_vars[buildenv].deletion_protection}}"

--- a/dynamic_inventory/tasks/gcp.yml
+++ b/dynamic_inventory/tasks/gcp.yml
@@ -7,7 +7,7 @@
     filters:
       - "name = {{cluster_name}}*"
       - "status = RUNNING"            # gcloud compute instances list --filter="status=RUNNING"
-    project: "{{cluster_vars.project_id}}"
+    project: "{{cluster_vars[buildenv].vpc_project_id}}"
     auth_kind: "serviceaccount"
     service_account_file: "{{gcp_credentials_file}}"
     scopes: ["https://www.googleapis.com/auth/compute.readonly"]

--- a/readiness/tasks/config_dns_cname.yml
+++ b/readiness/tasks/config_dns_cname.yml
@@ -40,9 +40,9 @@
       gcp_dns_managed_zone_info:
         auth_kind: serviceaccount
         dns_name: "{{cluster_vars.dns_nameserver_zone}}"
-        project: "{{cluster_vars.project_id}}"
+        project: "{{cluster_vars[buildenv].vpc_host_project_id}}"
         service_account_file: "{{gcp_credentials_file}}"
-      register: gcp_dns_managed_zone_info
+      register: r__gcp_dns_managed_zone_info
       become: false
       delegate_to: localhost
       run_once: true
@@ -51,16 +51,18 @@
       gcp_dns_resource_record_set:
         auth_kind: serviceaccount
         managed_zone:
-          name: "{{gcp_dns_managed_zone_info.resources.0.name}}"
-          dnsName: "{{gcp_dns_managed_zone_info.resources.0.dnsName}}"
-        name: "{{item.hostname | regex_replace('-(?!.*-).*')}}.{{cluster_vars.dns_user_domain}}"
-        project: "{{cluster_vars.project_id}}"
+          name: "{{item.1.name}}"
+          dnsName: "{{item.1.dnsName}}"
+        name: "{{item.0.hostname | regex_replace('-(?!.*-).*')}}.{{cluster_vars.dns_user_domain}}"
+        project: "{{cluster_vars[buildenv].vpc_host_project_id}}"
         service_account_file: "{{gcp_credentials_file}}"
         state: present
-        target: "{{item.hostname}}.{{cluster_vars.dns_user_domain}}"
+        target: "{{item.0.hostname}}.{{cluster_vars.dns_user_domain}}"
         type: CNAME
         ttl: 60
-      with_items: "{{ cluster_hosts_target }}"
+      with_nested:
+        - "{{ cluster_hosts_target }}"
+        - "{{ r__gcp_dns_managed_zone_info.resources | json_query(\"[?dnsName==`\" + cluster_vars.dns_nameserver_zone + \"` && !(peeringConfig)]\") }}"
       become: false
       delegate_to: localhost
       run_once: true

--- a/readiness/tasks/remove_maintenance_mode.yml
+++ b/readiness/tasks/remove_maintenance_mode.yml
@@ -32,7 +32,7 @@
         zone: "{{cluster_vars.region}}-{{item}}"
         filters:
           - "labels.cluster_name = {{cluster_name}}"
-        project: "{{cluster_vars.project_id}}"
+        project: "{{cluster_vars[buildenv].vpc_project_id}}"
         auth_kind: "serviceaccount"
         service_account_file: "{{gcp_credentials_file}}"
         scopes: ["https://www.googleapis.com/auth/compute.readonly"]
@@ -45,7 +45,7 @@
     - name: remove_maintenance_mode/gcp | Set maintenance_mode to false
       gcp_compute_instance:
         name: "{{item.name}}"
-        project: "{{cluster_vars.project_id}}"
+        project: "{{cluster_vars[buildenv].vpc_project_id}}"
         zone: "{{ item.zone | regex_replace('^.*/(.*)$', '\\1') }}"
         auth_kind: "serviceaccount"
         service_account_file: "{{gcp_credentials_file}}"

--- a/redeploy/__common/tasks/poweroff_vms.yml
+++ b/redeploy/__common/tasks/poweroff_vms.yml
@@ -34,7 +34,7 @@
         - name: poweroff_vms | Power-off GCP GCE VM(s) and set maintenance_mode=true
           gcp_compute_instance:
             name: "{{item.name}}"
-            project: "{{cluster_vars.project_id}}"
+            project: "{{cluster_vars[buildenv].vpc_project_id}}"
             zone: "{{ item.regionzone }}"
             auth_kind: "serviceaccount"
             service_account_file: "{{gcp_credentials_file}}"

--- a/redeploy/__common/tasks/poweron_vms.yml
+++ b/redeploy/__common/tasks/poweron_vms.yml
@@ -24,7 +24,7 @@
         - name: poweron_vms | Power-on GCP GCE VM(s)
           gcp_compute_instance:
             name: "{{item.name}}"
-            project: "{{cluster_vars.project_id}}"
+            project: "{{cluster_vars[buildenv].vpc_project_id}}"
             zone: "{{ item.regionzone }}"
             auth_kind: "serviceaccount"
             service_account_file: "{{gcp_credentials_file}}"

--- a/redeploy/__common/tasks/set_lifecycle_state_label.yml
+++ b/redeploy/__common/tasks/set_lifecycle_state_label.yml
@@ -18,7 +18,7 @@
     - name: set_lifecycle_state_label | Change lifecycle_state label on GCP GCE VM
       gcp_compute_instance:
         name: "{{item.name}}"
-        project: "{{cluster_vars.project_id}}"
+        project: "{{cluster_vars[buildenv].vpc_project_id}}"
         zone: "{{ item.regionzone }}"
         auth_kind: "serviceaccount"
         service_account_file: "{{gcp_credentials_file}}"


### PR DESCRIPTION
By having a list of paths under `filebeat_extra_logs_paths`, which can be configured on the `app_vars.yml` of any clusterverse project, we can have more control on the logs being read by FileBeat.

Example configuration:

`app_vars.yml`:
```
filebeat_extra_logs_paths:
  - /var/log/myapplication/*.log
  - /var/log/app2*.log
```