### PR TITLE
GCP credentials fix: _dependencies/main.yml

### DIFF
--- a/_dependencies/tasks/main.yml
+++ b/_dependencies/tasks/main.yml
@@ -57,7 +57,7 @@
   block:
     - name: "set gcp_credentials_file fact"
       set_fact:
-        gcp_credentials_file: "gcp__{{ (cluster_vars[buildenv].gcp_service_account_rawtext | string | from_json).project_id }}.json"
+        gcp_credentials_file: "gcp__{{ (cluster_vars[buildenv].gcp_service_account_rawtext if cluster_vars[buildenv].gcp_service_account_rawtext|type_debug == 'dict' else cluster_vars[buildenv].gcp_service_account_rawtext | string | from_json).project_id }}.json"
       when: gcp_credentials_file is not defined
 
     - name: dynamic_inventory | stat the gcp_credentials_file
@@ -66,5 +66,5 @@
 
     - name: "Copy credentials into gcp_credentials_file as {{gcp_credentials_file}}"
       local_action: copy content={{cluster_vars[buildenv].gcp_service_account_rawtext}} dest={{gcp_credentials_file}}
-      when: not (stat_inventory_file.stat is defined and stat_inventory_file.stat.exists|bool == false )
+      when: not r__stat_gcp_credentials_file.stat.exists|default(False)|bool
   when: cluster_vars.type == "gcp"


### PR DESCRIPTION
- incorrect stat is used in copy credentials which caused problems when **gcp_credentials_file** is defined by user
- add ability to use dict in **cluster_vars[buildenv].gcp_service_account_rawtext** which helps with external secret source(aka hashi vault)