### PR TITLE
Fix ec2_vol volume_size parameter

### DIFF
--- a/create/tasks/aws.yml
+++ b/create/tasks/aws.yml
@@ -93,7 +93,7 @@
         snapshot: "{{item.auto_volume.snapshot | default(omit)}}"
         device_name: "{{item.auto_volume.device_name}}"
         encrypted: "{{item.auto_volume.encrypted}}"
-        volume_size: "{%- if 'src' not in item.auto_volume -%}{{item.auto_volume.volume_size}}{%- endif -%}"
+        volume_size: "{%- if 'src' in item.auto_volume -%}{{omit}}{%- else -%}{{item.auto_volume.volume_size}}{%- endif -%}"
         volume_type: "{{item.auto_volume.volume_type}}"
         delete_on_termination: yes
       loop: "{{ cluster_hosts_target_denormalised_by_volume | selectattr('auto_volume.src', 'defined') | list }}"


### PR DESCRIPTION
In newer Ansible versions (i.e. 2.10.6) the ec2_vol module does not accept an empty volume_size var if attaching an existing volume. Volume_size param should not exist in this case. This issue has been observed while redeploying (scheme _scheme_rmvm_keepdisk_rollback):

TASK [create/aws | Attach (or create) volumes where 'src' is present (e.g. inserted as part of _scheme_rmvm_keepdisk_rollback scheme)]
fatal: [localhost]: FAILED! => changed=false
  msg: 'argument volume_size is of type <class ''str''> and we were unable to convert to int: <class ''str''> cannot be converted to an int'

The change has been successfully tested in creation (cluster.yml) and redeploy (redeploy.yml) playbooks.