### PR TITLE
Enable Ansible 4. Optionally use route53_info to get record sets for delete

### DIFF
--- a/EXAMPLE/jenkinsfiles/Jenkinsfile_ops
+++ b/EXAMPLE/jenkinsfiles/Jenkinsfile_ops
@@ -22,13 +22,13 @@ def create_custom_image(image_name, params = "") {
             ENV HOME=${env.JENKINS_HOME}
             ENV PIPENV_VENV_IN_PROJECT=true
             ENV TZ=Europe/London
+            RUN groupadd -g ${jenkins_gid} ${jenkins_username} && useradd -m -u ${jenkins_uid} -g ${jenkins_gid} -s /bin/bash ${jenkins_username}
             ### Note: use pip to install pipenv (not apt) to avoid pypa/pipenv#2196 (when using PIPENV_VENV_IN_PROJECT)
             RUN apt-get update \
                 && apt-get install -y git iproute2 \
                       python3-boto python3-boto3 python3-botocore python3-dev python3-distutils python3-dnspython python3-google-auth python3-googleapi python3-libcloud python3-jinja2 python3-jmespath python3-netaddr python3-paramiko python3-pip python3-ruamel.yaml python3-setuptools python3-wheel python3-xmltodict \
-                && pip3 install pipenv ansible \
+                && pip3 install pipenv ansible>=4.2.0 \
                 && pip3 install -r \$(pip3 show ansible | grep ^Location | sed 's/Location: \\(.*\\)/\\1/')/ansible_collections/azure/azcollection/requirements-azure.txt
-            RUN groupadd -g ${jenkins_gid} ${jenkins_username} && useradd -m -u ${jenkins_uid} -g ${jenkins_gid} -s /bin/bash ${jenkins_username}
             """.stripIndent()
 
         writeFile(file: "Dockerfile", text: dockerfile, encoding: "UTF-8")
@@ -72,23 +72,33 @@ node {
     sh 'printenv | sort'
     echo "Params: $params"
 
-    def docker_parent_net_str = ""
-    if (sh(script: 'grep -sq "docker\\|lxc" /proc/1/cgroup', returnStatus: true) == 0) {
-        println("Running in docker.  Getting network to pass to docker-in-docker containers...")
-        def docker_parent_net_id = sh(script: 'docker inspect  $(basename $(cat /proc/1/cpuset)) -f "{{ range .NetworkSettings.Networks }}{{println .NetworkID}}{{end}}" | head -n 1', returnStdout: true).trim()
-        docker_parent_net_str = "--network ${docker_parent_net_id}"
-        println("docker_parent_net_str: ${docker_parent_net_str}")
-    }
-
     if (params.BUILDENV && params.CLUSTER_ID && params.CLOUD_REGION) {
+        println("Checkout SCS from SCM...")
+        try {
+            checkout(scm)
+        } catch (Exception e) {
+            println("scm not available: " + e.toString())
+            println("we're probably *not* running in a multibranch or pipeline scm job, so we will checkout from the default (${PROJECT_BRANCH_DEFAULT}) branch")
+            checkout([$class: 'GitSCM', branches: [[name: "*${DEFAULT_CLUSTERVERSE_TESTSUITE_BRANCH}"]], doGenerateSubmoduleConfigurations: false, extensions: [[$class: 'WipeWorkspace']], submoduleCfg: [], userRemoteConfigs: [[credentialsId: params.CV_GIT_CREDS ? params.CV_GIT_CREDS : '', url: DEFAULT_CLUSTERVERSE_TESTSUITE_URL]]])
+        }
+
+        def docker_parent_net_str = ""
+        if (sh(script: 'grep -sq "docker\\|lxc" /proc/1/cgroup', returnStatus: true) == 0) {
+            println("Running in docker.  Getting network to pass to docker-in-docker containers...")
+            def docker_parent_net_id = sh(script: 'docker inspect  $(basename $(cat /proc/1/cpuset)) -f "{{ range .NetworkSettings.Networks }}{{println .NetworkID}}{{end}}" | head -n 1', returnStdout: true).trim()
+            docker_parent_net_str = "--network ${docker_parent_net_id}"
+            println("docker_parent_net_str: ${docker_parent_net_str}")
+        }
+
+
         /*** Use a docker image that is already on the host ***/
-        //  docker.image('ubuntu_python').inside("${docker_parent_net_str}") {
+        //  docker.image('ubuntu_python').inside("${docker_parent_net_str} -e JENKINS_HOME=${env.JENKINS_HOME}") {
 
         /*** Use a docker image from the local directory ***/
         //  def jenkins_username = sh(script: 'whoami', returnStdout: true).trim()
         //  def jenkins_uid = sh(script: "id -u  ${jenkins_username}", returnStdout: true).trim()
         //  def jenkins_gid = sh(script: "id -g  ${jenkins_username}", returnStdout: true).trim()
-        //  docker.build("cvops", "--build-arg JENKINS_USERNAME=${jenkins_username} --build-arg JENKINS_UID=${jenkins_uid} --build-arg JENKINS_GID=${jenkins_gid} ./jenkinsfiles").inside("${docker_parent_net_str}") {
+        //  docker.build("cvops", "--build-arg JENKINS_USERNAME=${jenkins_username} --build-arg JENKINS_UID=${jenkins_uid} --build-arg JENKINS_GID=${jenkins_gid} ./jenkinsfiles").inside("${docker_parent_net_str} -e JENKINS_HOME=${env.JENKINS_HOME}") {
 
         /*** Create a custom docker image within this Jenkinsfile ***/
         create_custom_image("ubuntu_cvtest", "").inside("${docker_parent_net_str}") {
@@ -102,16 +112,6 @@ node {
 
                 withCredentials([string(credentialsId: "VAULT_PASSWORD_${params.BUILDENV.toUpperCase()}", variable: 'VAULT_PASSWORD_BUILDENV')]) {
                     env.VAULT_PASSWORD_BUILDENV = VAULT_PASSWORD_BUILDENV
-                }
-
-                sh 'ls -la'
-                println("currentBuild.getBuildCauses: " + currentBuild.getBuildCauses())
-                if (currentBuild.getBuildCauses('hudson.model.Cause$SCMTriggerCause').size() > 0 || currentBuild.getBuildCauses('hudson.model.Cause$UpstreamCause').size() > 0) {
-                    println("Checking out default scm: " + scm.userRemoteConfigs + " -- " + scm.branches)
-                    checkout(scm)
-                } else {
-                    println("No 'scm' params for clusterverse testsuite repo; using params.")
-                    checkout([$class: 'GitSCM', branches: [[name: "*/${DEFAULT_CLUSTERVERSE_TESTSUITE_BRANCH}"]], doGenerateSubmoduleConfigurations: false, extensions: [[$class: 'WipeWorkspace']], submoduleCfg: [], userRemoteConfigs: [[credentialsId: params.CV_GIT_CREDS ? params.CV_GIT_CREDS : '', url: DEFAULT_CLUSTERVERSE_TESTSUITE_URL]]])
                 }
 
                 sh 'ls -la'

--- a/EXAMPLE/jenkinsfiles/Jenkinsfile_ops
+++ b/EXAMPLE/jenkinsfiles/Jenkinsfile_ops
@@ -9,151 +9,174 @@ def DEFAULT_CLUSTERVERSE_TESTSUITE_BRANCH = "master"
 
 //This allows us to create our own Docker image for this specific use-case.  Once it is built, it will not be rebuilt, so only adds delay the first time we use it.
 def create_custom_image(image_name, params = "") {
-  // TODO: Create a lock-file and wait on it if it is set (instead of building the same image in parallel then deleting it).
-  def jenkins_username = sh(script: 'whoami', returnStdout: true).trim()
-  def jenkins_uid = sh(script: "id -u  ${jenkins_username}", returnStdout: true).trim()
-  def jenkins_gid = sh(script: "id -g  ${jenkins_username}", returnStdout: true).trim()
+    // Create a lock to prevent building the same image in parallel
+    lock('IMAGEBUILDLOCK__' + env.NODE_NAME) {
+        def jenkins_username = sh(script: 'whoami', returnStdout: true).trim()
+        def jenkins_uid = sh(script: "id -u  ${jenkins_username}", returnStdout: true).trim()
+        def jenkins_gid = sh(script: "id -g  ${jenkins_username}", returnStdout: true).trim()
 
-  def dockerfile = """
+        def dockerfile = """
             FROM ubuntu:20.04
             ARG DEBIAN_FRONTEND=noninteractive
             ENV JENKINS_HOME=${env.JENKINS_HOME}
             ENV HOME=${env.JENKINS_HOME}
             ENV PIPENV_VENV_IN_PROJECT=true
             ENV TZ=Europe/London
-            RUN apt-get update && apt-get install -y ansible git python3-boto python3-boto3 python3-botocore python3-dev python3-distutils python3-dnspython python3-google-auth python3-googleapi python3-libcloud python3-jinja2 python3-jmespath python3-lxml python3-paramiko python3-pyvmomi python3-ruamel.yaml python3-setuptools python3-wheel
+            ### Note: use pip to install pipenv (not apt) to avoid pypa/pipenv#2196 (when using PIPENV_VENV_IN_PROJECT)
+            RUN apt-get update \
+                && apt-get install -y git iproute2 \
+                      python3-boto python3-boto3 python3-botocore python3-dev python3-distutils python3-dnspython python3-google-auth python3-googleapi python3-libcloud python3-jinja2 python3-jmespath python3-netaddr python3-paramiko python3-pip python3-ruamel.yaml python3-setuptools python3-wheel python3-xmltodict \
+                && pip3 install pipenv ansible \
+                && pip3 install -r \$(pip3 show ansible | grep ^Location | sed 's/Location: \\(.*\\)/\\1/')/ansible_collections/azure/azcollection/requirements-azure.txt
             RUN groupadd -g ${jenkins_gid} ${jenkins_username} && useradd -m -u ${jenkins_uid} -g ${jenkins_gid} -s /bin/bash ${jenkins_username}
             """.stripIndent()
 
-  writeFile(file: "Dockerfile", text: dockerfile, encoding: "UTF-8")
-  custom_build = docker.build(image_name, params + " .")
+        writeFile(file: "Dockerfile", text: dockerfile, encoding: "UTF-8")
+        custom_build = docker.build(image_name, params + "--network host .")
 
-  println("Pruning dangling docker images (might have been created due to parallel builds)")
-  sh 'docker image prune -f'
-
-  return (custom_build)
+        return (custom_build)
+    }
 }
 
 
 //This allows us to copy&paste this entire script into a pipeline job in the GUI for faster development time (don't have to commit/push to Git to test every change).
 node {
-  if (currentBuild.getBuildCauses('hudson.model.Cause$UserIdCause').size() > 0) {
-    println("Get bare clusterverse repo to obtain the version history for the RELEASE gitParameter")
-    git(changelog: false, poll: false, url: DEFAULT_CLUSTERVERSE_URL)
-  }
+    if (currentBuild.getBuildCauses('hudson.model.Cause$UserIdCause').size() > 0) {
+        println("Get bare clusterverse repo to obtain the version history for the RELEASE gitParameter")
+        git(changelog: false, poll: false, url: DEFAULT_CLUSTERVERSE_URL)
+    }
 }
 
 properties([
-    parameters([
-        string(name: 'APP_NAME', description: "An optional custom app_name to override the default in the playbook"),
-        booleanParam(name: 'APPEND_BUILD_NUMBER', defaultValue: false, description: 'Tick the box to append the Jenkins BUILD_NUMBER to APP_NAME'),
-        choice(name: 'CLOUD_REGION', choices: ['aws/us-west-2', 'aws/eu-central-1', 'aws/eu-west-1', 'gcp/us-west2', 'gcp/europe-west1'], description: "Choose a cloud/region"),
-        choice(name: 'BUILDENV', choices: ['sandbox', 'dev', 'mgmt', 'tools', 'stage', 'prod'], description: "Choose an environment to deploy"),
-        string(name: 'CLUSTER_ID', defaultValue: '', description: "Select a cluster_id to deploy", trim: true),
-        booleanParam(name: 'DNS_FORCE_DISABLE', defaultValue: false, description: 'Tick the box to force disable the DNS as defined in playbook'),
-        choice(name: 'DEPLOY_TYPE', choices: ['deploy', 'redeploy', 'clean'], description: "Choose the deploy type"),
-        choice(name: 'REDEPLOY_SCHEME', choices: ['', '_scheme_addallnew_rmdisk_rollback', '_scheme_addnewvm_rmdisk_rollback', '_scheme_rmvm_rmdisk_only', '_scheme_rmvm_keepdisk_rollback'], description: "Choose the redeploy schemes"),
-        choice(name: 'CANARY', choices: ['none', 'start', 'finish', 'tidy'], description: "Choose the canary type"),
-        booleanParam(name: 'CANARY_TIDY_ON_SUCCESS', defaultValue: false, description: 'Tick the box to tidy up successful canary (none or finish) redeploys (by default, old machines are left powered off)'),
-        string(name: 'MYHOSTTYPES', description: "comma-separated string, e.g. master,slave - In redeployment you can define which host type you like to redeploy. If not defined it will redeploy all host types"),
-        gitParameter(name: 'RELEASE', type: 'PT_TAG', useRepository: 'clusterverse', branch: 'master', branchFilter: '.*', defaultValue: 'master', description: 'Choose an existing release version to deploy (or \'master\')', quickFilterEnabled: false, selectedValue: 'NONE', sortMode: 'DESCENDING_SMART', tagFilter: '*'),
-        string(name: 'CV_GIT_URL', defaultValue: DEFAULT_CLUSTERVERSE_URL, description: "The main clusterverse URL."),
-        string(name: 'CV_GIT_BRANCH', defaultValue: DEFAULT_CLUSTERVERSE_BRANCH, description: "The clusterverse branch to test."),
-        credentials(name: 'CV_GIT_CREDS', credentialType: 'com.cloudbees.plugins.credentials.impl.UsernamePasswordCredentialsImpl', defaultValue: 'GITHUB_SVC_USER', description: 'Jenkins username/password credentials for GitHub', required: false),
-        string(name: 'USER_CMDLINE_VARS', defaultValue: '', description: "Any user-defined command-line parameters."),
-    ])
+        parameters([
+                string(name: 'APP_NAME', description: "An optional custom app_name to override the default in the playbook"),
+                booleanParam(name: 'APPEND_BUILD_NUMBER', defaultValue: false, description: 'Tick the box to append the Jenkins BUILD_NUMBER to APP_NAME'),
+                choice(name: 'CLOUD_REGION', choices: ['aws/us-west-2', 'aws/eu-central-1', 'aws/eu-west-1', 'gcp/us-west2', 'gcp/europe-west1'], description: "Choose a cloud/region"),
+                choice(name: 'BUILDENV', choices: ['sandbox', 'dev', 'mgmt', 'tools', 'stage', 'prod'], description: "Choose an environment to deploy"),
+                string(name: 'CLUSTER_ID', defaultValue: '', description: "Select a cluster_id to deploy", trim: true),
+                booleanParam(name: 'DNS_FORCE_DISABLE', defaultValue: false, description: 'Tick the box to force disable the DNS as defined in playbook'),
+                choice(name: 'DEPLOY_TYPE', choices: ['deploy', 'redeploy', 'clean'], description: "Choose the deploy type"),
+                choice(name: 'REDEPLOY_SCHEME', choices: ['', '_scheme_addallnew_rmdisk_rollback', '_scheme_addnewvm_rmdisk_rollback', '_scheme_rmvm_rmdisk_only', '_scheme_rmvm_keepdisk_rollback'], description: "Choose the redeploy schemes"),
+                choice(name: 'CANARY', choices: ['none', 'start', 'finish', 'tidy'], description: "Choose the canary type"),
+                booleanParam(name: 'CANARY_TIDY_ON_SUCCESS', defaultValue: false, description: 'Tick the box to tidy up successful canary (none or finish) redeploys (by default, old machines are left powered off)'),
+                string(name: 'MYHOSTTYPES', description: "comma-separated string, e.g. master,slave - In redeployment you can define which host type you like to redeploy. If not defined it will redeploy all host types"),
+                gitParameter(name: 'RELEASE', type: 'PT_TAG', useRepository: '.*clusterverse.git', branch: 'master', branchFilter: '.*', defaultValue: 'master', description: 'Choose an existing release version to deploy (or \'master\')', quickFilterEnabled: false, selectedValue: 'NONE', sortMode: 'DESCENDING_SMART', tagFilter: '*'),
+                string(name: 'CV_GIT_URL', defaultValue: DEFAULT_CLUSTERVERSE_URL, description: "The main clusterverse URL."),
+                string(name: 'CV_GIT_BRANCH', defaultValue: DEFAULT_CLUSTERVERSE_BRANCH, description: "The clusterverse branch to test."),
+                credentials(name: 'CV_GIT_CREDS', credentialType: 'com.cloudbees.plugins.credentials.impl.UsernamePasswordCredentialsImpl', defaultValue: 'GITHUB_SVC_USER', description: 'Jenkins username/password credentials for GitHub', required: false),
+                string(name: 'USER_CMDLINE_VARS', defaultValue: '', description: "Any user-defined command-line parameters."),
+        ])
 ])
 
 node {
-  sh 'printenv | sort'
-  echo "Params: $params"
+    sh 'printenv | sort'
+    echo "Params: $params"
 
-//  def custom_docker_image
-//  stage('Create Docker image') {
-//    custom_docker_image = create_custom_image("ubuntu_cvtest", "")
-//  }
-
-//  create_custom_image("ubuntu_cvtest", "").inside {
-//  custom_docker_image.inside {
-  docker.image('ubuntu_python').inside {
-    stage('Check Environment') {
-      sh 'printenv | sort'
-      println("common_deploy_vars params:" + params)
-
-      if (params.CLUSTER_ID == '') {
-        unstable("CLUSTER_ID not defined")
-        throw new org.jenkinsci.plugins.workflow.steps.FlowInterruptedException(hudson.model.Result.ABORTED)
-      }
-      if (params.APPEND_BUILD_NUMBER == true && params.APP_NAME == "") {
-        error "APP_NAME is required when APPEND_BUILD_NUMBER is set."
-      }
-    }
-    withCredentials([string(credentialsId: "VAULT_PASSWORD_${params.BUILDENV.toUpperCase()}", variable: 'VAULT_PASSWORD_BUILDENV')]) {
-      env.VAULT_PASSWORD_BUILDENV = VAULT_PASSWORD_BUILDENV
+    def docker_parent_net_str = ""
+    if (sh(script: 'grep -sq "docker\\|lxc" /proc/1/cgroup', returnStatus: true) == 0) {
+        println("Running in docker.  Getting network to pass to docker-in-docker containers...")
+        def docker_parent_net_id = sh(script: 'docker inspect  $(basename $(cat /proc/1/cpuset)) -f "{{ range .NetworkSettings.Networks }}{{println .NetworkID}}{{end}}" | head -n 1', returnStdout: true).trim()
+        docker_parent_net_str = "--network ${docker_parent_net_id}"
+        println("docker_parent_net_str: ${docker_parent_net_str}")
     }
 
-    sh 'ls -la'
-    println("currentBuild.getBuildCauses: " + currentBuild.getBuildCauses())
-    if (currentBuild.getBuildCauses('hudson.model.Cause$SCMTriggerCause').size() > 0  ||  currentBuild.getBuildCauses('hudson.model.Cause$UpstreamCause').size() > 0) {
-      println("Checking out default scm: " + scm.userRemoteConfigs + " -- " + scm.branches)
-      checkout(scm)
+    if (params.BUILDENV && params.CLUSTER_ID && params.CLOUD_REGION) {
+        /*** Use a docker image that is already on the host ***/
+        //  docker.image('ubuntu_python').inside("${docker_parent_net_str}") {
+
+        /*** Use a docker image from the local directory ***/
+        //  def jenkins_username = sh(script: 'whoami', returnStdout: true).trim()
+        //  def jenkins_uid = sh(script: "id -u  ${jenkins_username}", returnStdout: true).trim()
+        //  def jenkins_gid = sh(script: "id -g  ${jenkins_username}", returnStdout: true).trim()
+        //  docker.build("cvops", "--build-arg JENKINS_USERNAME=${jenkins_username} --build-arg JENKINS_UID=${jenkins_uid} --build-arg JENKINS_GID=${jenkins_gid} ./jenkinsfiles").inside("${docker_parent_net_str}") {
+
+        /*** Create a custom docker image within this Jenkinsfile ***/
+        create_custom_image("ubuntu_cvtest", "").inside("${docker_parent_net_str}") {
+            stage('Setup Environment') {
+                sh 'printenv | sort'
+                println("common_deploy_vars params:" + params)
+
+                if (params.APPEND_BUILD_NUMBER == true && params.APP_NAME == "") {
+                    error "APP_NAME is required when APPEND_BUILD_NUMBER is set."
+                }
+
+                withCredentials([string(credentialsId: "VAULT_PASSWORD_${params.BUILDENV.toUpperCase()}", variable: 'VAULT_PASSWORD_BUILDENV')]) {
+                    env.VAULT_PASSWORD_BUILDENV = VAULT_PASSWORD_BUILDENV
+                }
+
+                sh 'ls -la'
+                println("currentBuild.getBuildCauses: " + currentBuild.getBuildCauses())
+                if (currentBuild.getBuildCauses('hudson.model.Cause$SCMTriggerCause').size() > 0 || currentBuild.getBuildCauses('hudson.model.Cause$UpstreamCause').size() > 0) {
+                    println("Checking out default scm: " + scm.userRemoteConfigs + " -- " + scm.branches)
+                    checkout(scm)
+                } else {
+                    println("No 'scm' params for clusterverse testsuite repo; using params.")
+                    checkout([$class: 'GitSCM', branches: [[name: "*/${DEFAULT_CLUSTERVERSE_TESTSUITE_BRANCH}"]], doGenerateSubmoduleConfigurations: false, extensions: [[$class: 'WipeWorkspace']], submoduleCfg: [], userRemoteConfigs: [[credentialsId: params.CV_GIT_CREDS ? params.CV_GIT_CREDS : '', url: DEFAULT_CLUSTERVERSE_TESTSUITE_URL]]])
+                }
+
+                sh 'ls -la'
+                String requirementsYamlFile = './requirements.yml'
+                if (params.CV_GIT_URL && params.CV_GIT_BRANCH) {
+                    println("Updating $requirementsYamlFile with source ($params.CV_GIT_URL) and version ($params.CV_GIT_BRANCH) as passed in from upstream.")
+                    sh "cat ${requirementsYamlFile}"
+                    HashMap requirementsYaml = readYaml file: requirementsYamlFile
+                    HashMap clusterverse_role = requirementsYaml.roles.find { it.name == 'clusterverse' }
+                    clusterverse_role.src = params.CV_GIT_URL
+                    clusterverse_role.version = params.CV_GIT_BRANCH
+                    sh "rm $requirementsYamlFile"
+                    writeYaml file: requirementsYamlFile, data: requirementsYaml
+                }
+                sh "cat ${requirementsYamlFile}"
+            }
+
+            stage(params.DEPLOY_TYPE) {
+                String IAC_RELEASE = ""
+                if (params.RELEASE != "master" && params.RELEASE != null) {
+                    GIT_TOKEN = credentials("GITHUB_SVC_USER")
+                    sh "git remote set-url origin https://${GIT_TOKEN_USR}:${GIT_TOKEN_PSW}@" + DEFAULT_CLUSTERVERSE_URL.replaceFirst("^(http[s]?://)", "") + ".git"
+                    sh "git fetch --tags"
+                    sh "git checkout ${params.RELEASE}"
+                    IAC_RELEASE = ' -e release_version=' + params.RELEASE.replace('.', '_') as String
+                }
+
+                String DNS_FORCE_DISABLE = ""
+                if (params.DNS_FORCE_DISABLE == true && params.DNS_FORCE_DISABLE != null) {
+                    DNS_FORCE_DISABLE = " -e _dns_nameserver_zone=''"
+                }
+
+                String MYHOSTTYPES = ""
+                if (params.MYHOSTTYPES != "" && params.MYHOSTTYPES != null) {
+                    MYHOSTTYPES = ' -e myhosttypes=' + params.MYHOSTTYPES
+                }
+
+                String APP_NAME = ""
+                if (params.APP_NAME != "" && params.APP_NAME != null) {
+                    APP_NAME = " -e app_name=" + params.APP_NAME
+                    if (params.APPEND_BUILD_NUMBER == true) {
+                        APP_NAME = APP_NAME + '-' + env.BUILD_NUMBER
+                    }
+                }
+
+                def (CLOUD_TYPE, REGION) = params.CLOUD_REGION.split('/')
+                if (params.DEPLOY_TYPE == 'deploy') {
+                    sh "ansible-playbook -e cloud_type=${CLOUD_TYPE} -e region=${REGION} -e buildenv=${params.BUILDENV} -e clusterid=${params.CLUSTER_ID} --vault-id=default@.vaultpass-client.py --vault-id=${params.BUILDENV}@.vaultpass-client.py cluster.yml $APP_NAME $DNS_FORCE_DISABLE $MYHOSTTYPES $IAC_RELEASE $params.USER_CMDLINE_VARS"
+                } else if (params.DEPLOY_TYPE == 'redeploy') {
+                    sh "ansible-playbook -e cloud_type=${CLOUD_TYPE} -e region=${REGION} -e buildenv=${params.BUILDENV} -e clusterid=${params.CLUSTER_ID} --vault-id=default@.vaultpass-client.py --vault-id=${params.BUILDENV}@.vaultpass-client.py redeploy.yml -e canary=${params.CANARY} -e canary_tidy_on_success=${params.CANARY_TIDY_ON_SUCCESS} -e redeploy_scheme=${params.REDEPLOY_SCHEME} -e debug_nested_log_output=true $APP_NAME $DNS_FORCE_DISABLE $MYHOSTTYPES $IAC_RELEASE $params.USER_CMDLINE_VARS"
+                } else if (params.DEPLOY_TYPE == 'clean') {
+                    sh "ansible-playbook -e cloud_type=${CLOUD_TYPE} -e region=${REGION} -e buildenv=${params.BUILDENV} -e clusterid=${params.CLUSTER_ID} --vault-id=default@.vaultpass-client.py --vault-id=${params.BUILDENV}@.vaultpass-client.py cluster.yml --tags=clusterverse_clean -e clean=_all_ $APP_NAME $params.USER_CMDLINE_VARS"
+                } else error("DEPLOY_TYPE invalid")
+            }
+        }
     } else {
-      println("No 'scm' params for clusterverse testsuite repo; using params.")
-      checkout([$class: 'GitSCM', branches: [[name: "*/${DEFAULT_CLUSTERVERSE_TESTSUITE_BRANCH}"]], doGenerateSubmoduleConfigurations: false, extensions: [[$class: 'WipeWorkspace']], submoduleCfg: [], userRemoteConfigs: [[credentialsId: env.CV_GIT_CREDS ? env.CV_GIT_CREDS : '', url: DEFAULT_CLUSTERVERSE_TESTSUITE_URL]]])
+        if (!params.BUILDENV) {
+            currentBuild.result = 'ABORTED'
+            error("BUILDENV not defined")
+        } else if (!params.CLUSTER_ID) {
+            currentBuild.result = 'ABORTED'
+            error("CLUSTER_ID not defined")
+        } else if (!params.CLOUD_REGION) {
+            currentBuild.result = 'ABORTED'
+            error("CLOUD_REGION not defined")
+        }
     }
-
-    sh 'ls -la'
-    String requirementsYamlFile = './requirements.yml'
-    if (params.CV_GIT_URL && params.CV_GIT_BRANCH) {
-      println("Updating $requirementsYamlFile with source ($params.CV_GIT_URL) and version ($params.CV_GIT_BRANCH) as passed in from upstream.")
-      sh "cat ${requirementsYamlFile}"
-      HashMap requirementsYaml = readYaml file: requirementsYamlFile
-      HashMap clusterverse_role = requirementsYaml.roles.find { it.name == 'clusterverse' }
-      clusterverse_role.src = params.CV_GIT_URL
-      clusterverse_role.version = params.CV_GIT_BRANCH
-      sh "rm $requirementsYamlFile"
-      writeYaml file: requirementsYamlFile, data: requirementsYaml
-    }
-    sh "cat ${requirementsYamlFile}"
-
-
-    String IAC_RELEASE = ""
-    if (params.RELEASE != "master" && params.RELEASE != null) {
-      GIT_TOKEN = credentials("GITHUB_SVC_USER")
-      sh "git remote set-url origin https://${GIT_TOKEN_USR}:${GIT_TOKEN_PSW}@" + DEFAULT_CLUSTERVERSE_URL.replaceFirst("^(http[s]?://)","") + ".git"
-      sh "git fetch --tags"
-      sh "git checkout ${params.RELEASE}"
-      IAC_RELEASE = ' -e release_version=' + params.RELEASE.replace('.', '_') as String
-    }
-
-    String DNS_FORCE_DISABLE = ""
-    if (params.DNS_FORCE_DISABLE == true && params.DNS_FORCE_DISABLE != null) {
-      DNS_FORCE_DISABLE = " -e _dns_nameserver_zone=''"
-    }
-
-    String MYHOSTTYPES = ""
-    if (params.MYHOSTTYPES != "" && params.MYHOSTTYPES != null) {
-      MYHOSTTYPES = ' -e myhosttypes=' + params.MYHOSTTYPES
-    }
-
-    String APP_NAME = ""
-    if (params.APP_NAME != "" && params.APP_NAME != null) {
-      APP_NAME = " -e app_name=" + params.APP_NAME
-      if (params.APPEND_BUILD_NUMBER == true) {
-        APP_NAME = APP_NAME + '-' + env.BUILD_NUMBER
-      }
-    }
-
-    def (CLOUD_TYPE, REGION) = params.CLOUD_REGION.split('/')
-
-    stage(params.DEPLOY_TYPE) {
-      if (params.DEPLOY_TYPE == 'deploy') {
-          sh "ansible-playbook -e cloud_type=${CLOUD_TYPE} -e region=${REGION} -e buildenv=${params.BUILDENV} -e clusterid=${params.CLUSTER_ID} --vault-id=default@.vaultpass-client.py --vault-id=${params.BUILDENV}@.vaultpass-client.py cluster.yml $APP_NAME $DNS_FORCE_DISABLE $MYHOSTTYPES $IAC_RELEASE $params.USER_CMDLINE_VARS"
-      } else if (params.DEPLOY_TYPE == 'redeploy') {
-          sh "ansible-playbook -e cloud_type=${CLOUD_TYPE} -e region=${REGION} -e buildenv=${params.BUILDENV} -e clusterid=${params.CLUSTER_ID} --vault-id=default@.vaultpass-client.py --vault-id=${params.BUILDENV}@.vaultpass-client.py redeploy.yml -e canary=${params.CANARY} -e canary_tidy_on_success=${params.CANARY_TIDY_ON_SUCCESS} -e redeploy_scheme=${params.REDEPLOY_SCHEME} -e debug_nested_log_output=true $APP_NAME $DNS_FORCE_DISABLE $MYHOSTTYPES $IAC_RELEASE $params.USER_CMDLINE_VARS"
-      } else if (params.DEPLOY_TYPE == 'clean') {
-          sh "ansible-playbook -e cloud_type=${CLOUD_TYPE} -e region=${REGION} -e buildenv=${params.BUILDENV} -e clusterid=${params.CLUSTER_ID} --vault-id=default@.vaultpass-client.py --vault-id=${params.BUILDENV}@.vaultpass-client.py cluster.yml --tags=clusterverse_clean -e clean=_all_ $APP_NAME $params.USER_CMDLINE_VARS"
-      } else error("DEPLOY_TYPE invalid")
-    }
-  }
 }

--- a/_dependencies/tasks/main.yml
+++ b/_dependencies/tasks/main.yml
@@ -30,7 +30,7 @@
 
 - name: Preflight check
   block:
-    - assert: { that: "ansible_version.full is version_compare('2.9.6', '>=') and ansible_version.full is version_compare('2.10.6', '<=')", fail_msg: "2.10.6 >= Ansible >= 2.9.6 required." }  #2.10.7 has issue with AWS DNS: https://github.com/ansible-collections/community.aws/issues/523
+    - assert: { that: "ansible_version.full is version_compare('2.9.6', '>=')", fail_msg: "Ansible > 2.9.6 required." }
     - assert: { that: "app_name is defined and app_name != ''", fail_msg: "Please define app_name" }
     - assert: { that: "app_class is defined and app_class != ''", fail_msg: "Please define app_class" }
     - assert: { that: "cluster_vars is defined", fail_msg: "Please define cluster_vars" }

--- a/_dependencies/tasks/main.yml
+++ b/_dependencies/tasks/main.yml
@@ -33,10 +33,17 @@
     - assert: { that: "ansible_version.full is version_compare('2.10', '>=')", fail_msg: "ansible-core > 2.10 required for Azure support." }
       when: cluster_vars.type == "azure"
 
+      ## Note cannot use '--format json' in 'ansible-galaxy collection list' command, as it is not present in 2.10.x
     - assert:
-        that: "(ansible_version.full is version_compare('2.9.6', '>=') and ansible_version.full is version_compare('2.10.6', '<='))  or  galaxy_collections['community.aws'].version is version_compare('1.5.0', '>=')"
+        that: "(ansible_version.full is version('2.9.6', '>=') and ansible_version.full is version('2.10.6', '<='))  or  ('community.aws' in galaxy_collections  and  galaxy_collections['community.aws'].version is version('1.5.0', '>='))"
         fail_msg: "If Ansible > 2.9.6 then community.aws > 1.5.0 is required for valid community.aws.route53 support (by default in Ansible v4)."
-      vars: { galaxy_collections: "{{ (lookup('pipe', 'ansible-galaxy collection list --format json')) | from_json |  json_query(\"* | [0]\") }}" }
+      vars:
+        galaxy_collections: |-
+          {% set res = {} -%}
+          {%- for sub in (lookup('pipe', 'ansible-galaxy collection list')).split('\n') | map('trim') | map('regex_replace', '\\s+', ' ') -%}
+            {% set _ = res.update({sub.split(' ')[0]: {'version': sub.split(' ')[1]|default('')}}) -%}
+          {%- endfor %}
+          {{ res }}
 
     - assert: { that: "app_name is defined and app_name != ''", fail_msg: "Please define app_name" }
     - assert: { that: "app_class is defined and app_class != ''", fail_msg: "Please define app_class" }

--- a/_dependencies/tasks/main.yml
+++ b/_dependencies/tasks/main.yml
@@ -30,7 +30,14 @@
 
 - name: Preflight check
   block:
-    - assert: { that: "ansible_version.full is version_compare('2.9.6', '>=')", fail_msg: "Ansible > 2.9.6 required." }
+    - assert: { that: "ansible_version.full is version_compare('2.10', '>=')", fail_msg: "ansible-core > 2.10 required for Azure support." }
+      when: cluster_vars.type == "azure"
+
+    - assert:
+        that: "(ansible_version.full is version_compare('2.9.6', '>=') and ansible_version.full is version_compare('2.10.6', '<='))  or  galaxy_collections['community.aws'].version is version_compare('1.5.0', '>=')"
+        fail_msg: "If Ansible > 2.9.6 then community.aws > 1.5.0 is required for valid community.aws.route53 support (by default in Ansible v4)."
+      vars: { galaxy_collections: "{{ (lookup('pipe', 'ansible-galaxy collection list --format json')) | from_json |  json_query(\"* | [0]\") }}" }
+
     - assert: { that: "app_name is defined and app_name != ''", fail_msg: "Please define app_name" }
     - assert: { that: "app_class is defined and app_class != ''", fail_msg: "Please define app_class" }
     - assert: { that: "cluster_vars is defined", fail_msg: "Please define cluster_vars" }

--- a/clean/tasks/dns.yml
+++ b/clean/tasks/dns.yml
@@ -39,6 +39,8 @@
           route53_zone:
             aws_access_key: "{{cluster_vars[buildenv].aws_access_key}}"
             aws_secret_key: "{{cluster_vars[buildenv].aws_secret_key}}"
+            vpc_id: "{{ vpc_id if cluster_vars.route53_private_zone|bool else omit() }}"                     # If this is a private zone, we need to request the private (VPC/Region-specific) version of the Zone
+            vpc_region: "{{ cluster_vars.region if cluster_vars.route53_private_zone|bool else omit() }}"    # If this is a private zone, we need to request the private (VPC/Region-specific) version of the Zone
             zone: "{{cluster_vars.dns_nameserver_zone}}"
           register: r__route53_zone
 

--- a/clean/tasks/dns.yml
+++ b/clean/tasks/dns.yml
@@ -33,7 +33,76 @@
           when: (item.name + '.' + cluster_vars.dns_user_domain + "." == cname_value)
       when: cluster_vars.dns_server == "nsupdate"
 
-    - name: clean/dns/route53 | Delete DNS entries
+
+    - name: "clean/dns/route53 | Delete DNS entries (legacy (faster) mechanism: route53(state=get)/ route53)"
+      block:
+        - name: clean/dns/route53 | Get A records
+          route53:
+            aws_access_key: "{{cluster_vars[buildenv].aws_access_key}}"
+            aws_secret_key: "{{cluster_vars[buildenv].aws_secret_key}}"
+            state: "get"
+            zone: "{{cluster_vars.dns_nameserver_zone}}"
+            record: "{{item.name}}.{{cluster_vars.dns_user_domain}}"
+            type: "A"
+            private_zone: "{{cluster_vars.route53_private_zone | default(true)}}"
+          register: r__route53_a
+          with_items: "{{ hosts_to_clean }}"
+          ignore_errors: yes
+        - name: clean/dns/route53 | Remove failed DNS lookups from route53 state=get
+          set_fact:
+            r__route53_a: "{{r__route53_a.results | selectattr('failed', '==', false) | list}}"
+          when: r__route53_a is failed
+
+        - name: clean/dns/route53 | Delete A records
+          route53:
+            aws_access_key: "{{cluster_vars[buildenv].aws_access_key}}"
+            aws_secret_key: "{{cluster_vars[buildenv].aws_secret_key}}"
+            state: "absent"
+            zone: "{{ item.set.zone }}"
+            record: "{{ item.set.record }}"
+            type: "{{ item.set.type }}"
+            ttl: "{{ item.set.ttl }}"
+            value: ["{{ item.set.value }}"]
+            private_zone: "{{cluster_vars.route53_private_zone | default(true)}}"
+          with_items: "{{ r__route53_a.results }}"
+          when: item.set.value is defined
+
+        - name: clean/dns/route53 | Get CNAME records
+          route53:
+            aws_access_key: "{{cluster_vars[buildenv].aws_access_key}}"
+            aws_secret_key: "{{cluster_vars[buildenv].aws_secret_key}}"
+            state: "get"
+            zone: "{{cluster_vars.dns_nameserver_zone}}"
+            record: "{{item.name | regex_replace('-(?!.*-).*')}}.{{cluster_vars.dns_user_domain}}"
+            type: "CNAME"
+            private_zone: "{{cluster_vars.route53_private_zone | default(true)}}"
+          register: r__route53_cname
+          with_items: "{{ hosts_to_clean }}"
+          ignore_errors: yes
+        - name: clean/dns/route53 | Remove failed DNS lookups from route53 state=get
+          set_fact:
+            r__route53_cname: "{{r__route53_cname.results | selectattr('failed', '==', false) | list}}"
+          when: r__route53_cname is failed
+
+        - name: clean/dns/route53 | Delete CNAME records
+          route53:
+            aws_access_key: "{{cluster_vars[buildenv].aws_access_key}}"
+            aws_secret_key: "{{cluster_vars[buildenv].aws_secret_key}}"
+            state: "absent"
+            zone: "{{ item.1.set.zone }}"
+            record: "{{ item.1.set.record }}"
+            type: "{{ item.1.set.type }}"
+            ttl: "{{ item.1.set.ttl }}"
+            value: ["{{ item.1.set.value }}"]
+            private_zone: "{{cluster_vars.route53_private_zone | default(true)}}"
+          with_nested:
+            - "{{ hosts_to_clean }}"
+            - "{{ r__route53_cname.results }}"
+          when: (item.1.set.value is defined)  and  ((item.0.name | regex_replace('-(?!.*-).*')) == (item.1.set.record | regex_replace('^(.*?)\\..*$', '\\1')))  and  (item.0.name == item.1.set.value | regex_replace('^(.*?)\\..*$', '\\1'))
+      when: cluster_vars.dns_server == "route53" and (use_new_route53 is not defined or use_new_route53|bool == false)
+
+
+    - name: "clean/dns/route53 | Delete DNS entries (new mechanism: route53_zone/ route53_info/ route53)"
       block:
         - name: clean/dns/route53 | Get Zone
           route53_zone:
@@ -73,7 +142,7 @@
             private_zone: "{{cluster_vars.route53_private_zone | default(true)}}"
           with_items: "{{ records_to_clean }}"
           vars:
-            _hostnames_to_clean: "{{ hosts_to_clean | json_query(\"[].name\") | map('regex_replace', '^(.*)$', '\\1.' + cluster_vars.dns_user_domain + '.') }}"
+            _hostnames_to_clean: "{{ hosts_to_clean | json_query(\"[].name\") | map('regex_replace', '^(.*)$', '\\1.' + cluster_vars.dns_user_domain + '.') | list }}"
             records_to_clean: "{{ r__route53_info.results | json_query(\"[].ResourceRecordSets[?Type=='A' && contains(\"+ _hostnames_to_clean | string +\", Name)][]\") | unique }}"
 
         # Note: route53_info currently does not honour the 'max_items' or 'type' fields, (and if 'start_record_name' is not found, it just returns all records), so we need to filter the responses to match 'hosts_to_clean' when doing the delete
@@ -104,13 +173,15 @@
             value: "{{ item.1.ResourceRecords | json_query(\"[].Value\") }}"
             private_zone: "{{cluster_vars.route53_private_zone | default(true)}}"
           vars:
-            _cnames_to_clean: "{{ hosts_to_clean | json_query(\"[].name\") | map('regex_replace', '^(.*)-(?!.*-).*$', '\\1.' + cluster_vars.dns_user_domain + '.') }}"   #Remove the last '-.*' (cluster_suffix)
+            _cnames_to_clean: "{{ hosts_to_clean | json_query(\"[].name\") | map('regex_replace', '^(.*)-(?!.*-).*$', '\\1.' + cluster_vars.dns_user_domain + '.') | list }}"   #Remove the last '-.*' (cluster_suffix)
             records_to_clean: "{{ r__route53_info.results | json_query(\"[].ResourceRecordSets[?Type=='CNAME' && contains(\"+ _cnames_to_clean | string +\", Name)][]\") | unique }}"
           with_nested:
             - "{{ hosts_to_clean }}"
             - "{{ records_to_clean }}"
           when: ((item.0.name | regex_replace('-(?!.*-).*')) == (item.1.Name | regex_replace('^(.*?)\\..*$', '\\1')))  and  ((item.0.name == item.1.ResourceRecords[0].Value | regex_replace('^(.*?)\\..*$', '\\1')))
-      when: cluster_vars.dns_server == "route53"
+      when: cluster_vars.dns_server == "route53" and (use_new_route53 is defined and use_new_route53|bool)
+
+
 
     - name: clean/dns/clouddns | Delete DNS entries
       block:
@@ -121,8 +192,6 @@
             project: "{{cluster_vars[buildenv].vpc_host_project_id}}"
             service_account_file: "{{gcp_credentials_file}}"
           register: r__gcp_dns_managed_zone_info
-
-#        - debug: msg={{r__gcp_dns_managed_zone_info}}
 
         - name: clean/dns/clouddns | Get all non-peered DNS records for managed zones that match cluster_vars.dns_nameserver_zone
           gcp_dns_resource_record_set_info:
@@ -135,12 +204,8 @@
           register: r__gcp_dns_resource_record_set_info
           with_items: "{{r__gcp_dns_managed_zone_info.resources | json_query(\"[?dnsName==`\" + cluster_vars.dns_nameserver_zone + \"` && !(peeringConfig)]\") }}"
 
-#        - debug: msg={{r__gcp_dns_resource_record_set_info}}
-
         - name: clean/dns/clouddns | Delete A and CNAME records
           block:
-#            - debug: msg={{gcp_dns_resource_record_set_info__and__gcp_dns_managed_zone_info}}
-
             - name: clean/dns/clouddns | Delete A records
               gcp_dns_resource_record_set:
                 auth_kind: serviceaccount

--- a/clean/tasks/dns.yml
+++ b/clean/tasks/dns.yml
@@ -39,9 +39,9 @@
           route53_zone:
             aws_access_key: "{{cluster_vars[buildenv].aws_access_key}}"
             aws_secret_key: "{{cluster_vars[buildenv].aws_secret_key}}"
-            vpc_id: "{{ vpc_id if cluster_vars.route53_private_zone|bool else omit() }}"                     # If this is a private zone, we need to request the private (VPC/Region-specific) version of the Zone
-            vpc_region: "{{ cluster_vars.region if cluster_vars.route53_private_zone|bool else omit() }}"    # If this is a private zone, we need to request the private (VPC/Region-specific) version of the Zone
             zone: "{{cluster_vars.dns_nameserver_zone}}"
+            vpc_id: "{{ vpc_id if cluster_vars.route53_private_zone|bool else omit }}"                     # If this is a private zone, we need to request the private (VPC/Region-specific) version of the Zone
+            vpc_region: "{{ cluster_vars.region if cluster_vars.route53_private_zone|bool else omit }}"    # If this is a private zone, we need to request the private (VPC/Region-specific) version of the Zone
           register: r__route53_zone
 
         # Note: route53_info currently does not honour the 'max_items' or 'type' fields, (and if 'start_record_name' is not found, it just returns all records), so we need to filter the responses to match 'hosts_to_clean' when doing the delete

--- a/clean/tasks/dns.yml
+++ b/clean/tasks/dns.yml
@@ -35,16 +35,27 @@
 
     - name: clean/dns/route53 | Delete DNS entries
       block:
-        - name: clean/dns/route53 | Get A records
-          route53:
+        - name: clean/dns/route53 | Get Zone
+          route53_zone:
             aws_access_key: "{{cluster_vars[buildenv].aws_access_key}}"
             aws_secret_key: "{{cluster_vars[buildenv].aws_secret_key}}"
-            state: "get"
             zone: "{{cluster_vars.dns_nameserver_zone}}"
-            record: "{{item.name}}.{{cluster_vars.dns_user_domain}}"
+          register: r__route53_zone
+
+        # Note: route53_info currently does not honour the 'max_items' or 'type' fields, (and if 'start_record_name' is not found, it just returns all records), so we need to filter the responses to match 'hosts_to_clean' when doing the delete
+        # Note: cannot run route53_info asynchronously as it makes too many concurrent requests and blows the AWS Route53 API limit.
+        - name: clean/dns/route53 | Get A records
+          route53_info:
+            aws_access_key: "{{cluster_vars[buildenv].aws_access_key}}"
+            aws_secret_key: "{{cluster_vars[buildenv].aws_secret_key}}"
             type: "A"
-            private_zone: "{{cluster_vars.route53_private_zone | default(true)}}"
-          register: r__route53_a
+            max_items: 1
+            query: record_sets
+            hosted_zone_id: "{{ r__route53_zone.zone_id }}"
+            start_record_name: "{{item.name}}.{{cluster_vars.dns_user_domain}}"
+          register: r__route53_info
+          until: r__route53_info is success
+          retries: 10
           with_items: "{{ hosts_to_clean }}"
 
         - name: clean/dns/route53 | Delete A records
@@ -52,42 +63,51 @@
             aws_access_key: "{{cluster_vars[buildenv].aws_access_key}}"
             aws_secret_key: "{{cluster_vars[buildenv].aws_secret_key}}"
             state: "absent"
-            zone: "{{ item.set.zone }}"
-            record: "{{ item.set.record }}"
-            type: "{{ item.set.type }}"
-            ttl: "{{ item.set.ttl }}"
-            value: ["{{ item.set.value }}"]
+            zone: "{{ cluster_vars.dns_nameserver_zone }}"
+            record: "{{ item.Name }}"
+            type: "{{ item.Type }}"
+            ttl: "{{ item.TTL }}"
+            value: "{{ item.ResourceRecords | json_query(\"[].Value\") }}"
             private_zone: "{{cluster_vars.route53_private_zone | default(true)}}"
-          with_items: "{{ r__route53_a.results }}"
-          when: item.set.value is defined
+          with_items: "{{ records_to_clean }}"
+          vars:
+            _hostnames_to_clean: "{{ hosts_to_clean | json_query(\"[].name\") | map('regex_replace', '^(.*)$', '\\1.' + cluster_vars.dns_user_domain + '.') }}"
+            records_to_clean: "{{ r__route53_info.results | json_query(\"[].ResourceRecordSets[?Type=='A' && contains(\"+ _hostnames_to_clean | string +\", Name)][]\") | unique }}"
 
+        # Note: route53_info currently does not honour the 'max_items' or 'type' fields, (and if 'start_record_name' is not found, it just returns all records), so we need to filter the responses to match 'hosts_to_clean' when doing the delete
+        # Note: cannot run route53_info asynchronously as it makes too many concurrent requests and blows the AWS Route53 API limit.
         - name: clean/dns/route53 | Get CNAME records
-          route53:
+          route53_info:
             aws_access_key: "{{cluster_vars[buildenv].aws_access_key}}"
             aws_secret_key: "{{cluster_vars[buildenv].aws_secret_key}}"
-            state: "get"
-            zone: "{{cluster_vars.dns_nameserver_zone}}"
-            record: "{{item.name | regex_replace('-(?!.*-).*')}}.{{cluster_vars.dns_user_domain}}"
             type: "CNAME"
-            private_zone: "{{cluster_vars.route53_private_zone | default(true)}}"
-          register: r__route53_cname
+            max_items: 1
+            query: record_sets
+            hosted_zone_id: "{{ r__route53_zone.zone_id }}"
+            start_record_name: "{{item.name | regex_replace('-(?!.*-).*')}}.{{cluster_vars.dns_user_domain}}"
+          register: r__route53_info
           with_items: "{{ hosts_to_clean }}"
+          until: r__route53_info is success
+          retries: 10
 
         - name: clean/dns/route53 | Delete CNAME records
           route53:
             aws_access_key: "{{cluster_vars[buildenv].aws_access_key}}"
             aws_secret_key: "{{cluster_vars[buildenv].aws_secret_key}}"
             state: "absent"
-            zone: "{{ item.1.set.zone }}"
-            record: "{{ item.1.set.record }}"
-            type: "{{ item.1.set.type }}"
-            ttl: "{{ item.1.set.ttl }}"
-            value: ["{{ item.1.set.value }}"]
+            zone: "{{ cluster_vars.dns_nameserver_zone }}"
+            record: "{{ item.1.Name }}"
+            type: "{{ item.1.Type }}"
+            ttl: "{{ item.1.TTL }}"
+            value: "{{ item.1.ResourceRecords | json_query(\"[].Value\") }}"
             private_zone: "{{cluster_vars.route53_private_zone | default(true)}}"
+          vars:
+            _cnames_to_clean: "{{ hosts_to_clean | json_query(\"[].name\") | map('regex_replace', '^(.*)-(?!.*-).*$', '\\1.' + cluster_vars.dns_user_domain + '.') }}"   #Remove the last '-.*' (cluster_suffix)
+            records_to_clean: "{{ r__route53_info.results | json_query(\"[].ResourceRecordSets[?Type=='CNAME' && contains(\"+ _cnames_to_clean | string +\", Name)][]\") | unique }}"
           with_nested:
             - "{{ hosts_to_clean }}"
-            - "{{ r__route53_cname.results }}"
-          when: (item.1.set.value is defined)  and  ((item.0.name | regex_replace('-(?!.*-).*')) == (item.1.set.record | regex_replace('^(.*?)\\..*$', '\\1')))  and  (item.0.name == item.1.set.value | regex_replace('^(.*?)\\..*$', '\\1'))
+            - "{{ records_to_clean }}"
+          when: ((item.0.name | regex_replace('-(?!.*-).*')) == (item.1.Name | regex_replace('^(.*?)\\..*$', '\\1')))  and  ((item.0.name == item.1.ResourceRecords[0].Value | regex_replace('^(.*?)\\..*$', '\\1')))
       when: cluster_vars.dns_server == "route53"
 
     - name: clean/dns/clouddns | Delete DNS entries

--- a/config/tasks/main.yml
+++ b/config/tasks/main.yml
@@ -1,5 +1,10 @@
 ---
 
+- name: Run cloud-specific config (if defined)
+  include: "{{ item }}"
+  loop: "{{ query('first_found', params) }}"
+  vars: { params: { files: ["config_{{cluster_vars.type}}.yml"], skip: true } }
+
 - name: Disable unattended-upgrades and apt-daily services & timers. Wait for in-flight updates to finish.
   block:
     - name: Disable unattended-upgrades and apt-daily services & timers

--- a/jenkinsfiles/Jenkinsfile_testsuite
+++ b/jenkinsfiles/Jenkinsfile_testsuite
@@ -3,23 +3,24 @@
 // NOTE: Clusterverse is an independent Ansible role - it cannot run on its own, and needs cluster variables and top-level playbooks of the kind defined in roles/clusterverse/EXAMPLE/ that will import clusterverse
 // This test suite executes (a matrix of) a series of deploy/redeploy/clean steps that are defined in a Jenkinsfile that are located in such a playbook that can actually run clusterverse (e.g. roles/clusterverse/EXAMPLE/jenkinsfiles/Jenkinsfile_ops)
 
-//This will not be needed if we're running this as a multibranch pipeline SCM job, as these are automatically added to the 'scm' variable, but if we instead just cut & paste this file into a pipeline job, they will be used as fallback
-def DEFAULT_CLUSTERVERSE_URL = "https://github.com/sky-uk/clusterverse"
-def DEFAULT_CLUSTERVERSE_BRANCH = "master"
 
-//Set the git branch for clusterverse_ops to either the PR branch (env.CHANGE_BRANCH), or the current SCM branch (env.BRANCH_NAME)
-def CV_OPS_GIT_BRANCH = DEFAULT_CLUSTERVERSE_BRANCH
-if (env.CHANGE_BRANCH) {
-  CV_OPS_GIT_BRANCH = env.CHANGE_BRANCH
-}
-else if (env.BRANCH_NAME) {
-  CV_OPS_GIT_BRANCH = env.BRANCH_NAME
+//This is the branch name we must pass to Jenkinsfile_ops as the git branch from which it will checkout Clusterverse.  Normally, we would rely on the 'scm' object being available (as it is a pipeline scm job), but the scm object does not propagate to downstream Jenkinsfiles.
+def CV_OPS_GIT_BRANCH = "master"
+if (env.TAG_NAME) {
+    CV_OPS_GIT_BRANCH = env.TAG_NAME
+} else if (env.CHANGE_BRANCH) {
+    CV_OPS_GIT_BRANCH = env.CHANGE_BRANCH
+} else if (env.BRANCH_NAME) {
+    CV_OPS_GIT_BRANCH = env.BRANCH_NAME
 }
 
-//This allows us to copy&paste this entire script into a pipeline job in the GUI for faster development time (don't have to commit/push to Git to test every change).
-def scmVars = null
-if (currentBuild.getBuildCauses('hudson.model.Cause$SCMTriggerCause').size() > 0) {
-  scmVars = checkout scm
+// Tolerate non-scm builds
+def CV_OPS_GIT_URL = "https://github.com/sky-uk/clusterverse"
+try {
+    CV_OPS_GIT_URL = scm.getUserRemoteConfigs()[0].getUrl()
+} catch (Exception e) {
+    println("scm not available: " + e.toString())
+    println("we're probably *not* running in a multibranch or pipeline scm job")
 }
 
 
@@ -29,73 +30,74 @@ if (currentBuild.getBuildCauses('hudson.model.Cause$SCMTriggerCause').size() > 0
 // It takes some inspiration from this blog: https://www.jenkins.io/blog/2019/12/02/matrix-building-with-scripted-pipeline/
 /**************************************************************************************/
 class MatrixBuilder {
-  private HashMap jenkinsParamsCopy
-  private HashMap _matrixParams               //This cannot be made into a Closure due to CPS (again).  (https://www.jenkins.io/doc/book/pipeline/cps-method-mismatches/)
-  private Closure clJenkinsParamsMutate
-  private Closure clMatrixAxesFilter
-  private Closure clTaskMap
+    private HashMap jenkinsParams
+    private HashMap _matrixParams               //This cannot be made into a Closure due to CPS (again).  (https://www.jenkins.io/doc/book/pipeline/cps-method-mismatches/)
+    private Closure clJenkinsParamsMutate       //A closure that mutates the Jenkins params _before_ we calculate the axes.  Useful in case some params are not intended to be part of the axes (and should be removed)
+    private Closure clMatrixAxesFilter          //A closure of invalid axis combinations, which allows us to filter out combinations that are incompatible with each other (e.g. testing internet explorer on linux)
+    private Closure clTaskMap
 
-  // NOTE: No constructor.
-  // When undeclared, constructors are created automatically, creating the instance variables defined above, (where they correspond to the Map that is passed with the instantiation).  You can't do a lot of work in a Jenkins Groovy constructor anyway because of CPS (https://www.jenkins.io/doc/book/pipeline/cps-method-mismatches/)
+    // NOTE: No constructor.
+    // When undeclared, constructors are created automatically, creating the instance variables defined above, (where they correspond to the Map that is passed with the instantiation).  You can't do a lot of work in a Jenkins Groovy constructor anyway because of CPS (https://www.jenkins.io/doc/book/pipeline/cps-method-mismatches/)
 
-  public Map getTaskMap() {
-    HashMap tasks = [failFast: false]
-    _getMatrixAxes().each() { axis ->
-      List axisEnvVars = axis.collect { key, val -> "${key}=${val}" }
-      axisEnvVars.add("BUILD_HASH=" + generateMD5(hashCode() + axisEnvVars.join(','), 12))      //A unique build hash of the classid (hashcode) and the matrix elements
-      tasks[axisEnvVars.join(', ')] = { this.clTaskMap(axisEnvVars) }
+    public Map getTaskMap() {
+        HashMap tasks = [failFast: false]
+        _getMatrixAxes().each() { axis ->
+            List axisEnvVars = axis.collect { key, val -> "${key}=${val}" }
+            axisEnvVars.add("BUILD_HASH=" + generateMD5(hashCode() + axisEnvVars.join(','), 12))      //A unique build hash of the classid (hashcode) and the matrix elements
+            tasks[axisEnvVars.join(', ')] = { this.clTaskMap(axisEnvVars) }
+        }
+        return (tasks)
     }
-    return (tasks)
-  }
 
-  private List _getMatrixAxes() {
-    this._getMatrixParams()
-    List allCombinations = this._getAxesCombinations()
-    return (this.clMatrixAxesFilter ? allCombinations.findAll(this.clMatrixAxesFilter) : allCombinations)
-  }
-
-  private HashMap _getMatrixParams() {
-    HashMap newMatrixParams = Eval.me(this.jenkinsParamsCopy.inspect())
-    newMatrixParams = this.clJenkinsParamsMutate ? this.clJenkinsParamsMutate(newMatrixParams) : newMatrixParams
-    newMatrixParams = newMatrixParams.each { key, choice -> newMatrixParams.put(key, (choice instanceof String) ? choice.split(',') : choice.toString()) }      //newMatrixParams().each { param -> param.value = (param.value instanceof String) ? param.value.split(',') : param.value }     //NOTE: Doesn't work: https://www.jenkins.io/doc/book/pipeline/cps-method-mismatches/
-    this._matrixParams = newMatrixParams
-    return (newMatrixParams)
-  }
-
-  @NonCPS
-  private List _getAxesCombinations() {
-    List axes = []
-    this._matrixParams.each { axis, values ->
-      List axisList = []
-      values.each { value ->
-        axisList << [(axis): value]
-      }
-      axes << axisList
+    private List _getMatrixAxes() {
+        this._getMatrixParams()
+        List allCombinations = this._getAxesCombinations()
+        return (this.clMatrixAxesFilter ? allCombinations.findAll(this.clMatrixAxesFilter) : allCombinations)
     }
-    axes.combinations()*.sum()    // calculates the cartesian product
-  }
 
-  static String generateMD5(String s, int len = 31) {
-    java.security.MessageDigest.getInstance("MD5").digest(s.bytes).encodeHex().toString()[0..len]
-  }
+    private HashMap _getMatrixParams() {
+        HashMap newMatrixParams = Eval.me(this.jenkinsParams.inspect())
+        newMatrixParams = this.clJenkinsParamsMutate ? this.clJenkinsParamsMutate(newMatrixParams) : newMatrixParams
+        newMatrixParams = newMatrixParams.each { key, choice -> newMatrixParams.put(key, (choice instanceof String) ? choice.split(',') : choice.toString()) }      //newMatrixParams().each { param -> param.value = (param.value instanceof String) ? param.value.split(',') : param.value }     //NOTE: Doesn't work: https://www.jenkins.io/doc/book/pipeline/cps-method-mismatches/
+        this._matrixParams = newMatrixParams
+        return (newMatrixParams)
+    }
+
+    @NonCPS
+    private List _getAxesCombinations() {
+        List axes = []
+        this._matrixParams.each { axis, values ->
+            List axisList = []
+            values.each { value ->
+                axisList << [(axis): value]
+            }
+            axes << axisList
+        }
+        axes.combinations()*.sum()    // calculates the cartesian product
+    }
+
+    static String generateMD5(String s, int len = 31) {
+        java.security.MessageDigest.getInstance("MD5").digest(s.bytes).encodeHex().toString()[0..len]
+    }
 }
 
 
 properties([
-    //disableConcurrentBuilds(),
-    //pipelineTriggers([pollSCM(ignorePostCommitHooks: true, scmpoll_spec: '''H/30 8-19 * * 1-5''')]),
-    parameters([
-        extendedChoice(name: 'CLOUD_REGION', type: 'PT_MULTI_SELECT', value: 'aws/us-west-2,aws/eu-central-1,aws/eu-west-1,gcp/us-west2,gcp/europe-west1', description: 'Specify which cloud/region(s) to test', visibleItemCount: 5),
-        choice(name: 'BUILDENV', choices: ['', 'dev', 'mgmt'], description: "The environment in which to run the tests"),
-        string(name: 'CLUSTER_ID', defaultValue: 'top_peacock', trim: true),
-        [name: 'DNS_FORCE_DISABLE', $class: 'ChoiceParameter', choiceType: 'PT_RADIO', description: '', randomName: 'choice-parameter-31196915540455', script: [$class: 'GroovyScript', fallbackScript: [classpath: [], sandbox: true, script: ''], script: [classpath: [], sandbox: true, script: 'return [\'false:selected\',\'true\',\'true,false\']']]],
-        extendedChoice(name: 'REDEPLOY_SCHEME', type: 'PT_CHECKBOX', value: '_scheme_addallnew_rmdisk_rollback,_scheme_addnewvm_rmdisk_rollback,_scheme_rmvm_rmdisk_only,_scheme_rmvm_keepdisk_rollback', defaultValue: '_scheme_addallnew_rmdisk_rollback,_scheme_addnewvm_rmdisk_rollback,_scheme_rmvm_rmdisk_only,_scheme_rmvm_keepdisk_rollback', description: 'Specify which redeploy scheme(s) to test', visibleItemCount: 5),
-        choice(name: 'CLEAN_ON_FAILURE', choices: [true, false], description: "Run a clusterverse clean in the event of a failure."),
-        extendedChoice(name: 'MYHOSTTYPES_TEST', type: 'PT_MULTI_SELECT', value: 'nomyhosttypes,myhosttypes', defaultValue: 'nomyhosttypes', descriptionPropertyValue: 'Without myhosttypes, With myhosttypes', description: 'Whether to run tests on pre-configured hosttypes.', visibleItemCount: 2),
-        [name: 'MYHOSTTYPES_LIST', $class: 'DynamicReferenceParameter', choiceType: 'ET_FORMATTED_HTML', description: 'These hosttype definitions must exist in cluster_vars for all clusters', randomName: 'choice-parameter-423779762617532', referencedParameters: 'MYHOSTTYPES_TEST', script: [$class: 'GroovyScript', fallbackScript: [classpath: [], sandbox: true, script: 'return ""'], script: [classpath: [], sandbox: true, script: 'if (MYHOSTTYPES_TEST.split(\',\').contains(\'myhosttypes\')) { return ("<input name=\\"value\\" value=\\"sys,sysdisks2\\" class=\\"setting-input\\" type=\\"text\\">") }']]],
-        [name: 'MYHOSTTYPES_SERIAL_PARALLEL', $class: 'CascadeChoiceParameter', choiceType: 'PT_RADIO', description: 'Run the myhosttype test in serial or parallel', randomName: 'choice-parameter-424489601389882', referencedParameters: 'MYHOSTTYPES_TEST', script: [$class: 'GroovyScript', fallbackScript: [classpath: [], sandbox: true, script: 'return([])'], script: [classpath: [], sandbox: true, script: 'if (MYHOSTTYPES_TEST==\'nomyhosttypes,myhosttypes\') { return([\'serial:selected\',\'parallel\']) }']]],
-        extendedChoice(name: 'IMAGE_TESTED', type: 'PT_MULTI_SELECT', value: '_ubuntu2004image,_centos7image', defaultValue: '_ubuntu2004image', descriptionPropertyValue: 'Ubuntu 20.04, CentOS 7', description: 'Specify which image(s) to test', visibleItemCount: 3),
-    ])
+        //disableConcurrentBuilds(),
+        //pipelineTriggers([pollSCM(ignorePostCommitHooks: true, scmpoll_spec: '''H/30 8-19 * * 1-5''')]),
+        parameters([
+                extendedChoice(name: 'CLOUD_REGION', type: 'PT_MULTI_SELECT', value: 'aws/us-west-2,aws/eu-central-1,aws/eu-west-1,gcp/us-west2,gcp/europe-west1', description: 'Specify which cloud/region(s) to test', visibleItemCount: 5),
+                choice(name: 'BUILDENV', choices: ['', 'dev', 'mgmt'], description: "The environment in which to run the tests"),
+                string(name: 'CLUSTER_ID', defaultValue: '', trim: true),
+                [name: 'DNS_FORCE_DISABLE', $class: 'ChoiceParameter', choiceType: 'PT_RADIO', description: '', randomName: 'choice-parameter-31196915540455', script: [$class: 'GroovyScript', fallbackScript: [classpath: [], sandbox: true, script: ''], script: [classpath: [], sandbox: true, script: 'return [\'false:selected\',\'true\',\'true,false\']']]],
+                extendedChoice(name: 'REDEPLOY_SCHEME', type: 'PT_CHECKBOX', value: '_scheme_addallnew_rmdisk_rollback,_scheme_addnewvm_rmdisk_rollback,_scheme_rmvm_rmdisk_only,_scheme_rmvm_keepdisk_rollback', defaultValue: '_scheme_addallnew_rmdisk_rollback,_scheme_addnewvm_rmdisk_rollback,_scheme_rmvm_rmdisk_only,_scheme_rmvm_keepdisk_rollback', description: 'Specify which redeploy scheme(s) to test', visibleItemCount: 5),
+                choice(name: 'CLEAN_ON_FAILURE', choices: [true, false], description: "Run a clusterverse clean in the event of a failure."),
+                extendedChoice(name: 'MYHOSTTYPES_TEST', type: 'PT_MULTI_SELECT', value: 'nomyhosttypes,myhosttypes', defaultValue: 'nomyhosttypes', descriptionPropertyValue: 'Without myhosttypes, With myhosttypes', description: 'Whether to run tests on pre-configured hosttypes.', visibleItemCount: 3),
+                [name: 'MYHOSTTYPES_LIST', $class: 'DynamicReferenceParameter', choiceType: 'ET_FORMATTED_HTML', description: 'These hosttype definitions must exist in cluster_vars for all clusters', randomName: 'choice-parameter-423779762617532', referencedParameters: 'MYHOSTTYPES_TEST', script: [$class: 'GroovyScript', fallbackScript: [classpath: [], sandbox: true, script: 'return ""'], script: [classpath: [], sandbox: true, script: 'if (MYHOSTTYPES_TEST.split(\',\').contains(\'myhosttypes\')) { return ("<input name=\\"value\\" value=\\"sys,sysdisks2\\" class=\\"setting-input\\" type=\\"text\\">") }']]],
+                [name: 'MYHOSTTYPES_SERIAL_PARALLEL', $class: 'CascadeChoiceParameter', choiceType: 'PT_RADIO', description: 'Run the myhosttype test in serial or parallel', randomName: 'choice-parameter-424489601389882', referencedParameters: 'MYHOSTTYPES_TEST', script: [$class: 'GroovyScript', fallbackScript: [classpath: [], sandbox: true, script: 'return([])'], script: [classpath: [], sandbox: true, script: 'if (MYHOSTTYPES_TEST==\'nomyhosttypes,myhosttypes\') { return([\'serial:selected\',\'parallel\']) }']]],
+                extendedChoice(name: 'SCALEUPDOWN', type: 'PT_MULTI_SELECT', value: 'noscale,scaleup,scaledown', defaultValue: 'noscale', description: 'Specify whether to test scaling up and/or down.', visibleItemCount: 3),
+                extendedChoice(name: 'IMAGE_TESTED', type: 'PT_MULTI_SELECT', value: '_ubuntu2004image,_centos7image', defaultValue: '_ubuntu2004image', descriptionPropertyValue: 'Ubuntu 20.04, CentOS 7', description: 'Specify which image(s) to test', visibleItemCount: 3),
+        ])
 ])
 
 println("User-supplied 'params': \n" + params.inspect() + "\n")
@@ -107,155 +109,193 @@ println("User-supplied 'params': \n" + params.inspect() + "\n")
 
 // A class to hold the status of each stage, so we can fail a stage and be able to run the clean at the end if needed
 class cStageBuild {
-  public String result = 'SUCCESS'
-  public HashMap userParams = [:]
+    public String result = 'SUCCESS'
+    public HashMap userParams = [:]
 
-  String getUserParamsString() {
-    String userParamsString = ""
-    this.userParams.each({paramName, paramVal ->
-      userParamsString += " -e ${paramName}=${paramVal}"
-    })
-    return(userParamsString + " -vvvv")
-  }
+    String getUserParamsString() {
+        String userParamsString = ""
+        this.userParams.each({ paramName, paramVal ->
+            userParamsString += " -e ${paramName}=${paramVal}"
+        })
+        return (userParamsString + " -vvvv")
+    }
 }
 
 // A pipeline 'stage' template for clusterverse-ops boilerplate
 def stage_cvops(String stageLabel, cStageBuild stageBuild, Closure stageExpressions) {
-  stage(stageLabel) {
-    if (stageBuild.result == 'SUCCESS') {
-      try {
-        stageExpressions()
-      } catch (Exception err) {
-        currentBuild.result = 'FAILURE'
-        stageBuild.result = 'FAILURE'
-        unstable('Stage failed!  Error was: ' + err)       // OR:  'error "Stage failure"' or 'throw new org.jenkinsci.plugins.workflow.steps.FlowInterruptedException(hudson.model.Result.FAILURE)', but both of these fail all future stages, preventing us calling the clean.
-      }
+    stage(stageLabel) {
+        if (stageBuild.result == 'SUCCESS') {
+            try {
+                stageExpressions()
+            } catch (Exception err) {
+                currentBuild.result = 'FAILURE'
+                stageBuild.result = 'FAILURE'
+                unstable('Stage failed!  Error was: ' + err)       // OR:  'error "Stage failure"' or 'throw new org.jenkinsci.plugins.workflow.steps.FlowInterruptedException(hudson.model.Result.FAILURE)', but both of these fail all future stages, preventing us calling the clean.
+            }
+        }
     }
-  }
 }
 
-/**************************************************************************************/
-// A 'self-test' matrix.  Doesn't actually do anything, just tests the logic of the matrix
-/**************************************************************************************/
-SELFTEST = new MatrixBuilder([
-    jenkinsParamsCopy: params,
-    clJenkinsParamsMutate: { jenkinsParamsCopy ->
-      jenkinsParamsCopy.remove('MYHOSTTYPES_LIST')
-      jenkinsParamsCopy.remove('MYHOSTTYPES_TEST')
-      jenkinsParamsCopy.remove('MYHOSTTYPES_SERIAL_PARALLEL')
-      jenkinsParamsCopy.remove('CLEAN_ON_FAILURE')
-      return jenkinsParamsCopy
-    },
-    clMatrixAxesFilter: { axis ->
-      !(params.DNS_TEST == 'both' && axis['DNS_FORCE_DISABLE'] == 'true' && axis['CLOUD_REGION'] == 'esxifree/dougalab') &&
-      !(axis['IMAGE_TESTED'] != '_ubuntu2004image' && axis['CLOUD_REGION'] == 'esxifree/dougalab')
-    },
-    clTaskMap: { axisEnvVars ->
-      node {
-        withEnv(axisEnvVars) {
-          withCredentials([string(credentialsId: "VAULT_PASSWORD_${env.BUILDENV.toUpperCase()}", variable: 'VAULT_PASSWORD_BUILDENV')]) {
-            env.VAULT_PASSWORD_BUILDENV = VAULT_PASSWORD_BUILDENV
-          }
-          sh 'printenv | sort'
-          def stageBuild = new cStageBuild([result: 'SUCCESS'])
-
-          stage_cvops('deploy', stageBuild, {
-            echo "deploy"
-          })
-
-          stage_cvops('redeploy (1/4 fail)', stageBuild, {
-            echo "redeploy"
-            //Test that script can fail individual stages (1 in 4 should fail)
-            def x = Math.abs(new Random().nextInt() % 4) + 1
-            if (x == 1) throw new IllegalStateException("Test failed stage")
-          })
-
-          stage_cvops('deploy on top', stageBuild, {
-            echo "deploy on top"
-          })
-        }
-      }
-    }
-])
+///**************************************************************************************/
+//// A 'self-test' matrix.  Doesn't actually do anything, just tests the logic of the matrix
+///**************************************************************************************/
+////SELFTEST = library('MatrixBuilder').org.dougalseeley.MatrixBuilder.new([
+//SELFTEST = new MatrixBuilder([
+//        jenkinsParams: params,
+//        clJenkinsParamsMutate: { jenkinsParams ->
+//            jenkinsParams.remove('MYHOSTTYPES_LIST')
+//            jenkinsParams.remove('MYHOSTTYPES_TEST')
+//            jenkinsParams.remove('MYHOSTTYPES_SERIAL_PARALLEL')
+//            jenkinsParams.remove('CLEAN_ON_FAILURE')
+//            return jenkinsParams
+//        },
+//        clMatrixAxesFilter: { axis ->
+//            !(params.DNS_TEST == 'both' && axis['DNS_FORCE_DISABLE'] == 'true' && axis['CLOUD_REGION'] == 'esxifree/dougalab') &&                                 /* DNS is not supported in dougalab */
+//                    !(axis['IMAGE_TESTED'] != '_ubuntu2004image' && axis['CLOUD_REGION'] == 'esxifree/dougalab') &&                                               /* Only _ubuntu2004image is supported in dougalab */
+//                    !(axis['REDEPLOY_SCHEME'] == '_scheme_rmvm_keepdisk_rollback' && axis['CLOUD_REGION'].split('/')[0] == 'azure') &&                            /* _scheme_rmvm_keepdisk_rollback not supported in Azure */
+//                    !(axis['REDEPLOY_SCHEME'] == '_scheme_rmvm_rmdisk_only' && axis['SCALEUPDOWN'] == 'scaledown') &&                                             /* _scheme_rmvm_rmdisk_only only supports scaling up */
+//                    !(axis['REDEPLOY_SCHEME'] == '_scheme_rmvm_keepdisk_rollback' && (axis['SCALEUPDOWN'] == 'scaledown' || axis['SCALEUPDOWN'] == 'scaleup'))    /* _scheme_rmvm_keepdisk_rollback does not support scaling */
+//        },
+//        clTaskMap: { axisEnvVars ->
+//            node {
+//                withEnv(axisEnvVars) {
+//                    withCredentials([string(credentialsId: "VAULT_PASSWORD_${env.BUILDENV.toUpperCase()}", variable: 'VAULT_PASSWORD_BUILDENV')]) {
+//                        env.VAULT_PASSWORD_BUILDENV = VAULT_PASSWORD_BUILDENV
+//                    }
+//                    sh 'printenv | sort'
+//                    def stageBuild = new cStageBuild([result: 'SUCCESS'])
+//
+//                    stage_cvops('deploy', stageBuild, {
+//                        echo "deploy"
+//                    })
+//
+//                    stage_cvops('redeploy (1/4 fail)', stageBuild, {
+//                        echo "redeploy"
+//                        //Test that script can fail individual stages (1 in 4 should fail)
+//                        def x = Math.abs(new Random().nextInt() % 4) + 1
+//                        if (x == 1) throw new IllegalStateException("Test failed stage")
+//                    })
+//
+//                    stage_cvops('deploy on top', stageBuild, {
+//                        echo "deploy on top"
+//                    })
+//                }
+//            }
+//        }
+//])
 
 
 /**************************************************************************************/
 // Runs tests *without* setting myhosttypes.  This is a relatively straightforward application of the matrix algorithm.
 /**************************************************************************************/
 CVTEST_NOMYHOSTTYPES = new MatrixBuilder([
-    jenkinsParamsCopy: params,
-    clJenkinsParamsMutate: { jenkinsParamsCopy ->
-      jenkinsParamsCopy.remove('MYHOSTTYPES_LIST')
-      jenkinsParamsCopy.remove('MYHOSTTYPES_TEST')
-      jenkinsParamsCopy.remove('MYHOSTTYPES_SERIAL_PARALLEL')
-      jenkinsParamsCopy.remove('CLEAN_ON_FAILURE')
-      return jenkinsParamsCopy
-    },
-    clMatrixAxesFilter: { axis ->
-      !(params.DNS_TEST == 'both' && axis['DNS_FORCE_DISABLE'] == 'true' && axis['CLOUD_REGION'] == 'esxifree/dougalab') &&
-      !(axis['IMAGE_TESTED'] != '_ubuntu2004image' && axis['CLOUD_REGION'] == 'esxifree/dougalab')
-    },
-    clTaskMap: { axisEnvVars ->
-      node {
-        withEnv(axisEnvVars) {
-          withCredentials([string(credentialsId: "VAULT_PASSWORD_${env.BUILDENV.toUpperCase()}", variable: 'VAULT_PASSWORD_BUILDENV')]) {
-            env.VAULT_PASSWORD_BUILDENV = VAULT_PASSWORD_BUILDENV
-          }
-          sh 'printenv | sort'
-          def stageBuild = new cStageBuild([result: 'SUCCESS'])
+        jenkinsParams: params,
+        clJenkinsParamsMutate: { jenkinsParams ->
+            jenkinsParams.remove('MYHOSTTYPES_LIST')
+            jenkinsParams.remove('MYHOSTTYPES_TEST')
+            jenkinsParams.remove('MYHOSTTYPES_SERIAL_PARALLEL')
+            jenkinsParams.remove('CLEAN_ON_FAILURE')
+            return jenkinsParams
+        },
+        clMatrixAxesFilter: { axis ->
+            !(params.DNS_TEST == 'both' && axis['DNS_FORCE_DISABLE'] == 'true' && axis['CLOUD_REGION'] == 'esxifree/dougalab') &&                                 /* DNS is not supported in dougalab */
+                    !(axis['IMAGE_TESTED'] != '_ubuntu2004image' && axis['CLOUD_REGION'] == 'esxifree/dougalab') &&                                               /* Only _ubuntu2004image is supported in dougalab */
+                    !(axis['REDEPLOY_SCHEME'] == '_scheme_rmvm_keepdisk_rollback' && axis['CLOUD_REGION'].split('/')[0] == 'azure') &&                            /* _scheme_rmvm_keepdisk_rollback not supported in Azure */
+                    !(axis['REDEPLOY_SCHEME'] == '_scheme_rmvm_rmdisk_only' && axis['SCALEUPDOWN'] == 'scaledown') &&                                             /* _scheme_rmvm_rmdisk_only only supports scaling up */
+                    !(axis['REDEPLOY_SCHEME'] == '_scheme_rmvm_keepdisk_rollback' && (axis['SCALEUPDOWN'] == 'scaledown' || axis['SCALEUPDOWN'] == 'scaleup'))    /* _scheme_rmvm_keepdisk_rollback does not support scaling */
+        },
+        clTaskMap: { axisEnvVars ->
+            node {
+                withEnv(axisEnvVars) {
+                    withCredentials([string(credentialsId: "VAULT_PASSWORD_${env.BUILDENV.toUpperCase()}", variable: 'VAULT_PASSWORD_BUILDENV')]) {
+                        env.VAULT_PASSWORD_BUILDENV = VAULT_PASSWORD_BUILDENV
+                    }
+                    sh 'printenv | sort'
+                    def stageBuild = new cStageBuild([result: 'SUCCESS'])
+                    HashMap cluster_vars_override = [:]
 
-          if (env.IMAGE_TESTED) {
-            stageBuild.userParams.put("cluster_vars_override", "\\\'{\\\"image\\\":\\\"{{${env.IMAGE_TESTED}}}\\\"}\\\'")       //NOTE: NO SPACES are allowed in this!!
-          }
+                    if (env.IMAGE_TESTED) {
+                        cluster_vars_override += [image: "{{${env.IMAGE_TESTED}}}"]
+                        stageBuild.userParams.put("cluster_vars_override", "\\\'" + groovy.json.JsonOutput.toJson(cluster_vars_override).replace("\"", "\\\"") + "\\\'")   //NOTE: NO SPACES are allowed in this!!
+                    }
 
+                    stageBuild.userParams.put("skip_release_version_check", "true")
+                    stageBuild.userParams.put("release_version", "1_0_0")
+                    stage_cvops('deploy', stageBuild, {
+                        build job: 'clusterverse/clusterverse-ops', parameters: [string(name: 'APP_NAME', value: "cvtest-${BUILD_NUMBER}-${env.BUILD_HASH}"), string(name: 'CLOUD_REGION', value: env.CLOUD_REGION), string(name: 'BUILDENV', value: env.BUILDENV), string(name: 'CLUSTER_ID', value: env.CLUSTER_ID), booleanParam(name: 'DNS_FORCE_DISABLE', value: env.DNS_FORCE_DISABLE), string(name: 'DEPLOY_TYPE', value: 'deploy'), string(name: 'REDEPLOY_SCHEME', value: ''), string(name: 'CANARY', value: 'none'), booleanParam(name: 'CANARY_TIDY_ON_SUCCESS', value: true), string(name: 'MYHOSTTYPES', value: ''), string(name: 'CV_GIT_URL', value: CV_OPS_GIT_URL), string(name: 'CV_GIT_BRANCH', value: CV_OPS_GIT_BRANCH), string(name: 'USER_CMDLINE_VARS', value: stageBuild.getUserParamsString())]
+                    })
 
-          stageBuild.userParams.put("skip_release_version_check", "true")
-          stageBuild.userParams.put("release_version", "1_0_0")
-          stage_cvops('deploy', stageBuild, {
-            build job: 'clusterverse/clusterverse-ops', parameters: [string(name: 'APP_NAME', value: "cvtest-${BUILD_NUMBER}-${env.BUILD_HASH}"), string(name: 'CLOUD_REGION', value: env.CLOUD_REGION), string(name: 'BUILDENV', value: env.BUILDENV), string(name: 'CLUSTER_ID', value: env.CLUSTER_ID), booleanParam(name: 'DNS_FORCE_DISABLE', value: env.DNS_FORCE_DISABLE), string(name: 'DEPLOY_TYPE', value: 'deploy'), string(name: 'REDEPLOY_SCHEME', value: ''), string(name: 'CANARY', value: 'none'), booleanParam(name: 'CANARY_TIDY_ON_SUCCESS', value: true), string(name: 'MYHOSTTYPES', value: ''), string(name: 'CV_GIT_URL', value: scmVars ? scmVars.getUserRemoteConfigs()[0].getUrl() : DEFAULT_CLUSTERVERSE_URL), string(name: 'CV_GIT_BRANCH', value: CV_OPS_GIT_BRANCH), string(name: 'USER_CMDLINE_VARS', value: stageBuild.userParamsString())]
-          })
+                    // Update the clustervars with new scaled cluster size
+                    if (env.SCALEUPDOWN == 'scaleup') {
+                        cluster_vars_override += ["${env.BUILDENV}": [hosttype_vars: [sys: [vms_by_az: [b: 1, c: 1]]]]]     // AZ 'c' is not set normally
+                    } else if (env.SCALEUPDOWN == 'scaledown') {
+                        cluster_vars_override += ["${env.BUILDENV}": [hosttype_vars: [sys: [vms_by_az: [b: 0, c: 0]]]]]     // AZ 'b' is set normally
+                    }
 
-          if (env.REDEPLOY_SCHEME) {
-            stageBuild.userParams.put("release_version", "2_0_0")
-            stage_cvops('redeploy canary=start', stageBuild, {
-              build job: 'clusterverse/clusterverse-ops', parameters: [string(name: 'APP_NAME', value: "cvtest-${env.BUILD_NUMBER}-${env.BUILD_HASH}"), string(name: 'CLOUD_REGION', value: env.CLOUD_REGION), string(name: 'BUILDENV', value: env.BUILDENV), string(name: 'CLUSTER_ID', value: env.CLUSTER_ID), booleanParam(name: 'DNS_FORCE_DISABLE', value: DNS_FORCE_DISABLE), string(name: 'DEPLOY_TYPE', value: 'redeploy'), string(name: 'REDEPLOY_SCHEME', value: (env.REDEPLOY_SCHEME ? env.REDEPLOY_SCHEME : '')), string(name: 'CANARY', value: 'start'), booleanParam(name: 'CANARY_TIDY_ON_SUCCESS', value: false), string(name: 'MYHOSTTYPES', value: ''), string(name: 'CV_GIT_URL', value: scmVars ? scmVars.getUserRemoteConfigs()[0].getUrl() : DEFAULT_CLUSTERVERSE_URL), string(name: 'CV_GIT_BRANCH', value: CV_OPS_GIT_BRANCH), string(name: 'USER_CMDLINE_VARS', value: stageBuild.userParamsString())]
-            })
+                    if (cluster_vars_override.size()) {
+                        stageBuild.userParams.put("cluster_vars_override", "\\\'" + groovy.json.JsonOutput.toJson(cluster_vars_override).replace("\"", "\\\"") + "\\\'")   //NOTE: NO SPACES are allowed in this!!
+                    }
 
-            stage_cvops('redeploy canary=finish', stageBuild, {
-              build job: 'clusterverse/clusterverse-ops', parameters: [string(name: 'APP_NAME', value: "cvtest-${env.BUILD_NUMBER}-${env.BUILD_HASH}"), string(name: 'CLOUD_REGION', value: env.CLOUD_REGION), string(name: 'BUILDENV', value: env.BUILDENV), string(name: 'CLUSTER_ID', value: env.CLUSTER_ID), booleanParam(name: 'DNS_FORCE_DISABLE', value: DNS_FORCE_DISABLE), string(name: 'DEPLOY_TYPE', value: 'redeploy'), string(name: 'REDEPLOY_SCHEME', value: (env.REDEPLOY_SCHEME ? env.REDEPLOY_SCHEME : '')), string(name: 'CANARY', value: 'finish'), booleanParam(name: 'CANARY_TIDY_ON_SUCCESS', value: false), string(name: 'MYHOSTTYPES', value: ''), string(name: 'CV_GIT_URL', value: scmVars ? scmVars.getUserRemoteConfigs()[0].getUrl() : DEFAULT_CLUSTERVERSE_URL), string(name: 'CV_GIT_BRANCH', value: CV_OPS_GIT_BRANCH), string(name: 'USER_CMDLINE_VARS', value: stageBuild.userParamsString())]
-            })
+                    if (env.REDEPLOY_SCHEME) {
+                        stageBuild.userParams.put("release_version", "2_0_0")
+                        stage_cvops('redeploy canary=start', stageBuild, {
+                            build job: 'clusterverse/clusterverse-ops', parameters: [string(name: 'APP_NAME', value: "cvtest-${env.BUILD_NUMBER}-${env.BUILD_HASH}"), string(name: 'CLOUD_REGION', value: env.CLOUD_REGION), string(name: 'BUILDENV', value: env.BUILDENV), string(name: 'CLUSTER_ID', value: env.CLUSTER_ID), booleanParam(name: 'DNS_FORCE_DISABLE', value: env.DNS_FORCE_DISABLE), string(name: 'DEPLOY_TYPE', value: 'redeploy'), string(name: 'REDEPLOY_SCHEME', value: (env.REDEPLOY_SCHEME ? env.REDEPLOY_SCHEME : '')), string(name: 'CANARY', value: 'start'), booleanParam(name: 'CANARY_TIDY_ON_SUCCESS', value: false), string(name: 'MYHOSTTYPES', value: ''), string(name: 'CV_GIT_URL', value: CV_OPS_GIT_URL), string(name: 'CV_GIT_BRANCH', value: CV_OPS_GIT_BRANCH), string(name: 'USER_CMDLINE_VARS', value: stageBuild.getUserParamsString())]
+                        })
 
-            stage_cvops('redeploy canary=tidy', stageBuild, {
-              build job: 'clusterverse/clusterverse-ops', parameters: [string(name: 'APP_NAME', value: "cvtest-${env.BUILD_NUMBER}-${env.BUILD_HASH}"), string(name: 'CLOUD_REGION', value: env.CLOUD_REGION), string(name: 'BUILDENV', value: env.BUILDENV), string(name: 'CLUSTER_ID', value: env.CLUSTER_ID), booleanParam(name: 'DNS_FORCE_DISABLE', value: DNS_FORCE_DISABLE), string(name: 'DEPLOY_TYPE', value: 'redeploy'), string(name: 'REDEPLOY_SCHEME', value: (env.REDEPLOY_SCHEME ? env.REDEPLOY_SCHEME : '')), string(name: 'CANARY', value: 'tidy'), booleanParam(name: 'CANARY_TIDY_ON_SUCCESS', value: false), string(name: 'MYHOSTTYPES', value: ''), string(name: 'CV_GIT_URL', value: scmVars ? scmVars.getUserRemoteConfigs()[0].getUrl() : DEFAULT_CLUSTERVERSE_URL), string(name: 'CV_GIT_BRANCH', value: CV_OPS_GIT_BRANCH), string(name: 'USER_CMDLINE_VARS', value: stageBuild.userParamsString())]
-            })
+                        stage_cvops('redeploy canary=finish', stageBuild, {
+                            build job: 'clusterverse/clusterverse-ops', parameters: [string(name: 'APP_NAME', value: "cvtest-${env.BUILD_NUMBER}-${env.BUILD_HASH}"), string(name: 'CLOUD_REGION', value: env.CLOUD_REGION), string(name: 'BUILDENV', value: env.BUILDENV), string(name: 'CLUSTER_ID', value: env.CLUSTER_ID), booleanParam(name: 'DNS_FORCE_DISABLE', value: env.DNS_FORCE_DISABLE), string(name: 'DEPLOY_TYPE', value: 'redeploy'), string(name: 'REDEPLOY_SCHEME', value: (env.REDEPLOY_SCHEME ? env.REDEPLOY_SCHEME : '')), string(name: 'CANARY', value: 'finish'), booleanParam(name: 'CANARY_TIDY_ON_SUCCESS', value: false), string(name: 'MYHOSTTYPES', value: ''), string(name: 'CV_GIT_URL', value: CV_OPS_GIT_URL), string(name: 'CV_GIT_BRANCH', value: CV_OPS_GIT_BRANCH), string(name: 'USER_CMDLINE_VARS', value: stageBuild.getUserParamsString())]
+                        })
 
-            stageBuild.userParams.put("release_version", "3_0_0")
-            stage_cvops('redeploy canary=none (tidy_on_success)', stageBuild, {
-              build job: 'clusterverse/clusterverse-ops', parameters: [string(name: 'APP_NAME', value: "cvtest-${env.BUILD_NUMBER}-${env.BUILD_HASH}"), string(name: 'CLOUD_REGION', value: env.CLOUD_REGION), string(name: 'BUILDENV', value: env.BUILDENV), string(name: 'CLUSTER_ID', value: env.CLUSTER_ID), booleanParam(name: 'DNS_FORCE_DISABLE', value: env.DNS_FORCE_DISABLE), string(name: 'DEPLOY_TYPE', value: 'redeploy'), string(name: 'REDEPLOY_SCHEME', value: (env.REDEPLOY_SCHEME ? env.REDEPLOY_SCHEME : '')), string(name: 'CANARY', value: 'none'), booleanParam(name: 'CANARY_TIDY_ON_SUCCESS', value: true), string(name: 'MYHOSTTYPES', value: ''), string(name: 'CV_GIT_URL', value: scmVars ? scmVars.getUserRemoteConfigs()[0].getUrl() : DEFAULT_CLUSTERVERSE_URL), string(name: 'CV_GIT_BRANCH', value: CV_OPS_GIT_BRANCH), string(name: 'USER_CMDLINE_VARS', value: stageBuild.userParamsString())]
-            })
-          } else {
-            stage_cvops('Redeploy not requested', stageBuild, {
-              echo "Redeploy testing not requested"
-            })
-          }
+                        stage_cvops('redeploy canary=tidy', stageBuild, {
+                            build job: 'clusterverse/clusterverse-ops', parameters: [string(name: 'APP_NAME', value: "cvtest-${env.BUILD_NUMBER}-${env.BUILD_HASH}"), string(name: 'CLOUD_REGION', value: env.CLOUD_REGION), string(name: 'BUILDENV', value: env.BUILDENV), string(name: 'CLUSTER_ID', value: env.CLUSTER_ID), booleanParam(name: 'DNS_FORCE_DISABLE', value: env.DNS_FORCE_DISABLE), string(name: 'DEPLOY_TYPE', value: 'redeploy'), string(name: 'REDEPLOY_SCHEME', value: (env.REDEPLOY_SCHEME ? env.REDEPLOY_SCHEME : '')), string(name: 'CANARY', value: 'tidy'), booleanParam(name: 'CANARY_TIDY_ON_SUCCESS', value: false), string(name: 'MYHOSTTYPES', value: ''), string(name: 'CV_GIT_URL', value: CV_OPS_GIT_URL), string(name: 'CV_GIT_BRANCH', value: CV_OPS_GIT_BRANCH), string(name: 'USER_CMDLINE_VARS', value: stageBuild.getUserParamsString())]
+                        })
 
-          stage_cvops('deploy on top', stageBuild, {
-            build job: 'clusterverse/clusterverse-ops', parameters: [string(name: 'APP_NAME', value: "cvtest-${env.BUILD_NUMBER}-${env.BUILD_HASH}"), string(name: 'CLOUD_REGION', value: env.CLOUD_REGION), string(name: 'BUILDENV', value: env.BUILDENV), string(name: 'CLUSTER_ID', value: env.CLUSTER_ID), booleanParam(name: 'DNS_FORCE_DISABLE', value: env.DNS_FORCE_DISABLE), string(name: 'DEPLOY_TYPE', value: 'deploy'), string(name: 'REDEPLOY_SCHEME', value: ''), string(name: 'CANARY', value: 'none'), booleanParam(name: 'CANARY_TIDY_ON_SUCCESS', value: true), string(name: 'MYHOSTTYPES', value: ''), string(name: 'CV_GIT_URL', value: scmVars ? scmVars.getUserRemoteConfigs()[0].getUrl() : DEFAULT_CLUSTERVERSE_URL), string(name: 'CV_GIT_BRANCH', value: CV_OPS_GIT_BRANCH), string(name: 'USER_CMDLINE_VARS', value: stageBuild.userParamsString())]
-          })
+                        //Need to redeploy original cluster (without scaling), to test that scaling works with next redeploy test (canary=none)
+                        if (env.SCALEUPDOWN == 'scaleup' || env.SCALEUPDOWN == 'scaledown') {
+                            cluster_vars_override.remove("${env.BUILDENV}")
+                            stageBuild.userParams.put("cluster_vars_override", "\\\'" + groovy.json.JsonOutput.toJson(cluster_vars_override).replace("\"", "\\\"") + "\\\'")
+                            stageBuild.userParams.put("release_version", "2_5_0")
+                            stage_cvops('deploy clean original (unscaled) for next test', stageBuild, {
+                                build job: 'clusterverse/clusterverse-ops', parameters: [string(name: 'APP_NAME', value: "cvtest-${BUILD_NUMBER}-${env.BUILD_HASH}"), string(name: 'CLOUD_REGION', value: env.CLOUD_REGION), string(name: 'BUILDENV', value: env.BUILDENV), string(name: 'CLUSTER_ID', value: env.CLUSTER_ID), booleanParam(name: 'DNS_FORCE_DISABLE', value: env.DNS_FORCE_DISABLE), string(name: 'DEPLOY_TYPE', value: 'deploy'), string(name: 'REDEPLOY_SCHEME', value: ''), string(name: 'CANARY', value: 'none'), booleanParam(name: 'CANARY_TIDY_ON_SUCCESS', value: true), string(name: 'MYHOSTTYPES', value: ''), string(name: 'CV_GIT_URL', value: CV_OPS_GIT_URL), string(name: 'CV_GIT_BRANCH', value: CV_OPS_GIT_BRANCH), string(name: 'USER_CMDLINE_VARS', value: stageBuild.getUserParamsString() + " -e clean=_all_")]
+                            })
 
-          if (stageBuild.result == 'SUCCESS' || params.CLEAN_ON_FAILURE == 'true') {
-            stage('clean') {
-              if (stageBuild.result != 'SUCCESS') {
-                echo "Stage failure: Running clean-up on cluster..."
-              }
-              catchError {
-                build job: 'clusterverse/clusterverse-ops', parameters: [string(name: 'APP_NAME', value: "cvtest-${env.BUILD_NUMBER}-${env.BUILD_HASH}"), string(name: 'CLOUD_REGION', value: env.CLOUD_REGION), string(name: 'BUILDENV', value: env.BUILDENV), string(name: 'CLUSTER_ID', value: env.CLUSTER_ID), booleanParam(name: 'DNS_FORCE_DISABLE', value: env.DNS_FORCE_DISABLE), string(name: 'DEPLOY_TYPE', value: 'clean'), string(name: 'REDEPLOY_SCHEME', value: ''), string(name: 'CANARY', value: 'none'), booleanParam(name: 'CANARY_TIDY_ON_SUCCESS', value: true), string(name: 'MYHOSTTYPES', value: ''), string(name: 'CV_GIT_URL', value: scmVars ? scmVars.getUserRemoteConfigs()[0].getUrl() : DEFAULT_CLUSTERVERSE_URL), string(name: 'CV_GIT_BRANCH', value: CV_OPS_GIT_BRANCH), string(name: 'USER_CMDLINE_VARS', value: stageBuild.userParamsString())]
-              }
+                            //Re-add the scaleup/down cmdline for next redeploy test (canary=none)
+                            if (env.SCALEUPDOWN == 'scaleup') {
+                                cluster_vars_override += ["${env.BUILDENV}": [hosttype_vars: [sys: [vms_by_az: [b: 1, c: 1]]]]]     // AZ 'c' is not set normally
+                            } else if (env.SCALEUPDOWN == 'scaledown') {
+                                cluster_vars_override += ["${env.BUILDENV}": [hosttype_vars: [sys: [vms_by_az: [b: 0, c: 0]]]]]     // AZ 'b' is set normally
+                            }
+                            stageBuild.userParams.put("cluster_vars_override", "\\\'" + groovy.json.JsonOutput.toJson(cluster_vars_override).replace("\"", "\\\"") + "\\\'")
+                        }
+
+                        // Run the canary=none redeploy
+                        stageBuild.userParams.put("release_version", "3_0_0")
+                        stage_cvops('redeploy canary=none (tidy_on_success)', stageBuild, {
+                            build job: 'clusterverse/clusterverse-ops', parameters: [string(name: 'APP_NAME', value: "cvtest-${env.BUILD_NUMBER}-${env.BUILD_HASH}"), string(name: 'CLOUD_REGION', value: env.CLOUD_REGION), string(name: 'BUILDENV', value: env.BUILDENV), string(name: 'CLUSTER_ID', value: env.CLUSTER_ID), booleanParam(name: 'DNS_FORCE_DISABLE', value: env.DNS_FORCE_DISABLE), string(name: 'DEPLOY_TYPE', value: 'redeploy'), string(name: 'REDEPLOY_SCHEME', value: (env.REDEPLOY_SCHEME ? env.REDEPLOY_SCHEME : '')), string(name: 'CANARY', value: 'none'), booleanParam(name: 'CANARY_TIDY_ON_SUCCESS', value: true), string(name: 'MYHOSTTYPES', value: ''), string(name: 'CV_GIT_URL', value: CV_OPS_GIT_URL), string(name: 'CV_GIT_BRANCH', value: CV_OPS_GIT_BRANCH), string(name: 'USER_CMDLINE_VARS', value: stageBuild.getUserParamsString())]
+                        })
+                    } else {
+                        stage_cvops('Redeploy not requested', stageBuild, {
+                            echo "Redeploy testing not requested"
+                        })
+                    }
+
+                    stage_cvops('deploy on top', stageBuild, {
+                        build job: 'clusterverse/clusterverse-ops', parameters: [string(name: 'APP_NAME', value: "cvtest-${env.BUILD_NUMBER}-${env.BUILD_HASH}"), string(name: 'CLOUD_REGION', value: env.CLOUD_REGION), string(name: 'BUILDENV', value: env.BUILDENV), string(name: 'CLUSTER_ID', value: env.CLUSTER_ID), booleanParam(name: 'DNS_FORCE_DISABLE', value: env.DNS_FORCE_DISABLE), string(name: 'DEPLOY_TYPE', value: 'deploy'), string(name: 'REDEPLOY_SCHEME', value: ''), string(name: 'CANARY', value: 'none'), booleanParam(name: 'CANARY_TIDY_ON_SUCCESS', value: true), string(name: 'MYHOSTTYPES', value: ''), string(name: 'CV_GIT_URL', value: CV_OPS_GIT_URL), string(name: 'CV_GIT_BRANCH', value: CV_OPS_GIT_BRANCH), string(name: 'USER_CMDLINE_VARS', value: stageBuild.getUserParamsString())]
+                    })
+
+                    if (stageBuild.result == 'SUCCESS' || params.CLEAN_ON_FAILURE == 'true') {
+                        stage('clean') {
+                            if (stageBuild.result != 'SUCCESS') {
+                                echo "Stage failure: Running clean-up on cluster..."
+                            }
+                            catchError {
+                                build job: 'clusterverse/clusterverse-ops', parameters: [string(name: 'APP_NAME', value: "cvtest-${env.BUILD_NUMBER}-${env.BUILD_HASH}"), string(name: 'CLOUD_REGION', value: env.CLOUD_REGION), string(name: 'BUILDENV', value: env.BUILDENV), string(name: 'CLUSTER_ID', value: env.CLUSTER_ID), booleanParam(name: 'DNS_FORCE_DISABLE', value: env.DNS_FORCE_DISABLE), string(name: 'DEPLOY_TYPE', value: 'clean'), string(name: 'REDEPLOY_SCHEME', value: ''), string(name: 'CANARY', value: 'none'), booleanParam(name: 'CANARY_TIDY_ON_SUCCESS', value: true), string(name: 'MYHOSTTYPES', value: ''), string(name: 'CV_GIT_URL', value: CV_OPS_GIT_URL), string(name: 'CV_GIT_BRANCH', value: CV_OPS_GIT_BRANCH), string(name: 'USER_CMDLINE_VARS', value: stageBuild.getUserParamsString())]
+                            }
+                        }
+                    }
+                }
             }
-          }
         }
-      }
-    }
 ])
 
 
@@ -264,87 +304,121 @@ CVTEST_NOMYHOSTTYPES = new MatrixBuilder([
 // The logic of doing this is different to the matrix without myhosttypes, hence a separate matrix.
 /**************************************************************************************/
 CVTEST_MYHOSTTYPES = new MatrixBuilder([
-    jenkinsParamsCopy: params,
-    clJenkinsParamsMutate: { jenkinsParamsCopy ->
-      jenkinsParamsCopy.remove('MYHOSTTYPES_LIST')
-      jenkinsParamsCopy.remove('MYHOSTTYPES_TEST')
-      jenkinsParamsCopy.remove('MYHOSTTYPES_SERIAL_PARALLEL')
-      jenkinsParamsCopy.remove('CLEAN_ON_FAILURE')
-      return jenkinsParamsCopy
-    },
-    clMatrixAxesFilter: { axis ->
-      !(params.DNS_TEST == 'both' && axis['DNS_FORCE_DISABLE'] == 'true' && axis['CLOUD_REGION'] == 'esxifree/dougalab') &&
-      !(axis['IMAGE_TESTED'] != '_ubuntu2004image' && axis['CLOUD_REGION'] == 'esxifree/dougalab') &&
-      !(axis['REDEPLOY_SCHEME'] == '_scheme_addallnew_rmdisk_rollback')
-    },
-    clTaskMap: { axisEnvVars ->
-      node {
-        withEnv(axisEnvVars) {
-          withCredentials([string(credentialsId: "VAULT_PASSWORD_${env.BUILDENV.toUpperCase()}", variable: 'VAULT_PASSWORD_BUILDENV')]) {
-            env.VAULT_PASSWORD_BUILDENV = VAULT_PASSWORD_BUILDENV
-          }
-          sh 'printenv | sort'
-          def stageBuild = new cStageBuild([result: 'SUCCESS'])
+        jenkinsParams: params,
+        clJenkinsParamsMutate: { jenkinsParams ->
+            jenkinsParams.remove('MYHOSTTYPES_LIST')
+            jenkinsParams.remove('MYHOSTTYPES_TEST')
+            jenkinsParams.remove('MYHOSTTYPES_SERIAL_PARALLEL')
+            jenkinsParams.remove('CLEAN_ON_FAILURE')
+            return jenkinsParams
+        },
+        clMatrixAxesFilter: { axis ->
+            !(params.DNS_TEST == 'both' && axis['DNS_FORCE_DISABLE'] == 'true' && axis['CLOUD_REGION'] == 'esxifree/dougalab') &&                                 /* DNS is not supported in dougalab */
+                    !(axis['IMAGE_TESTED'] != '_ubuntu2004image' && axis['CLOUD_REGION'] == 'esxifree/dougalab') &&                                               /* Only _ubuntu2004image is supported in dougalab */
+                    !(axis['REDEPLOY_SCHEME'] == '_scheme_addallnew_rmdisk_rollback') &&                                                                          /* _scheme_addallnew_rmdisk_rollback is not supported with myhostttpes set */
+                    !(axis['REDEPLOY_SCHEME'] == '_scheme_rmvm_keepdisk_rollback' && axis['CLOUD_REGION'].split('/')[0] == 'azure') &&                            /* _scheme_rmvm_keepdisk_rollback not supported in Azure */
+                    !(axis['REDEPLOY_SCHEME'] == '_scheme_rmvm_rmdisk_only' && axis['SCALEUPDOWN'] == 'scaledown') &&                                             /* _scheme_rmvm_rmdisk_only only supports scaling up */
+                    !(axis['REDEPLOY_SCHEME'] == '_scheme_rmvm_keepdisk_rollback' && (axis['SCALEUPDOWN'] == 'scaledown' || axis['SCALEUPDOWN'] == 'scaleup'))    /* _scheme_rmvm_keepdisk_rollback does not support scaling */
+        },
+        clTaskMap: { axisEnvVars ->
+            node {
+                withEnv(axisEnvVars) {
+                    withCredentials([string(credentialsId: "VAULT_PASSWORD_${env.BUILDENV.toUpperCase()}", variable: 'VAULT_PASSWORD_BUILDENV')]) {
+                        env.VAULT_PASSWORD_BUILDENV = VAULT_PASSWORD_BUILDENV
+                    }
+                    sh 'printenv | sort'
+                    def stageBuild = new cStageBuild([result: 'SUCCESS'])
+                    HashMap cluster_vars_override = [:]
 
-          if (env.IMAGE_TESTED) {
-            stageBuild.userParams.put("cluster_vars_override", "\\\'{\\\"image\\\":\\\"{{${env.IMAGE_TESTED}}}\\\"}\\\'")       //NOTE: NO SPACES are allowed in this!!
-          }
+                    if (env.IMAGE_TESTED) {
+                        cluster_vars_override += [image: "{{${env.IMAGE_TESTED}}}"]
+                        stageBuild.userParams.put("cluster_vars_override", "\\\'" + groovy.json.JsonOutput.toJson(cluster_vars_override).replace("\"", "\\\"") + "\\\'")   //NOTE: NO SPACES are allowed in this!!
+                    }
 
-          if (env.REDEPLOY_SCHEME) {
-            if (params.MYHOSTTYPES_LIST == '') {
-              currentBuild.result = 'FAILURE'
-              stageBuild.result = 'FAILURE'
-              unstable('Stage failed!  Error was: ' + err)       // OR:  'error "Stage failure"' or 'throw new org.jenkinsci.plugins.workflow.steps.FlowInterruptedException(hudson.model.Result.FAILURE)', but both of these fail all future stages, preventing us calling the clean.
-            }
+                    if (env.REDEPLOY_SCHEME) {
+                        if (params.MYHOSTTYPES_LIST == '') {
+                            currentBuild.result = 'FAILURE'
+                            stageBuild.result = 'FAILURE'
+                            unstable('Stage failed!  Error was: ' + err)       // OR:  'error "Stage failure"' or 'throw new org.jenkinsci.plugins.workflow.steps.FlowInterruptedException(hudson.model.Result.FAILURE)', but both of these fail all future stages, preventing us calling the clean.
+                        }
 
-            stageBuild.userParams.put("skip_release_version_check", "true")
-            stageBuild.userParams.put("release_version", "1_0_0")
-            stage_cvops('deploy', stageBuild, {
-              build job: 'clusterverse/clusterverse-ops', parameters: [string(name: 'APP_NAME', value: "cvtest-${BUILD_NUMBER}-${env.BUILD_HASH}"), string(name: 'CLOUD_REGION', value: env.CLOUD_REGION), string(name: 'BUILDENV', value: env.BUILDENV), string(name: 'CLUSTER_ID', value: env.CLUSTER_ID), booleanParam(name: 'DNS_FORCE_DISABLE', value: env.DNS_FORCE_DISABLE), string(name: 'DEPLOY_TYPE', value: 'deploy'), string(name: 'REDEPLOY_SCHEME', value: ''), string(name: 'CANARY', value: 'none'), booleanParam(name: 'CANARY_TIDY_ON_SUCCESS', value: true), string(name: 'MYHOSTTYPES', value: ''), string(name: 'CV_GIT_URL', value: scmVars ? scmVars.getUserRemoteConfigs()[0].getUrl() : DEFAULT_CLUSTERVERSE_URL), string(name: 'CV_GIT_BRANCH', value: CV_OPS_GIT_BRANCH), string(name: 'USER_CMDLINE_VARS', value: stageBuild.userParamsString())]
-            })
+                        stageBuild.userParams.put("skip_release_version_check", "true")
+                        stageBuild.userParams.put("release_version", "1_0_0")
+                        stage_cvops('deploy', stageBuild, {
+                            build job: 'clusterverse/clusterverse-ops', parameters: [string(name: 'APP_NAME', value: "cvtest-${BUILD_NUMBER}-${env.BUILD_HASH}"), string(name: 'CLOUD_REGION', value: env.CLOUD_REGION), string(name: 'BUILDENV', value: env.BUILDENV), string(name: 'CLUSTER_ID', value: env.CLUSTER_ID), booleanParam(name: 'DNS_FORCE_DISABLE', value: env.DNS_FORCE_DISABLE), string(name: 'DEPLOY_TYPE', value: 'deploy'), string(name: 'REDEPLOY_SCHEME', value: ''), string(name: 'CANARY', value: 'none'), booleanParam(name: 'CANARY_TIDY_ON_SUCCESS', value: true), string(name: 'MYHOSTTYPES', value: ''), string(name: 'CV_GIT_URL', value: CV_OPS_GIT_URL), string(name: 'CV_GIT_BRANCH', value: CV_OPS_GIT_BRANCH), string(name: 'USER_CMDLINE_VARS', value: stageBuild.getUserParamsString())]
+                        })
 
-            // Run the split redeploy over all hosttypes
-            stageBuild.userParams.put("release_version", "2_0_0")
-            params.MYHOSTTYPES_LIST.split(',').each({ my_host_type ->
-              stage_cvops("redeploy canary=start ($my_host_type)", stageBuild, {
-                build job: 'clusterverse/clusterverse-ops', parameters: [string(name: 'APP_NAME', value: "cvtest-${env.BUILD_NUMBER}-${env.BUILD_HASH}"), string(name: 'CLOUD_REGION', value: env.CLOUD_REGION), string(name: 'BUILDENV', value: env.BUILDENV), string(name: 'CLUSTER_ID', value: env.CLUSTER_ID), booleanParam(name: 'DNS_FORCE_DISABLE', value: DNS_FORCE_DISABLE), string(name: 'DEPLOY_TYPE', value: 'redeploy'), string(name: 'REDEPLOY_SCHEME', value: (env.REDEPLOY_SCHEME ? env.REDEPLOY_SCHEME : '')), string(name: 'CANARY', value: 'start'), booleanParam(name: 'CANARY_TIDY_ON_SUCCESS', value: false), string(name: 'MYHOSTTYPES', value: my_host_type), string(name: 'CV_GIT_URL', value: scmVars ? scmVars.getUserRemoteConfigs()[0].getUrl() : DEFAULT_CLUSTERVERSE_URL), string(name: 'CV_GIT_BRANCH', value: CV_OPS_GIT_BRANCH), string(name: 'USER_CMDLINE_VARS', value: stageBuild.userParamsString())]
-              })
+                        // Update the clustervars with new scaled cluster size
+                        if (env.SCALEUPDOWN == 'scaleup') {
+                            cluster_vars_override += ["${env.BUILDENV}": [hosttype_vars: [sys: [vms_by_az: [b: 1, c: 1]]]]]     // AZ 'c' is not set normally
+                        } else if (env.SCALEUPDOWN == 'scaledown') {
+                            cluster_vars_override += ["${env.BUILDENV}": [hosttype_vars: [sys: [vms_by_az: [b: 0, c: 0]]]]]     // AZ 'b' is set normally
+                        }
 
-              stage_cvops("redeploy canary=finish ($my_host_type)", stageBuild, {
-                build job: 'clusterverse/clusterverse-ops', parameters: [string(name: 'APP_NAME', value: "cvtest-${env.BUILD_NUMBER}-${env.BUILD_HASH}"), string(name: 'CLOUD_REGION', value: env.CLOUD_REGION), string(name: 'BUILDENV', value: env.BUILDENV), string(name: 'CLUSTER_ID', value: env.CLUSTER_ID), booleanParam(name: 'DNS_FORCE_DISABLE', value: DNS_FORCE_DISABLE), string(name: 'DEPLOY_TYPE', value: 'redeploy'), string(name: 'REDEPLOY_SCHEME', value: (env.REDEPLOY_SCHEME ? env.REDEPLOY_SCHEME : '')), string(name: 'CANARY', value: 'finish'), booleanParam(name: 'CANARY_TIDY_ON_SUCCESS', value: false), string(name: 'MYHOSTTYPES', value: my_host_type), string(name: 'CV_GIT_URL', value: scmVars ? scmVars.getUserRemoteConfigs()[0].getUrl() : DEFAULT_CLUSTERVERSE_URL), string(name: 'CV_GIT_BRANCH', value: CV_OPS_GIT_BRANCH), string(name: 'USER_CMDLINE_VARS', value: stageBuild.userParamsString())]
-              })
+                        if (cluster_vars_override.size()) {
+                            stageBuild.userParams.put("cluster_vars_override", "\\\'" + groovy.json.JsonOutput.toJson(cluster_vars_override).replace("\"", "\\\"") + "\\\'")   //NOTE: NO SPACES are allowed in this!!
+                        }
 
-              stage_cvops("redeploy canary=tidy ($my_host_type)", stageBuild, {
-                build job: 'clusterverse/clusterverse-ops', parameters: [string(name: 'APP_NAME', value: "cvtest-${env.BUILD_NUMBER}-${env.BUILD_HASH}"), string(name: 'CLOUD_REGION', value: env.CLOUD_REGION), string(name: 'BUILDENV', value: env.BUILDENV), string(name: 'CLUSTER_ID', value: env.CLUSTER_ID), booleanParam(name: 'DNS_FORCE_DISABLE', value: DNS_FORCE_DISABLE), string(name: 'DEPLOY_TYPE', value: 'redeploy'), string(name: 'REDEPLOY_SCHEME', value: (env.REDEPLOY_SCHEME ? env.REDEPLOY_SCHEME : '')), string(name: 'CANARY', value: 'tidy'), booleanParam(name: 'CANARY_TIDY_ON_SUCCESS', value: false), string(name: 'MYHOSTTYPES', value: my_host_type), string(name: 'CV_GIT_URL', value: scmVars ? scmVars.getUserRemoteConfigs()[0].getUrl() : DEFAULT_CLUSTERVERSE_URL), string(name: 'CV_GIT_BRANCH', value: CV_OPS_GIT_BRANCH), string(name: 'USER_CMDLINE_VARS', value: stageBuild.userParamsString())]
-              })
-            })
+                        // Run the split redeploy over all hosttypes
+                        stageBuild.userParams.put("release_version", "2_0_0")
+                        params.MYHOSTTYPES_LIST.split(',').each({ my_host_type ->
+                            stage_cvops("redeploy canary=start ($my_host_type)", stageBuild, {
+                                build job: 'clusterverse/clusterverse-ops', parameters: [string(name: 'APP_NAME', value: "cvtest-${env.BUILD_NUMBER}-${env.BUILD_HASH}"), string(name: 'CLOUD_REGION', value: env.CLOUD_REGION), string(name: 'BUILDENV', value: env.BUILDENV), string(name: 'CLUSTER_ID', value: env.CLUSTER_ID), booleanParam(name: 'DNS_FORCE_DISABLE', value: env.DNS_FORCE_DISABLE), string(name: 'DEPLOY_TYPE', value: 'redeploy'), string(name: 'REDEPLOY_SCHEME', value: (env.REDEPLOY_SCHEME ? env.REDEPLOY_SCHEME : '')), string(name: 'CANARY', value: 'start'), booleanParam(name: 'CANARY_TIDY_ON_SUCCESS', value: false), string(name: 'MYHOSTTYPES', value: my_host_type), string(name: 'CV_GIT_URL', value: CV_OPS_GIT_URL), string(name: 'CV_GIT_BRANCH', value: CV_OPS_GIT_BRANCH), string(name: 'USER_CMDLINE_VARS', value: stageBuild.getUserParamsString())]
+                            })
 
-            // Run the mono-redeploy over all hosttypes
-            stageBuild.userParams.put("release_version", "3_0_0")
-            params.MYHOSTTYPES_LIST.split(',').each({ my_host_type ->
-              stage_cvops("redeploy canary=none ($my_host_type) (tidy_on_success)", stageBuild, {
-                build job: 'clusterverse/clusterverse-ops', parameters: [string(name: 'APP_NAME', value: "cvtest-${env.BUILD_NUMBER}-${env.BUILD_HASH}"), string(name: 'CLOUD_REGION', value: env.CLOUD_REGION), string(name: 'BUILDENV', value: env.BUILDENV), string(name: 'CLUSTER_ID', value: env.CLUSTER_ID), booleanParam(name: 'DNS_FORCE_DISABLE', value: env.DNS_FORCE_DISABLE), string(name: 'DEPLOY_TYPE', value: 'redeploy'), string(name: 'REDEPLOY_SCHEME', value: (env.REDEPLOY_SCHEME ? env.REDEPLOY_SCHEME : '')), string(name: 'CANARY', value: 'none'), booleanParam(name: 'CANARY_TIDY_ON_SUCCESS', value: true), string(name: 'MYHOSTTYPES', value: my_host_type), string(name: 'CV_GIT_URL', value: scmVars ? scmVars.getUserRemoteConfigs()[0].getUrl() : DEFAULT_CLUSTERVERSE_URL), string(name: 'CV_GIT_BRANCH', value: CV_OPS_GIT_BRANCH), string(name: 'USER_CMDLINE_VARS', value: stageBuild.userParamsString())]
-              })
-            })
+                            stage_cvops("redeploy canary=finish ($my_host_type)", stageBuild, {
+                                build job: 'clusterverse/clusterverse-ops', parameters: [string(name: 'APP_NAME', value: "cvtest-${env.BUILD_NUMBER}-${env.BUILD_HASH}"), string(name: 'CLOUD_REGION', value: env.CLOUD_REGION), string(name: 'BUILDENV', value: env.BUILDENV), string(name: 'CLUSTER_ID', value: env.CLUSTER_ID), booleanParam(name: 'DNS_FORCE_DISABLE', value: env.DNS_FORCE_DISABLE), string(name: 'DEPLOY_TYPE', value: 'redeploy'), string(name: 'REDEPLOY_SCHEME', value: (env.REDEPLOY_SCHEME ? env.REDEPLOY_SCHEME : '')), string(name: 'CANARY', value: 'finish'), booleanParam(name: 'CANARY_TIDY_ON_SUCCESS', value: false), string(name: 'MYHOSTTYPES', value: my_host_type), string(name: 'CV_GIT_URL', value: CV_OPS_GIT_URL), string(name: 'CV_GIT_BRANCH', value: CV_OPS_GIT_BRANCH), string(name: 'USER_CMDLINE_VARS', value: stageBuild.getUserParamsString())]
+                            })
 
-            if (stageBuild.result == 'SUCCESS' || params.CLEAN_ON_FAILURE == 'true') {
-              stage('clean') {
-                if (stageBuild.result != 'SUCCESS') {
-                  echo "Stage failure: Running clean-up on cluster..."
+                            stage_cvops("redeploy canary=tidy ($my_host_type)", stageBuild, {
+                                build job: 'clusterverse/clusterverse-ops', parameters: [string(name: 'APP_NAME', value: "cvtest-${env.BUILD_NUMBER}-${env.BUILD_HASH}"), string(name: 'CLOUD_REGION', value: env.CLOUD_REGION), string(name: 'BUILDENV', value: env.BUILDENV), string(name: 'CLUSTER_ID', value: env.CLUSTER_ID), booleanParam(name: 'DNS_FORCE_DISABLE', value: env.DNS_FORCE_DISABLE), string(name: 'DEPLOY_TYPE', value: 'redeploy'), string(name: 'REDEPLOY_SCHEME', value: (env.REDEPLOY_SCHEME ? env.REDEPLOY_SCHEME : '')), string(name: 'CANARY', value: 'tidy'), booleanParam(name: 'CANARY_TIDY_ON_SUCCESS', value: false), string(name: 'MYHOSTTYPES', value: my_host_type), string(name: 'CV_GIT_URL', value: CV_OPS_GIT_URL), string(name: 'CV_GIT_BRANCH', value: CV_OPS_GIT_BRANCH), string(name: 'USER_CMDLINE_VARS', value: stageBuild.getUserParamsString())]
+                            })
+                        })
+
+                        //Need to redeploy original cluster (without scaling), to test that scaling works with next redeploy test (canary=none)
+                        if (env.SCALEUPDOWN == 'scaleup' || env.SCALEUPDOWN == 'scaledown') {
+                            cluster_vars_override.remove("${env.BUILDENV}")
+                            stageBuild.userParams.put("cluster_vars_override", "\\\'" + groovy.json.JsonOutput.toJson(cluster_vars_override).replace("\"", "\\\"") + "\\\'")
+                            stageBuild.userParams.put("release_version", "2_5_0")
+                            stage_cvops('deploy clean original (unscaled) for next test', stageBuild, {
+                                build job: 'clusterverse/clusterverse-ops', parameters: [string(name: 'APP_NAME', value: "cvtest-${BUILD_NUMBER}-${env.BUILD_HASH}"), string(name: 'CLOUD_REGION', value: env.CLOUD_REGION), string(name: 'BUILDENV', value: env.BUILDENV), string(name: 'CLUSTER_ID', value: env.CLUSTER_ID), booleanParam(name: 'DNS_FORCE_DISABLE', value: env.DNS_FORCE_DISABLE), string(name: 'DEPLOY_TYPE', value: 'deploy'), string(name: 'REDEPLOY_SCHEME', value: ''), string(name: 'CANARY', value: 'none'), booleanParam(name: 'CANARY_TIDY_ON_SUCCESS', value: true), string(name: 'MYHOSTTYPES', value: ''), string(name: 'CV_GIT_URL', value: CV_OPS_GIT_URL), string(name: 'CV_GIT_BRANCH', value: CV_OPS_GIT_BRANCH), string(name: 'USER_CMDLINE_VARS', value: stageBuild.getUserParamsString() + " -e clean=_all_")]
+                            })
+
+                            //Re-add the scaleup/down cmdline for next redeploy test (canary=none)
+                            if (env.SCALEUPDOWN == 'scaleup') {
+                                cluster_vars_override += ["${env.BUILDENV}": [hosttype_vars: [sys: [vms_by_az: [b: 1, c: 1]]]]]     // AZ 'c' is not set normally
+                            } else if (env.SCALEUPDOWN == 'scaledown') {
+                                cluster_vars_override += ["${env.BUILDENV}": [hosttype_vars: [sys: [vms_by_az: [b: 0, c: 0]]]]]     // AZ 'b' is set normally
+                            }
+                            stageBuild.userParams.put("cluster_vars_override", "\\\'" + groovy.json.JsonOutput.toJson(cluster_vars_override).replace("\"", "\\\"") + "\\\'")
+                        }
+
+                        // Run the canary=none redeploy over all hosttypes
+                        stageBuild.userParams.put("release_version", "3_0_0")
+                        params.MYHOSTTYPES_LIST.split(',').each({ my_host_type ->
+                            stage_cvops("redeploy canary=none ($my_host_type) (tidy_on_success)", stageBuild, {
+                                build job: 'clusterverse/clusterverse-ops', parameters: [string(name: 'APP_NAME', value: "cvtest-${env.BUILD_NUMBER}-${env.BUILD_HASH}"), string(name: 'CLOUD_REGION', value: env.CLOUD_REGION), string(name: 'BUILDENV', value: env.BUILDENV), string(name: 'CLUSTER_ID', value: env.CLUSTER_ID), booleanParam(name: 'DNS_FORCE_DISABLE', value: env.DNS_FORCE_DISABLE), string(name: 'DEPLOY_TYPE', value: 'redeploy'), string(name: 'REDEPLOY_SCHEME', value: (env.REDEPLOY_SCHEME ? env.REDEPLOY_SCHEME : '')), string(name: 'CANARY', value: 'none'), booleanParam(name: 'CANARY_TIDY_ON_SUCCESS', value: true), string(name: 'MYHOSTTYPES', value: my_host_type), string(name: 'CV_GIT_URL', value: CV_OPS_GIT_URL), string(name: 'CV_GIT_BRANCH', value: CV_OPS_GIT_BRANCH), string(name: 'USER_CMDLINE_VARS', value: stageBuild.getUserParamsString())]
+                            })
+                        })
+
+                        if (stageBuild.result == 'SUCCESS' || params.CLEAN_ON_FAILURE == 'true') {
+                            stage('clean') {
+                                if (stageBuild.result != 'SUCCESS') {
+                                    echo "Stage failure: Running clean-up on cluster..."
+                                }
+                                catchError {
+                                    build job: 'clusterverse/clusterverse-ops', parameters: [string(name: 'APP_NAME', value: "cvtest-${env.BUILD_NUMBER}-${env.BUILD_HASH}"), string(name: 'CLOUD_REGION', value: env.CLOUD_REGION), string(name: 'BUILDENV', value: env.BUILDENV), string(name: 'CLUSTER_ID', value: env.CLUSTER_ID), booleanParam(name: 'DNS_FORCE_DISABLE', value: env.DNS_FORCE_DISABLE), string(name: 'DEPLOY_TYPE', value: 'clean'), string(name: 'REDEPLOY_SCHEME', value: ''), string(name: 'CANARY', value: 'none'), booleanParam(name: 'CANARY_TIDY_ON_SUCCESS', value: true), string(name: 'MYHOSTTYPES', value: ''), string(name: 'CV_GIT_URL', value: CV_OPS_GIT_URL), string(name: 'CV_GIT_BRANCH', value: CV_OPS_GIT_BRANCH), string(name: 'USER_CMDLINE_VARS', value: stageBuild.getUserParamsString())]
+                                }
+                            }
+                        }
+                    } else {
+                        stage_cvops('Redeploy not requested', stageBuild, {
+                            echo "Redeploy testing not requested"
+                        })
+                    }
                 }
-                catchError {
-                  build job: 'clusterverse/clusterverse-ops', parameters: [string(name: 'APP_NAME', value: "cvtest-${env.BUILD_NUMBER}-${env.BUILD_HASH}"), string(name: 'CLOUD_REGION', value: env.CLOUD_REGION), string(name: 'BUILDENV', value: env.BUILDENV), string(name: 'CLUSTER_ID', value: env.CLUSTER_ID), booleanParam(name: 'DNS_FORCE_DISABLE', value: env.DNS_FORCE_DISABLE), string(name: 'DEPLOY_TYPE', value: 'clean'), string(name: 'REDEPLOY_SCHEME', value: ''), string(name: 'CANARY', value: 'none'), booleanParam(name: 'CANARY_TIDY_ON_SUCCESS', value: true), string(name: 'MYHOSTTYPES', value: ''), string(name: 'CV_GIT_URL', value: scmVars ? scmVars.getUserRemoteConfigs()[0].getUrl() : DEFAULT_CLUSTERVERSE_URL), string(name: 'CV_GIT_BRANCH', value: CV_OPS_GIT_BRANCH), string(name: 'USER_CMDLINE_VARS', value: stageBuild.userParamsString())]
-                }
-              }
             }
-          } else {
-            stage_cvops('Redeploy not requested', stageBuild, {
-              echo "Redeploy testing not requested"
-            })
-          }
         }
-      }
-    }
 ])
 
 
@@ -354,60 +428,64 @@ CVTEST_MYHOSTTYPES = new MatrixBuilder([
 
 // A check stage - no actual work
 stage('Check Environment') {
-  node {
-    sh 'printenv | sort'
-    println(params.inspect())
-    if (params.BUILDENV == '') {
-//      currentBuild.result = 'ABORTED'
-//      error "BUILDENV not defined"
-      unstable("BUILDENV not defined")
-      throw new org.jenkinsci.plugins.workflow.steps.FlowInterruptedException(hudson.model.Result.ABORTED)
+    node {
+        sh 'printenv | sort'
+        println(params.inspect())
+        if (params.BUILDENV == '') {
+            currentBuild.result = 'ABORTED'
+            error("BUILDENV not defined")
+        } else if (params.CLUSTER_ID == '') {
+            currentBuild.result = 'ABORTED'
+            error("CLUSTER_ID not defined")
+        } else if (params.CLOUD_REGION == '') {
+            currentBuild.result = 'ABORTED'
+            error("CLOUD_REGION not defined")
+        }
     }
-  }
 }
 
 // A map to be loaded with matrices (of stages)
 HashMap matrixBuilds = [:]
 
-// A 'self-test' matrix.  Only outputs debug.
+//// A 'self-test' matrix.  Only outputs debug.
 //matrixBuilds["SELFTEST1 Matrix builds"] = {
-//  stage("SELFTEST Matrix builds") {
-//    echo("Matrix 'params' used to build Matrix axes: \n" + SELFTEST._getMatrixParams().inspect() + "\n")
-//    echo("Matrix axes: \n" + SELFTEST._getMatrixAxes().inspect() + "\n")
-//    parallel(SELFTEST.getTaskMap())
-//  }
+//    stage("SELFTEST Matrix builds") {
+//        echo("Matrix 'params' used to build Matrix axes: \n" + SELFTEST._getMatrixParams().inspect() + "\n")
+//        echo("Matrix axes: \n" + SELFTEST._getMatrixAxes().inspect() + "\n")
+//        parallel(SELFTEST.getTaskMap())
+//    }
 //}
 
 
 // A matrix of tests that test pipelines *without* myhosttypes configured
 if (params.MYHOSTTYPES_TEST.split(',').contains('nomyhosttypes')) {
-  matrixBuilds["NOMYHOSTTYPES Matrix builds"] = {
-    stage("NOMYHOSTTYPES Matrix builds") {
-      echo("Matrix 'params' used to build Matrix axes: \n" + CVTEST_NOMYHOSTTYPES._getMatrixParams().inspect() + "\n")
-      echo("Matrix axes: \n" + CVTEST_NOMYHOSTTYPES._getMatrixAxes().inspect() + "\n")
-      parallel(CVTEST_NOMYHOSTTYPES.getTaskMap())
+    matrixBuilds["NOMYHOSTTYPES Matrix builds"] = {
+        stage("NOMYHOSTTYPES Matrix builds") {
+            echo("Matrix 'params' used to build Matrix axes: \n" + CVTEST_NOMYHOSTTYPES._getMatrixParams().inspect() + "\n")
+            echo("Matrix axes: \n" + CVTEST_NOMYHOSTTYPES._getMatrixAxes().inspect() + "\n")
+            parallel(CVTEST_NOMYHOSTTYPES.getTaskMap())
+        }
     }
-  }
 }
 
 // A matrix of tests that test pipelines *with* myhosttypes configured
 if (params.MYHOSTTYPES_TEST.split(',').contains('myhosttypes')) {
-  matrixBuilds["MYHOSTTYPES Matrix builds"] = {
-    stage("MYHOSTTYPES Matrix builds") {
-      echo("Matrix 'params' used to build Matrix axes: \n" + CVTEST_MYHOSTTYPES._getMatrixParams().inspect() + "\n")
-      echo("Matrix axes: \n" + CVTEST_MYHOSTTYPES._getMatrixAxes().inspect() + "\n")
-      parallel(CVTEST_MYHOSTTYPES.getTaskMap())
+    matrixBuilds["MYHOSTTYPES Matrix builds"] = {
+        stage("MYHOSTTYPES Matrix builds") {
+            echo("Matrix 'params' used to build Matrix axes: \n" + CVTEST_MYHOSTTYPES._getMatrixParams().inspect() + "\n")
+            echo("Matrix axes: \n" + CVTEST_MYHOSTTYPES._getMatrixAxes().inspect() + "\n")
+            parallel(CVTEST_MYHOSTTYPES.getTaskMap())
+        }
     }
-  }
 }
 
 // Run the matrices in parallel if the MYHOSTTYPES_SERIAL_PARALLEL parameter is set (makes in mess in Blue Ocean, but is faster).  Else run serially.
 if (params.MYHOSTTYPES_SERIAL_PARALLEL == 'parallel') {
-  stage("All matrices") {
-    parallel(matrixBuilds)
-  }
+    stage("All matrices") {
+        parallel(matrixBuilds)
+    }
 } else {
-  matrixBuilds.each { matrix ->
-    matrix.value.call()
-  }
+    matrixBuilds.each { matrix ->
+        matrix.value.call()
+    }
 }


### PR DESCRIPTION
cherry-picked from https://github.com/dseeley/clusterverse/commit/de0939ef45c3817a7918d4a694626ce230f4c64f
+ Removes restriction on Ansible <= 2.10.6.  Can now be either 2.9.6...2.10.6 or >4.0.0 (core 2.11.0).
  + The method of getting `route53` records (using `route53` module with `state=get`), has an issue in 2.10.7 <= Ansible < 4 where the return values have changed due to boto3 migration (https://github.com/ansible-collections/community.aws/issues/523).  This is fixed in `community.aws` v1.5.0 (Ansible 4.0).
  + Also apply a fix to the `state=get`  mechanism to not fail when the records are not found.
+ The `state=get` function on the route53 module is not likely to remain supported indefinitely, so this optionally supports using `route53_info` instead (needs `-e use_new_route53=true`).
  + This mechanism has issues with ignoring `type` and `max_items` (https://github.com/ansible-collections/community.aws/issues/529).  The `type` can be worked around by filtering the output, but the `max_items` is a problem for large zone recordsets, where it downloads all the records (~800 records takes >2m).
