### PR TITLE
[FEATURE] Improved beats configuration structure

### DIFF
--- a/EXAMPLE/group_vars/_skel/cluster_vars.yml
+++ b/EXAMPLE/group_vars/_skel/cluster_vars.yml
@@ -7,7 +7,13 @@ gcp_credentials_json: "{{ lookup('file', gcp_credentials_file) | default({'proje
 app_name: "test"                  # The name of the application cluster (e.g. 'couchbase', 'nginx'); becomes part of cluster_name.
 app_class: "test"                 # The class of application (e.g. 'database', 'webserver'); becomes part of the fqdn
 
-beats_target_hosts: []            # The destination hosts for e.g. filebeat/ metricbeat logs
+beats_config:
+  filebeat:
+#    output_logstash_hosts: ["localhost:5044"]   # The destination hosts for filebeat-gathered logs
+#    extra_logs_paths: # The array is optional, if you need to add more paths or files to scrape for logs
+#      - /var/log/myapp/*.log 
+  metricbeat:
+#    output_logstash_hosts: ["localhost:5044"]   # The destination hosts for metricbeat-gathered metrics
 
 ## Vulnerability scanners - Tenable and/ or Qualys cloud agents:
 cloud_agent:

--- a/EXAMPLE/group_vars/test_aws_euw1/cluster_vars.yml
+++ b/EXAMPLE/group_vars/test_aws_euw1/cluster_vars.yml
@@ -7,7 +7,13 @@ redeploy_scheme: _scheme_addallnew_rmdisk_rollback
 app_name: "test"                  # The name of the application cluster (e.g. 'couchbase', 'nginx'); becomes part of cluster_name.
 app_class: "test"                 # The class of application (e.g. 'database', 'webserver'); becomes part of the fqdn
 
-beats_target_hosts: []            # The destination hosts for e.g. filebeat/ metricbeat logs
+beats_config:
+  filebeat:
+#    output_logstash_hosts: ["localhost:5044"]   # The destination hosts for filebeat-gathered logs
+#    extra_logs_paths: # The array is optional, if you need to add more paths or files to scrape for logs
+#      - /var/log/myapp/*.log 
+  metricbeat:
+#    output_logstash_hosts: ["localhost:5044"]   # The destination hosts for metricbeat-gathered metrics
 
 ## Vulnerability scanners - Tenable and/ or Qualys cloud agents:
 cloud_agent:

--- a/EXAMPLE/group_vars/test_gcp_euw1/cluster_vars.yml
+++ b/EXAMPLE/group_vars/test_gcp_euw1/cluster_vars.yml
@@ -11,7 +11,13 @@ redeploy_scheme: _scheme_addallnew_rmdisk_rollback
 app_name: "test"                  # The name of the application cluster (e.g. 'couchbase', 'nginx'); becomes part of cluster_name.
 app_class: "test"                 # The class of application (e.g. 'database', 'webserver'); becomes part of the fqdn
 
-beats_target_hosts: []            # The destination hosts for e.g. filebeat/ metricbeat logs
+beats_config:
+  filebeat:
+#    output_logstash_hosts: ["localhost:5044"]   # The destination hosts for filebeat-gathered logs
+#    extra_logs_paths: # The array is optional, if you need to add more paths or files to scrape for logs
+#      - /var/log/myapp/*.log 
+  metricbeat:
+#    output_logstash_hosts: ["localhost:5044"]   # The destination hosts for metricbeat-gathered metrics
 
 ## Vulnerability scanners - Tenable and/ or Qualys cloud agents:
 cloud_agent:

--- a/config/tasks/filebeat.yml
+++ b/config/tasks/filebeat.yml
@@ -17,7 +17,8 @@
   until: yum_jobs is success
   retries: 5
   when: ansible_os_family == 'RedHat'
-  
+
+# the variable "beats_target_hosts" will be deprecated in Clusterverse 4.0
 - name: Filebeat | Configure filebeat
   block:
     - name: Filebeat | Copy filebeat configuration
@@ -33,4 +34,4 @@
         src: lib/systemd/system//filebeat.service.j2
         dest: "/lib/systemd/system/filebeat.service"
       notify: Filebeat | Restart and enable filebeat
-  when: beats_target_hosts is defined and (beats_target_hosts | length)
+  when: (beats_target_hosts is defined and (beats_target_hosts | length)) or (beats_config.filebeat.output_logstash_hosts is defined and (beats_config.filebeat.output_logstash_hosts | length))

--- a/config/tasks/metricbeat.yml
+++ b/config/tasks/metricbeat.yml
@@ -17,7 +17,8 @@
   until: yum_jobs is success
   retries: 5
   when: ansible_os_family == 'RedHat'
-  
+
+# the variable "beats_target_hosts" will be deprecated in Clusterverse 4.0  
 - name: Metricbeat | Configure metricbeat
   block:
     - name: Metricbeat | Copy metricbeat configuration
@@ -33,4 +34,4 @@
         src: lib/systemd/system//metricbeat.service.j2
         dest: "/lib/systemd/system/metricbeat.service"
       notify: Metricbeat | Restart and enable metricbeat
-  when: beats_target_hosts is defined and (beats_target_hosts | length)
+  when: (beats_target_hosts is defined and (beats_target_hosts | length)) or (beats_config.metricbeat.output_logstash_hosts is defined and (beats_config.metricbeat.output_logstash_hosts | length))

--- a/config/templates/etc/filebeat/filebeat.yml.j2
+++ b/config/templates/etc/filebeat/filebeat.yml.j2
@@ -30,7 +30,11 @@ filebeat.inputs:
     - /var/log/messages
     - /var/log/secure
     - /var/log/dmesg
-
+{% if beats_config.filebeat.extra_logs_paths %}
+{% for logpath in beats_config.filebeat.extra_logs_paths %}
+    - {{ logpath }}
+{% endfor %}
+{% endif %}
     #- c:\programdata\elasticsearch\logs\*
 
   # Exclude lines. A list of regular expressions to match. It drops the lines that are
@@ -150,20 +154,23 @@ setup.kibana:
 # Configure what output to use when sending the data collected by the beat.
 
 #-------------------------- Elasticsearch output ------------------------------
-#output.elasticsearch:
+{% if beats_config.filebeat.elasticsearch_output_hosts %}
+output.elasticsearch:
   # Array of hosts to connect to.
-  #hosts: ["localhost:9200"]
-
+  hosts: {{ beats_config.filebeat.output_elasticsearch_hosts | default(beats_target_hosts) }}
+{% endif %}
   # Optional protocol and basic auth credentials.
   #protocol: "https"
   #username: "elastic"
   #password: "changeme"
 
 #----------------------------- Logstash output --------------------------------
+{% if beats_config.filebeat.logstash_output_hosts %}
 output.logstash:
   # The Logstash hosts
-  hosts: {{ beats_target_hosts }}
-
+  # "beats_target_hosts" below refers to a previous Clusterverse release variable, it will be deprecated in Clusterverse 4.0
+  hosts: {{ beats_config.filebeat.output_logstash_hosts | default(beats_target_hosts) }}
+{% endif %}
   # Optional SSL. By default is off.
   # List of root certificates for HTTPS server verifications
   #ssl.certificate_authorities: ["/etc/pki/root/ca.pem"]

--- a/config/templates/etc/filebeat/filebeat.yml.j2
+++ b/config/templates/etc/filebeat/filebeat.yml.j2
@@ -165,7 +165,7 @@ output.elasticsearch:
   #password: "changeme"
 
 #----------------------------- Logstash output --------------------------------
-{% if beats_config.filebeat.logstash_output_hosts %}
+{% if (beats_target_hosts is defined and (beats_target_hosts | length)) or (beats_config.filebeat.output_logstash_hosts is defined and (beats_config.filebeat.output_logstash_hosts | length)) %}
 output.logstash:
   # The Logstash hosts
   # "beats_target_hosts" below refers to a previous Clusterverse release variable, it will be deprecated in Clusterverse 4.0

--- a/config/templates/etc/filebeat/filebeat.yml.j2
+++ b/config/templates/etc/filebeat/filebeat.yml.j2
@@ -154,7 +154,7 @@ setup.kibana:
 # Configure what output to use when sending the data collected by the beat.
 
 #-------------------------- Elasticsearch output ------------------------------
-{% if beats_config.filebeat.elasticsearch_output_hosts %}
+{% if beats_config.filebeat.output_elasticsearch_hosts is defined and (beats_config.filebeat.output_elasticsearch_hosts | length) %}
 output.elasticsearch:
   # Array of hosts to connect to.
   hosts: {{ beats_config.filebeat.output_elasticsearch_hosts | default(beats_target_hosts) }}

--- a/config/templates/etc/metricbeat/metricbeat.yml.j2
+++ b/config/templates/etc/metricbeat/metricbeat.yml.j2
@@ -102,7 +102,7 @@ output.elasticsearch:
   #password: "changeme"
 
 #----------------------------- Logstash output --------------------------------
-{% if beats_config.metricbeat.logstash_output_hosts %}
+{% if (beats_target_hosts is defined and (beats_target_hosts | length)) or (beats_config.metricbeat.output_logstash_hosts is defined and (beats_config.metricbeat.output_logstash_hosts | length)) %}
 output.logstash:
   # The Logstash hosts
   # "beats_target_hosts" below refers to a previous Clusterverse release variable, it will be deprecated in Clusterverse 4.0

--- a/config/templates/etc/metricbeat/metricbeat.yml.j2
+++ b/config/templates/etc/metricbeat/metricbeat.yml.j2
@@ -90,9 +90,11 @@ setup.kibana:
 # Configure what output to use when sending the data collected by the beat.
 
 #-------------------------- Elasticsearch output ------------------------------
-# output.elasticsearch:
+{% if beats_config.metricbeat.elasticsearch_output_hosts %}
+output.elasticsearch:
   # Array of hosts to connect to.
-  # hosts: ["localhost:9200"]
+  hosts: {{ beats_config.metricbeat.output_elasticsearch_hosts | default(beats_target_hosts) }}
+{% endif %}
 
   # Optional protocol and basic auth credentials.
   #protocol: "https"
@@ -100,9 +102,12 @@ setup.kibana:
   #password: "changeme"
 
 #----------------------------- Logstash output --------------------------------
+{% if beats_config.metricbeat.logstash_output_hosts %}
 output.logstash:
   # The Logstash hosts
-  hosts: {{ beats_target_hosts }}
+  # "beats_target_hosts" below refers to a previous Clusterverse release variable, it will be deprecated in Clusterverse 4.0
+  hosts: {{ beats_config.metricbeat.output_logstash_hosts | default(beats_target_hosts) }}
+{% endif %}
 
   # Optional SSL. By default is off.
   # List of root certificates for HTTPS server verifications

--- a/config/templates/etc/metricbeat/metricbeat.yml.j2
+++ b/config/templates/etc/metricbeat/metricbeat.yml.j2
@@ -90,7 +90,7 @@ setup.kibana:
 # Configure what output to use when sending the data collected by the beat.
 
 #-------------------------- Elasticsearch output ------------------------------
-{% if beats_config.metricbeat.elasticsearch_output_hosts %}
+{% if beats_config.metricbeat.output_elasticsearch_hosts is defined and (beats_config.metricbeat.output_elasticsearch_hosts | length) %}
 output.elasticsearch:
   # Array of hosts to connect to.
   hosts: {{ beats_config.metricbeat.output_elasticsearch_hosts | default(beats_target_hosts) }}


### PR DESCRIPTION
As suggested by @dseeley, reworked on the structure for the `beats` configuration:

```
beats_config:
  filebeat:
    output_logstash_hosts: ["localhost:5044"]   # The destination hosts for filebeat-gathered logs
    extra_logs_paths: # The array is optional, if you need to add more paths or files to scrape for logs
      - /var/log/myapp/*.log 
  metricbeat:
    output_logstash_hosts: ["localhost:5044"]   # The destination hosts for metricbeat-gathered metrics
```

NB:
- `beats_target_hosts` is still usable together with the new var `beats_config.filebeat.output_logstash_hosts` to avoid breaking backwards compatibility (the playbook checks for both variables)
- `beats_config.filebeat.elasticsearch_output_hosts` has been added to the configuration, but is not recognised by the playbook nor documented yet. However, it might be useful to implement this in the future (or when making the beats roles part of a separate repository from Clusterverse)

---
- [X] Tested working 13/08