### PR TITLE
[FEATURE] Enable Metricbeat diskio module

### DIFF
--- a/EXAMPLE/group_vars/test_aws_euw1/cluster_vars.yml
+++ b/EXAMPLE/group_vars/test_aws_euw1/cluster_vars.yml
@@ -14,6 +14,8 @@ beats_config:
 #      - /var/log/myapp/*.log
   metricbeat:
 #    output_logstash_hosts: ["localhost:5044"]   # The destination hosts for metricbeat-gathered metrics
+#    diskio:                       # Diskio retrieves metrics for all disks partitions by default. When diskio.include_devices is defined, only look for defined partitions
+#      include_devices: ["sda", "sdb", "nvme0n1", "nvme1n1", "nvme2n1"]     
 
 ## Vulnerability scanners - Tenable and/ or Qualys cloud agents:
 cloud_agent:

--- a/EXAMPLE/group_vars/test_gcp_euw1/cluster_vars.yml
+++ b/EXAMPLE/group_vars/test_gcp_euw1/cluster_vars.yml
@@ -18,6 +18,8 @@ beats_config:
 #      - /var/log/myapp/*.log
   metricbeat:
 #    output_logstash_hosts: ["localhost:5044"]   # The destination hosts for metricbeat-gathered metrics
+#    diskio:                       # Diskio retrieves metrics for all disks partitions by default. When diskio.include_devices is defined, only look for defined partitions
+#      include_devices: ["sda", "sdb", "nvme0n1", "nvme1n1", "nvme2n1"]
 
 ## Vulnerability scanners - Tenable and/ or Qualys cloud agents:
 cloud_agent:

--- a/config/tasks/metricbeat.yml
+++ b/config/tasks/metricbeat.yml
@@ -28,6 +28,13 @@
         dest: "/etc/metricbeat/metricbeat.yml"
       notify: Metricbeat | Restart and enable metricbeat
 
+    - name: Metricbeat | Copy metricbeat system module configuration
+      become: yes
+      template:
+        src: etc/metricbeat/metricbeat_system.yml.j2
+        dest: "/etc/metricbeat/modules.d/system.yml"
+      notify: Metricbeat | Restart and enable metricbeat
+
     - name: Metricbeat | Copy metricbeat service
       become: yes
       template:

--- a/config/templates/etc/metricbeat/metricbeat_system.yml.j2
+++ b/config/templates/etc/metricbeat/metricbeat_system.yml.j2
@@ -1,0 +1,37 @@
+# Module: system
+# Docs: https://www.elastic.co/guide/en/beats/metricbeat/7.5/metricbeat-module-system.html
+
+- module: system
+  period: 10s
+  metricsets:
+    - cpu
+    - load
+    - memory
+    - network
+    - process
+    - process_summary
+    - socket_summary
+    - diskio
+    #- entropy
+    #- core
+    #- socket
+  process.include_top_n:
+    by_cpu: 5      # include top 5 processes by CPU
+    by_memory: 5   # include top 5 processes by memory
+{% if (metricbeat.diskio.include_devices is defined and (metricbeat.diskio.include_devices | length)) %}
+# Custom diskio settings
+  diskio.include_devices: {{ metricbeat.diskio.include_devices }} 
+{% endif %}
+- module: system
+  period: 1m
+  metricsets:
+    - filesystem
+    - fsstat
+  processors:
+  - drop_event.when.regexp:
+      system.filesystem.mount_point: '^/(sys|cgroup|proc|dev|etc|host|lib|snap)($|/)'
+
+- module: system
+  period: 15m
+  metricsets:
+    - uptime


### PR DESCRIPTION
This PR enables Metricbeat to ship disks related metrics such as incoming/outgoing read/writes per second and iowait.

- Enables Metricbeat diskio system module
- Provides default configuration template for mb system module
- Diskio looks for all partitions by default when undefined; when defined as below in `cluster_vars.yml`, looks for the desired partitions only:
```bash
  metricbeat:
    output_logstash_hosts: ["localhost:5044"]  
    diskio:
      include_devices: ["sda", "sdb", "nvme0n1", "nvme1n1", "nvme2n1"]
```