### PR TITLE
[FIX] Replaced qualys agents to be pulled from github repo

### DIFF
--- a/EXAMPLE/group_vars/_skel/cluster_vars.yml
+++ b/EXAMPLE/group_vars/_skel/cluster_vars.yml
@@ -28,7 +28,8 @@ cloud_agent:
 #    proxy: {host: "", port: ""}
 #  qualys:
 #    service: "qualys-cloud-agent"
-#    debpackage: ""
+#    github_release: ""
+#    bin_name: ""
 #    bin_path: "/usr/local/qualys/cloud-agent/bin"
 #    config_path: "/etc/default/qualys-cloud-agent"
 #    activation_id: ""

--- a/EXAMPLE/group_vars/test_aws_euw1/cluster_vars.yml
+++ b/EXAMPLE/group_vars/test_aws_euw1/cluster_vars.yml
@@ -31,7 +31,8 @@ cloud_agent:
 #    proxy: {host: "", port: ""}
 #  qualys:
 #    service: "qualys-cloud-agent"
-#    debpackage: ""
+#    github_release: ""
+#    bin_name: ""
 #    bin_path: "/usr/local/qualys/cloud-agent/bin"
 #    config_path: "/etc/default/qualys-cloud-agent"
 #    activation_id: ""

--- a/EXAMPLE/group_vars/test_gcp_euw1/cluster_vars.yml
+++ b/EXAMPLE/group_vars/test_gcp_euw1/cluster_vars.yml
@@ -35,7 +35,8 @@ cloud_agent:
 #    proxy: {host: "", port: ""}
 #  qualys:
 #    service: "qualys-cloud-agent"
-#    debpackage: ""
+#    github_release: ""
+#    bin_name: ""
 #    bin_path: "/usr/local/qualys/cloud-agent/bin"
 #    config_path: "/etc/default/qualys-cloud-agent"
 #    activation_id: ""

--- a/config/tasks/cloud_agents.yml
+++ b/config/tasks/cloud_agents.yml
@@ -11,12 +11,10 @@
         headers:
           Accept: "application/vnd.github.v3+json"
       register: github_list_qualys
-    - set_fact: 
-        qualys_url: "{{ github_list_qualys | json_query('json[].assets[?name==`'+ cloud_agent.qualys.bin_name +'`].url[] | [0]') }}"
 
     - name: cloud_agents | Get latest Qualys agent
       uri:
-        url: "{{ qualys_url }}"
+        url: "{{ github_list_qualys | json_query('json[].assets[?name=='+ cloud_agent.qualys.bin_name +'].url[] | [0]') }}"
         follow_redirects: none
         status_code: 302
         return_content: no

--- a/config/tasks/cloud_agents.yml
+++ b/config/tasks/cloud_agents.yml
@@ -2,6 +2,37 @@
 
 - name: cloud_agents | Qualys cloud agent
   block:
+    - name: cloud_agents | Retrieve Qualys agents from github
+      uri:
+        url: "{{ cloud_agent.qualys.github_release }}"
+        force_basic_auth: yes
+        url_username: "{{ environment_credentials.github_username }}"
+        url_password: "{{ environment_credentials.github_password }}"
+        headers:
+          Accept: "application/vnd.github.v3+json"
+      register: github_list_qualys
+    - set_fact: 
+        qualys_url: "{{ github_list_qualys | json_query('json[].assets[?name==`'+ cloud_agent.qualys.bin_name +'`].url[] | [0]') }}"
+
+    - name: cloud_agents | Get latest Qualys agent
+      uri:
+        url: "{{ qualys_url }}"
+        follow_redirects: none
+        status_code: 302
+        return_content: no
+        force_basic_auth: yes
+        url_username: "{{ environment_credentials.github_username }}"
+        url_password: "{{ environment_credentials.github_password }}"
+        headers:
+          Accept: "application/octet-stream"
+      register: qualys_release_file
+
+    - name: cloud_agents | Download Qualys agents to tmp directory
+      get_url:
+        url: "{{ qualys_release_file.location }}"
+        dest: "/tmp/{{ cloud_agent.qualys.bin_name }}"
+        mode: 0755
+    
     - name: cloud_agents | Remove existing Qualys cloud agent pkg Debian
       become: yes
       apt:
@@ -12,7 +43,7 @@
     - name: cloud_agents | Download and install Qualys cloud agent pkg Debian
       become: yes
       apt:
-        deb: "{{ cloud_agent.qualys.debpackage }}"
+        deb: "/tmp/{{ cloud_agent.qualys.bin_name }}"
         state: present
       when: ansible_os_family == 'Debian'
     


### PR DESCRIPTION
Moved from downloading qualys agent from S3 bucket to security github repo.

I have tested this with Jenkins build with Giuseppe and Antoine