### PR TITLE
Fix the logic that writes the dynamic inventory to file

### DIFF
--- a/EXAMPLE/README.md
+++ b/EXAMPLE/README.md
@@ -1,7 +1,7 @@
 # clusterverse-example  &nbsp; [![License](https://img.shields.io/badge/License-BSD%203--Clause-blue.svg)](https://opensource.org/licenses/BSD-3-Clause) ![PRs Welcome](https://img.shields.io/badge/PRs-Welcome-brightgreen.svg)
 This is an example of a deployment of [clusterverse](https://github.com/sky-uk/clusterverse) - _the full-lifecycle cloud infrastructure cluster management project, using Ansible._
 
-_**Please refer to the full [README.md](https://github.com/sky-uk/clusterverse/blob/master/README.md) in the main  [clusterverse](https://github.com/sky-uk/clusterverse) repository.**_ 
+_**Please refer to the full [README.md](https://github.com/sky-uk/clusterverse/blob/master/README.md) in the main [clusterverse](https://github.com/sky-uk/clusterverse) repository.**_ 
 
 ## Contributing
 Contributions are welcome and encouraged.  Please see [CONTRIBUTING.md](https://github.com/sky-uk/clusterverse/blob/master/CONTRIBUTING.md) for details.
@@ -54,7 +54,7 @@ ansible-playbook -u ubuntu --private-key=/home/<user>/.ssh/<rsa key> cluster.yml
 ### GCP:
 ```
 ansible-playbook -u <username> --private-key=/home/<user>/.ssh/<rsa key> cluster.yml -e buildenv=sandbox -e clusterid=vtp_gcp_euw1 --vault-id=sandbox@.vaultpass-client.py
-ansible-playbook -u <username> --private-key=/home/<user>/.ssh/<rsa key> cluster.yml -e buildenv=sandbox -e clusterid=vtp_gcp_euw1 --vault-id=sandbox@.vaultpass-client.py --tags=clusterverse_clean -e clean=_all_ -e release_version=v1.0.
+ansible-playbook -u <username> --private-key=/home/<user>/.ssh/<rsa key> cluster.yml -e buildenv=sandbox -e clusterid=vtp_gcp_euw1 --vault-id=sandbox@.vaultpass-client.py --tags=clusterverse_clean -e clean=_all_ -e release_version=v1.0.1
 ansible-playbook -u <username> --private-key=/home/<user>/.ssh/<rsa key> cluster.yml -e buildenv=sandbox -e clusterid=vtp_gcp_euw1 --vault-id=sandbox@.vaultpass-client.py -e clean=_all_
 ```
 

--- a/EXAMPLE/ansible.cfg
+++ b/EXAMPLE/ansible.cfg
@@ -11,5 +11,6 @@ interpreter_python = auto
 [ssh_connection]
 retries=5
 ssh_args = -o 'UserKnownHostsFile=/dev/null' -o 'ControlMaster=auto' -o 'ControlPersist=60s'
+#ssh_args = -o 'UserKnownHostsFile=/dev/null' -o 'ControlMaster=auto' -o 'ControlPersist=60s' -o ProxyCommand="ssh -i <proxy_cert> -W %h:%p -q <user>@<host>>"      ##To use with bastion
 pipelining = True
 control_path_dir=/tmp/.ansible/cp

--- a/EXAMPLE/cluster.yml
+++ b/EXAMPLE/cluster.yml
@@ -7,24 +7,24 @@
   tasks:
     - { name: "Get dependent roles via ansible-galaxy", local_action: "command ansible-galaxy install -fr requirements.yml", tags: ["always"] }
 
-    - { include_role: { name: "clusterverse/clean", apply: {tags: &roletag_clean  ["clusterverse_clean"]} }, tags:  *roletag_clean, when: "clean is defined" }
-    - { include_role: { name: "clusterverse/create", apply: {tags: &roletag_create  ["clusterverse_create"]} }, tags:  *roletag_create }
-    - { include_role: { name: "clusterverse/dynamic_inventory", apply: {tags: &roletag_dynamic_inventory  ["clusterverse_dynamic_inventory"]} }, tags:  *roletag_dynamic_inventory }
+    - { include_role: { name: "clusterverse/clean", apply: { tags: ["clusterverse_clean"]} }, tags: ["clusterverse_clean"], when: "clean is defined"  }
+    - { include_role: { name: "clusterverse/create", apply: { tags: ["clusterverse_create"]} }, tags: ["clusterverse_create"] }
+    - { include_role: { name: "clusterverse/dynamic_inventory", apply: { tags: ["clusterverse_dynamic_inventory"]} }, tags: ["clusterverse_dynamic_inventory"] }
 
 - name: Configure the cluster
   hosts: all
   tasks:
-    - { include_role: { name: "clusterverse/config", apply: {tags: &roletag_config  ["clusterverse_config"]} }, tags:  *roletag_config }
+    - { include_role: { name: "clusterverse/config", apply: { tags: ["clusterverse_config"]} }, tags: ["clusterverse_config"] }
 
 ## Application roles
 - name: Application roles
   hosts: all
   tasks:
-    - { include_role: { name: "testrole", apply: {tags: &roletag_testrole  ["testrole"]} }, tags:  *roletag_testrole }
+    - { include_role: { name: "testrole", apply: { tags: ["testrole"]} }, tags: ["testrole"] }
 ##
 
 - name: Perform cluster readiness operations
   hosts: localhost
   connection: local
   tasks:
-    - { include_role: { name: "clusterverse/readiness", apply: {tags: &roletag_readiness  ["clusterverse_readiness"]} }, tags:  *roletag_readiness }
+    - { include_role: { name: "clusterverse/readiness", apply: { tags: ["clusterverse_readiness"]} }, tags: ["clusterverse_readiness"] }

--- a/EXAMPLE/group_vars/_skel/cluster_vars.yml
+++ b/EXAMPLE/group_vars/_skel/cluster_vars.yml
@@ -11,7 +11,7 @@ beats_config:
   filebeat:
 #    output_logstash_hosts: ["localhost:5044"]   # The destination hosts for filebeat-gathered logs
 #    extra_logs_paths: # The array is optional, if you need to add more paths or files to scrape for logs
-#      - /var/log/myapp/*.log 
+#      - /var/log/myapp/*.log
   metricbeat:
 #    output_logstash_hosts: ["localhost:5044"]   # The destination hosts for metricbeat-gathered metrics
 

--- a/EXAMPLE/group_vars/_skel/cluster_vars.yml
+++ b/EXAMPLE/group_vars/_skel/cluster_vars.yml
@@ -42,7 +42,8 @@ cluster_name: "{{app_name}}-{{buildenv}}"       # Identifies the cluster within 
 ### AWS example
 #cluster_vars:
 #  type: &cloud_type "aws"
-#  image: "ami-0964eb2dc8b836eb6"    # eu-west-1, 18.04, amd64, hvm-ssd, 20200430.  Ubuntu images can be located at https://cloud-images.ubuntu.com/locator/
+#  image: "ami-0c4c42893066a139e"            # eu-west-1, 20.04, amd64, hvm-ssd, 20200924.  Ubuntu images can be located at https://cloud-images.ubuntu.com/locator/
+#  image: "ami-06868ad5a3642e4d7"            # eu-west-1, 18.04, amd64, hvm-ssd, 20200923.  Ubuntu images can be located at https://cloud-images.ubuntu.com/locator/
 #  region: &region "eu-west-1"       # eu-west-1, us-west-2
 #  dns_cloud_internal_domain: "{{_region}}.compute.internal"                       # The cloud-internal zone as defined by the cloud provider (e.g. GCP, AWS)
 #  dns_nameserver_zone: &dns_nameserver_zone ""                                    # The zone that dns_server will operate on.  gcloud dns needs a trailing '.'.  Leave blank if no external DNS (use IPs only)
@@ -89,10 +90,11 @@ cluster_name: "{{app_name}}-{{buildenv}}"       # Identifies the cluster within 
 ### GCP example
 #cluster_vars:
 #  type: &cloud_type "gcp"
-#  image: "projects/ubuntu-os-cloud/global/images/ubuntu-1804-bionic-v20200430"    # Ubuntu images can be located at https://cloud-images.ubuntu.com/locator/
+#  image: "projects/ubuntu-os-cloud/global/images/ubuntu-2004-focal-v20200917"    # Ubuntu images can be located at https://cloud-images.ubuntu.com/locator/
+#  image: "projects/ubuntu-os-cloud/global/images/ubuntu-1804-bionic-v20200923"   # Ubuntu images can be located at https://cloud-images.ubuntu.com/locator/
 #  region: &region "europe-west1"
-#  dns_cloud_internal_domain: "c.{{gcp_credentials_json.project_id}}.internal"     # The cloud-internal zone as defined by the cloud provider (e.g. GCP, AWS)
-#  dns_nameserver_zone: &dns_nameserver_zone ""                                    # The zone that dns_server will operate on.  gcloud dns needs a trailing '.'.  Leave blank if no external DNS (use IPs only)
+#  dns_cloud_internal_domain: "c.{{gcp_credentials_json.project_id}}.internal"    # The cloud-internal zone as defined by the cloud provider (e.g. GCP, AWS)
+#  dns_nameserver_zone: &dns_nameserver_zone ""                                   # The zone that dns_server will operate on.  gcloud dns needs a trailing '.'.  Leave blank if no external DNS (use IPs only)
 #  dns_user_domain: "{%- if _dns_nameserver_zone -%}CUSTOM.PREFIXES.{{_dns_nameserver_zone}}{%- endif -%}"         # A user-defined _domain_ part of the FDQN, (if more prefixes are required before the dns_nameserver_zone)
 #  dns_server: ""                            # Specify DNS server. nsupdate, route53 or clouddns.  If empty string is specified, no DNS will be added.
 #  assign_public_ip: "yes"

--- a/EXAMPLE/group_vars/test_aws_euw1/cluster_vars.yml
+++ b/EXAMPLE/group_vars/test_aws_euw1/cluster_vars.yml
@@ -11,7 +11,7 @@ beats_config:
   filebeat:
 #    output_logstash_hosts: ["localhost:5044"]   # The destination hosts for filebeat-gathered logs
 #    extra_logs_paths: # The array is optional, if you need to add more paths or files to scrape for logs
-#      - /var/log/myapp/*.log 
+#      - /var/log/myapp/*.log
   metricbeat:
 #    output_logstash_hosts: ["localhost:5044"]   # The destination hosts for metricbeat-gathered metrics
 

--- a/EXAMPLE/group_vars/test_aws_euw1/cluster_vars.yml
+++ b/EXAMPLE/group_vars/test_aws_euw1/cluster_vars.yml
@@ -41,7 +41,8 @@ cluster_name: "{{app_name}}-{{buildenv}}"       # Identifies the cluster within 
 
 cluster_vars:
   type: &cloud_type "aws"
-  image: "ami-0964eb2dc8b836eb6"    # eu-west-1, 18.04, amd64, hvm-ssd, 20200430.  Ubuntu images can be located at https://cloud-images.ubuntu.com/locator/
+  image: "ami-0c4c42893066a139e"            # eu-west-1, 20.04, amd64, hvm-ssd, 20200924.  Ubuntu images can be located at https://cloud-images.ubuntu.com/locator/
+#  image: "ami-06868ad5a3642e4d7"            # eu-west-1, 18.04, amd64, hvm-ssd, 20200923.  Ubuntu images can be located at https://cloud-images.ubuntu.com/locator/
   region: &region "eu-west-1"       # eu-west-1, us-west-2
   dns_cloud_internal_domain: "{{_region}}.compute.internal"   # The cloud-internal zone as defined by the cloud provider (e.g. GCP, AWS)
   dns_nameserver_zone: &dns_nameserver_zone ""                # The zone that dns_server will operate on.  gcloud dns needs a trailing '.'.  Leave blank if no external DNS (use IPs only)

--- a/EXAMPLE/group_vars/test_gcp_euw1/cluster_vars.yml
+++ b/EXAMPLE/group_vars/test_gcp_euw1/cluster_vars.yml
@@ -15,7 +15,7 @@ beats_config:
   filebeat:
 #    output_logstash_hosts: ["localhost:5044"]   # The destination hosts for filebeat-gathered logs
 #    extra_logs_paths: # The array is optional, if you need to add more paths or files to scrape for logs
-#      - /var/log/myapp/*.log 
+#      - /var/log/myapp/*.log
   metricbeat:
 #    output_logstash_hosts: ["localhost:5044"]   # The destination hosts for metricbeat-gathered metrics
 

--- a/EXAMPLE/group_vars/test_gcp_euw1/cluster_vars.yml
+++ b/EXAMPLE/group_vars/test_gcp_euw1/cluster_vars.yml
@@ -45,7 +45,8 @@ cluster_name: "{{app_name}}-{{buildenv}}"       # Identifies the cluster within 
 
 cluster_vars:
   type: &cloud_type "gcp"
-  image: "projects/ubuntu-os-cloud/global/images/ubuntu-1804-bionic-v20200430"  # Ubuntu images can be located at https://cloud-images.ubuntu.com/locator/
+  image: "projects/ubuntu-os-cloud/global/images/ubuntu-2004-focal-v20200917"   # Ubuntu images can be located at https://cloud-images.ubuntu.com/locator/
+#  image: "projects/ubuntu-os-cloud/global/images/ubuntu-1804-bionic-v20200923"  # Ubuntu images can be located at https://cloud-images.ubuntu.com/locator/
   region: &region "europe-west1"
   dns_cloud_internal_domain: "c.{{gcp_credentials_json.project_id}}.internal"   # The cloud-internal zone as defined by the cloud provider (e.g. GCP, AWS)
   dns_nameserver_zone: &dns_nameserver_zone ""                                  # The zone that dns_server will operate on.  gcloud dns needs a trailing '.'.  Leave blank if no external DNS (use IPs only)

--- a/_dependencies/defaults/main.yml
+++ b/_dependencies/defaults/main.yml
@@ -3,9 +3,6 @@
 # Identifies the application version that is being deployed (optional)
 release_version: ""
 
-# Default redeploy scheme
-redeploy_scheme: _scheme_addnewvm_rmdisk_rollback
-
 # Default Prometheus node exporter configurations
 prometheus_node_exporter_install: true                    # Whether to install the prometheus node_exporter tool
 prometheus_node_exporter_port: "19100"                    # Port to export metrics to.  The default (9100), conflicts with a Couchbase port, and prevents couchbase working.

--- a/dynamic_inventory/tasks/main.yml
+++ b/dynamic_inventory/tasks/main.yml
@@ -22,7 +22,7 @@
 - name: dynamic_inventory | Add hosts to dynamic inventory
   add_host:
     name: "{{ item.hostname }}"
-    groups: "{{ item.hosttype }},{{ cluster_name }},{{ clusterid }}{%- if 'regionzone' in item -%},{{ item.regionzone }}{%- endif -%}"
+    groups: "{{ item.hosttype }},{{ cluster_name }},{{ clusterid }}{% if 'regionzone' in item %},{{ item.regionzone }}{% endif %}"
     ansible_host: "{{ item.inventory_ip }}"
     hosttype: "{{ item.hosttype }}"
     regionzone: "{{ item.regionzone | default(omit) }}"
@@ -40,7 +40,7 @@
       {% if groupname not in ["all", "ungrouped"] -%}
       [{{ groupname }}]
       {% for hostname in groups[groupname] %}
-      {{ hostname }} ansible_host={{hostvars[hostname].ansible_host}} hosttype={{ hostvars[hostname].hosttype }} {%- if 'regionzone' in hostvars[hostname] -%}regionzone={{ hostvars[hostname].regionzone }}{%- endif -%}
+      {{ hostname }} ansible_host={{hostvars[hostname].ansible_host}} hosttype={{ hostvars[hostname].hosttype }} {% if 'regionzone' in hostvars[hostname] %}regionzone={{ hostvars[hostname].regionzone }}{% endif %}{{''}}
       {% endfor %}
 
       {% endif %}


### PR DESCRIPTION
+ Jinja2 in Ansible is set to always delete whitespace before and after the expression, so the lines of inventory are concatenated. Fix the logic, by adding a "{{''}}" to the end of the jinja2 expression.
+ Simplify the EXAMPLE/cluster.yml to remove the anchors and aliases (& and *), which add no value here as they have to be duplicated instead of the tags they're referencing.