### PR TITLE
[FEATURE] Add close_timeout to filebeat config

### DIFF
--- a/config/templates/etc/filebeat/filebeat.yml.j2
+++ b/config/templates/etc/filebeat/filebeat.yml.j2
@@ -37,14 +37,6 @@ filebeat.inputs:
 {% endif %}
     #- c:\programdata\elasticsearch\logs\*
 
-{% if filebeat_close_timeout is defined %}
-  # Close timeout closes the harvester after the predefined time.
-  # This is independent if the harvester did finish reading the file or not.
-  # By default this option is disabled.
-  # Note: Potential data loss. Make sure to read and understand the docs for this option.
-  close_timeout: {{ filebeat_close_timeout }}
-{% endif %}
-
   # Exclude lines. A list of regular expressions to match. It drops the lines that are
   # matching any regular expression from the list.
   #exclude_lines: ['^DBG']
@@ -79,6 +71,13 @@ filebeat.inputs:
   # Note: After is the equivalent to previous and before is the equivalent to to next in Logstash
   #multiline.match: after
 
+{% if filebeat_close_timeout is defined %}
+  # Close timeout closes the harvester after the predefined time.
+  # This is independent if the harvester did finish reading the file or not.
+  # By default this option is disabled.
+  # Note: Potential data loss. Make sure to read and understand the docs for this option.
+  close_timeout: {{ filebeat_close_timeout }}
+{% endif %}
 
 #============================= Filebeat modules ===============================
 

--- a/config/templates/etc/filebeat/filebeat.yml.j2
+++ b/config/templates/etc/filebeat/filebeat.yml.j2
@@ -37,6 +37,14 @@ filebeat.inputs:
 {% endif %}
     #- c:\programdata\elasticsearch\logs\*
 
+{% if filebeat_close_timeout is defined %}
+  # Close timeout closes the harvester after the predefined time.
+  # This is independent if the harvester did finish reading the file or not.
+  # By default this option is disabled.
+  # Note: Potential data loss. Make sure to read and understand the docs for this option.
+  close_timeout: {{ filebeat_close_timeout }}
+{% endif %}
+
   # Exclude lines. A list of regular expressions to match. It drops the lines that are
   # matching any regular expression from the list.
   #exclude_lines: ['^DBG']

--- a/config/templates/etc/filebeat/filebeat.yml.j2
+++ b/config/templates/etc/filebeat/filebeat.yml.j2
@@ -71,12 +71,12 @@ filebeat.inputs:
   # Note: After is the equivalent to previous and before is the equivalent to to next in Logstash
   #multiline.match: after
 
-{% if filebeat_close_timeout is defined %}
+{% if beats_config.filebeat.close_timeout is defined %}
   # Close timeout closes the harvester after the predefined time.
   # This is independent if the harvester did finish reading the file or not.
   # By default this option is disabled.
   # Note: Potential data loss. Make sure to read and understand the docs for this option.
-  close_timeout: {{ filebeat_close_timeout }}
+  close_timeout: {{ beats_config.filebeat.close_timeout }}
 {% endif %}
 
 #============================= Filebeat modules ===============================


### PR DESCRIPTION
If defined, `close_timeout` will help preventing filebeat from retaining logs files which might cause the disk to be filled up