### PR TITLE
Support cleaning of multiple DNS managed zones per DNS name (GCP)

### DIFF
--- a/clean/tasks/clean_dns.yml
+++ b/clean/tasks/clean_dns.yml
@@ -90,10 +90,9 @@
           when: (item.1.set.value is defined)  and  ((item.0.name | regex_replace('-(?!.*-).*')) == (item.1.set.record | regex_replace('^(.*?)\\..*$', '\\1')))  and  (item.0.name == item.1.set.value | regex_replace('^(.*?)\\..*$', '\\1'))
       when: cluster_vars.dns_server == "route53"
 
-
     - name: clean/dns/clouddns | Delete DNS entries from clouddns
       block:
-        - name: clean/dns/clouddns | Get GCP Managed Zone
+        - name: clean/dns/clouddns | Get managed zone(s)
           gcp_dns_managed_zone_info:
             auth_kind: serviceaccount
             dns_name: "{{cluster_vars.dns_nameserver_zone}}"
@@ -101,53 +100,66 @@
             service_account_file: "{{gcp_credentials_file}}"
           register: r__gcp_dns_managed_zone_info
 
-        - block:
-            - assert: { that: "r__gcp_dns_managed_zone_info__non_peered | length <= 1", msg: "Multiple non-peered managed zones with the same DNS is not supported ({{r__gcp_dns_managed_zone_info__non_peered | json_query(\"[].name\") }}) - abort" }
+#        - debug: msg={{r__gcp_dns_managed_zone_info}}
 
-            - name: clean/dns/clouddns | Get DNS entries
-              gcp_dns_resource_record_set_info:
-                auth_kind: serviceaccount
-                managed_zone:
-                  name: "{{r__gcp_dns_managed_zone_info__non_peered.0.name}}"
-                  dnsName: "{{r__gcp_dns_managed_zone_info__non_peered.0.dnsName}}"
-                project: "{{cluster_vars[buildenv].vpc_host_project_id}}"
-                service_account_file: "{{gcp_credentials_file}}"
-              register: r__gcp_dns_resource_record_set_info
+        - name: clean/dns/clouddns | Get all non-peered DNS records for managed zones that match cluster_vars.dns_nameserver_zone
+          gcp_dns_resource_record_set_info:
+            auth_kind: serviceaccount
+            managed_zone:
+              name: "{{item.name}}"
+              dnsName: "{{item.dnsName}}"
+            project: "{{cluster_vars[buildenv].vpc_host_project_id}}"
+            service_account_file: "{{gcp_credentials_file}}"
+          register: r__gcp_dns_resource_record_set_info
+          with_items: "{{r__gcp_dns_managed_zone_info.resources | json_query(\"[?dnsName==`\" + cluster_vars.dns_nameserver_zone + \"` && !(peeringConfig)]\") }}"
+
+#        - debug: msg={{r__gcp_dns_resource_record_set_info}}
+
+        - name: clean/dns/clouddns | Delete A and CNAME records
+          block:
+#            - debug: msg={{gcp_dns_resource_record_set_info__and__gcp_dns_managed_zone_info}}
 
             - name: clean/dns/clouddns | Delete A records
               gcp_dns_resource_record_set:
                 auth_kind: serviceaccount
                 managed_zone:
-                  name: "{{r__gcp_dns_managed_zone_info__non_peered.0.name}}"
-                  dnsName: "{{r__gcp_dns_managed_zone_info__non_peered.0.dnsName}}"
-                name: "{{ item.1.name }}"
+                  name: "{{item.1.managed_zone.name}}"
+                  dnsName: "{{item.1.managed_zone.dnsName}}"
+                name: "{{ item.1.record.name }}"
                 project: "{{cluster_vars[buildenv].vpc_host_project_id}}"
                 service_account_file: "{{gcp_credentials_file}}"
                 state: absent
-                target: "{{ item.1.rrdatas }}"
+                target: "{{ item.1.record.rrdatas }}"
                 type: A
               with_nested:
                 - "{{ hosts_to_clean }}"
-                - "{{ r__gcp_dns_resource_record_set_info.resources | json_query(\"[?type=='A']\") }}"
-              when: item.0.name == (item.1.name | regex_replace('^(.*?)\\..*$', '\\1'))
+                - "{{ gcp_dns_resource_record_set_info__and__gcp_dns_managed_zone_info | json_query(\"[?record.type=='A']\") }}"
+              when: item.0.name == (item.1.record.name | regex_replace('^(.*?)\\..*$', '\\1'))
 
             - name: clean/dns/clouddns | Delete CNAME records
               gcp_dns_resource_record_set:
                 auth_kind: serviceaccount
                 managed_zone:
-                  name: "{{r__gcp_dns_managed_zone_info__non_peered.0.name}}"
-                  dnsName: "{{r__gcp_dns_managed_zone_info__non_peered.0.dnsName}}"
-                name: "{{ item.1.name }}"
+                  name: "{{item.1.managed_zone.name}}"
+                  dnsName: "{{item.1.managed_zone.dnsName}}"
+                name: "{{ item.1.record.name }}"
                 project: "{{cluster_vars[buildenv].vpc_host_project_id}}"
                 service_account_file: "{{gcp_credentials_file}}"
                 state: absent
-                target: "{{ item.1.rrdatas[0] }}"
+                target: "{{ item.1.record.rrdatas[0] }}"
                 type: CNAME
               with_nested:
                 - "{{ hosts_to_clean }}"
-                - "{{ r__gcp_dns_resource_record_set_info.resources | json_query(\"[?type=='CNAME']\") }}"
-              when: ((item.0.name |regex_replace('-(?!.*-).*')) == (item.1.name | regex_replace('^(.*?)\\..*$', '\\1')))  and  (item.0.name == item.1.rrdatas[0] | regex_replace('^(.*?)\\..*$', '\\1'))
+                - "{{ gcp_dns_resource_record_set_info__and__gcp_dns_managed_zone_info | json_query(\"[?record.type=='CNAME']\") }}"
+              when: ((item.0.name |regex_replace('-(?!.*-).*')) == (item.1.record.name | regex_replace('^(.*?)\\..*$', '\\1')))  and  (item.0.name == item.1.record.rrdatas[0] | regex_replace('^(.*?)\\..*$', '\\1'))
           vars:
-            r__gcp_dns_managed_zone_info__non_peered: "{{r__gcp_dns_managed_zone_info.resources | json_query(\"[?dnsName==`\" + cluster_vars.dns_nameserver_zone + \"` && !(peeringConfig)]\") }}"
+            gcp_dns_resource_record_set_info__and__gcp_dns_managed_zone_info: |
+              {%- set res = [] -%}
+              {%- for managed_zone in r__gcp_dns_resource_record_set_info.results -%}
+                {%- for record in managed_zone.resources -%}
+                  {%- set _dummy = res.extend([{ 'managed_zone': {'dnsName': managed_zone.item.dnsName, 'name': managed_zone.item.name}, 'record': record }]) -%}
+                {%- endfor -%}
+              {%- endfor -%}
+              {{ res }}
       when: cluster_vars.dns_server=="clouddns"
   when: hosts_to_clean | length


### PR DESCRIPTION
Support cleaning (creating already supported) of multiple DNS managed zones per DNS name (i.e. same name for both private and public zones).