### PR TITLE
Fix the misleading rollback error messages, when failure occurs in include_tasks.

### DIFF
--- a/redeploy/_scheme_addallnew_rmdisk_rollback/tasks/main.yml
+++ b/redeploy/_scheme_addallnew_rmdisk_rollback/tasks/main.yml
@@ -19,7 +19,7 @@
       include_tasks: rescue.yml
 
     - name: rescue | force fail from block so Jenkins gets error code.  (If we prefer not to fail, we should otherwise 'meta end_play' to prevent tidying of pre-rescued VMs)
-      fail: { msg: "Task '{{ansible_failed_task.name}}' failed in block.    Error message was: '{{ansible_failed_result.msg}}'" }
+      fail: { msg: ["Task '{{ansible_failed_task.name}}' failed in block (but rescued)", "{{ansible_failed_result.msg}}"] }
   when: canary!="tidy"
 
 

--- a/redeploy/_scheme_addnewvm_rmdisk_rollback/tasks/main.yml
+++ b/redeploy/_scheme_addnewvm_rmdisk_rollback/tasks/main.yml
@@ -27,12 +27,12 @@
 
     - name: Run redeploy per hosttype.  Create one at a time, then stop previous.
       include_tasks: redeploy_by_hosttype.yml
-      with_items: "{{ myhosttypes_array }}"
+      with_items: "{{ myhosttypes_array | default([]) }}"
       loop_control:
         loop_var: hosttype
       vars:
-        cluster_hosts_target_by_hosttype: "{{cluster_hosts_target | dict_agg('hosttype')}}"
-        myhosttypes_array: "{%- if myhosttypes is defined -%} {{ myhosttypes.split(',') }} {%- else -%} {{ cluster_hosts_target_by_hosttype.keys() | list }} {%- endif -%}"
+        cluster_hosts_target_by_hosttype: "{{cluster_hosts_target | default({}) | dict_agg('hosttype') }}"
+        myhosttypes_array: "{%- if myhosttypes is defined -%}{{ myhosttypes.split(',') }}{%- elif cluster_hosts_target_by_hosttype is defined and cluster_hosts_target_by_hosttype.keys() | length -%}{{ cluster_hosts_target_by_hosttype.keys() | list }}{%- else -%}[]{%- endif -%}"
 
     - name: Remove any other retiring VM(s) that might exist if we're redeploying to a smaller topology.
       block:
@@ -63,7 +63,7 @@
       include_tasks: rescue.yml
 
     - name: rescue | force fail from block so Jenkins gets error code.  (If we prefer not to fail, we should otherwise 'meta end_play' to prevent tidying of pre-rescued VMs)
-      fail: { msg: "Task '{{ansible_failed_task.name}}' failed in block.    Error message was: '{{ansible_failed_result.msg}}'" }
+      fail: { msg: ["Task '{{ansible_failed_task.name}}' failed in block (but rescued)", "{{ansible_failed_result.msg}}"] }
   when: canary!="tidy"
 
 

--- a/redeploy/_scheme_rmvm_keepdisk_rollback/tasks/main.yml
+++ b/redeploy/_scheme_rmvm_keepdisk_rollback/tasks/main.yml
@@ -30,12 +30,12 @@
 
     - name: Run redeploy per hosttype.  Create one at a time, then stop previous.
       include_tasks: by_hosttype.yml
-      with_items: "{{ myhosttypes_array }}"
+      with_items: "{{ myhosttypes_array | default([]) }}"
       loop_control:
         loop_var: hosttype
       vars:
-        cluster_hosts_target_by_hosttype: "{{cluster_hosts_target | dict_agg('hosttype')}}"
-        myhosttypes_array: "{%- if myhosttypes is defined -%} {{ myhosttypes.split(',') }} {%- else -%} {{ cluster_hosts_target_by_hosttype.keys() | list }} {%- endif -%}"
+        cluster_hosts_target_by_hosttype: "{{cluster_hosts_target | default({}) | dict_agg('hosttype') }}"
+        myhosttypes_array: "{%- if myhosttypes is defined -%}{{ myhosttypes.split(',') }}{%- elif cluster_hosts_target_by_hosttype is defined and cluster_hosts_target_by_hosttype.keys() | length -%}{{ cluster_hosts_target_by_hosttype.keys() | list }}{%- else -%}[]{%- endif -%}"
 
     - fail:
       when: testfail is defined and testfail == "fail_1"
@@ -89,7 +89,7 @@
         myhosttypes_array: "{%- if myhosttypes is defined -%} {{ myhosttypes.split(',') }} {%- else -%} {{ cluster_hosts_target_by_hosttype.keys() | list }} {%- endif -%}"
 
     - name: rescue | force fail from block so Jenkins gets error code.  (If we prefer not to fail, we should otherwise 'meta end_play' to prevent tidying of pre-rescued VMs)
-      fail: { msg: "Task '{{ansible_failed_task.name}}' failed in block.    Error message was: '{{ansible_failed_result.msg}}'" }
+      fail: { msg: ["Task '{{ansible_failed_task.name}}' failed in block (but rescued)", "{{ansible_failed_result.msg}}"] }
   when: canary!="tidy"
 
 


### PR DESCRIPTION


Because playbook failure can occur in include_tasks, variables that are used in those tasks have to be resolved, which doesn't happen after the failure has occurred (and the variables they depended on have changed) so we need to default the variables.