### PR TITLE
Filter canary option

### DIFF
--- a/EXAMPLE/README.md
+++ b/EXAMPLE/README.md
@@ -75,7 +75,7 @@ ansible-playbook redeploy.yml -e buildenv=sandbox -e clusterid=test_aws_euw1 --v
 
 ### Mandatory command-line variables:
 + `-e buildenv=<sandbox>` - The environment (dev, stage, etc), which must be an attribute of `cluster_vars` defined in `group_vars/<clusterid>/cluster_vars.yml`
-+ `-e canary=['start', 'finish', 'filter', none', 'tidy']` - Specify whether to start, finish or filter a canary deploy, or 'none' deploy
++ `-e canary=['start', 'finish', 'filter', 'none', 'tidy']` - Specify whether to start, finish or filter a canary deploy, or 'none' deploy
 
 ### Extra variables:
 + `-e redeploy_scheme=<subrole_name>` - The scheme corresponds to one defined in `roles/clusterverse/redeploy`

--- a/EXAMPLE/README.md
+++ b/EXAMPLE/README.md
@@ -65,6 +65,7 @@ The `redeploy.yml` sub-role will completely redeploy the cluster; this is useful
 ```
 ansible-playbook redeploy.yml -e buildenv=sandbox -e cloud_type=aws -e region=eu-west-1 -e clusterid=test --vault-id=sandbox@.vaultpass-client.py -e canary=none
 ansible-playbook redeploy.yml -e buildenv=sandbox -e clusterid=test_aws_euw1 --vault-id=sandbox@.vaultpass-client.py -e canary=none
+ansible-playbook redeploy.yml -e buildenv=sandbox -e clusterid=test_aws_euw1 --vault-id=sandbox@.vaultpass-client.py -e canary=filter -e canary_filter_regex='^*-test-sysdisks*$'
 ```
 ### GCP:
 ```
@@ -74,9 +75,10 @@ ansible-playbook redeploy.yml -e buildenv=sandbox -e clusterid=test_aws_euw1 --v
 
 ### Mandatory command-line variables:
 + `-e buildenv=<sandbox>` - The environment (dev, stage, etc), which must be an attribute of `cluster_vars` defined in `group_vars/<clusterid>/cluster_vars.yml`
-+ `-e canary=['start', 'finish', 'none', 'tidy']` - Specify whether to start or finish a canary deploy, or 'none' deploy
++ `-e canary=['start', 'finish', 'filter', none', 'tidy']` - Specify whether to start, finish or filter a canary deploy, or 'none' deploy
 
 ### Extra variables:
 + `-e redeploy_scheme=<subrole_name>` - The scheme corresponds to one defined in `roles/clusterverse/redeploy`
 + `-e canary_tidy_on_success=[true|false]` - Whether to run the tidy (remove the replaced VMs and DNS) on successful redeploy 
++ `-e canary_filter_regex=regex` - Mandatory when using `canary=filter` and sets the regex pattern used to filter the target hosts by their hostnames
 + `-e myhosttypes="master,slave"`- In redeployment you can define which host type you like to redeploy. If not defined it will redeploy all host types

--- a/EXAMPLE/README.md
+++ b/EXAMPLE/README.md
@@ -65,7 +65,7 @@ The `redeploy.yml` sub-role will completely redeploy the cluster; this is useful
 ```
 ansible-playbook redeploy.yml -e buildenv=sandbox -e cloud_type=aws -e region=eu-west-1 -e clusterid=test --vault-id=sandbox@.vaultpass-client.py -e canary=none
 ansible-playbook redeploy.yml -e buildenv=sandbox -e clusterid=test_aws_euw1 --vault-id=sandbox@.vaultpass-client.py -e canary=none
-ansible-playbook redeploy.yml -e buildenv=sandbox -e clusterid=test_aws_euw1 --vault-id=sandbox@.vaultpass-client.py -e canary=filter -e canary_filter_regex='^*-test-sysdisks*$'
+ansible-playbook redeploy.yml -e buildenv=sandbox -e clusterid=test_aws_euw1 --vault-id=sandbox@.vaultpass-client.py -e canary=filter -e canary_filter_regex='^.*-test-sysdisks.*$'
 ```
 ### GCP:
 ```

--- a/README.md
+++ b/README.md
@@ -195,7 +195,7 @@ The role is designed to run in two modes:
         + Delete/ terminate the node (note, this is _irreversible_).
         + Run the main cluster.yml (with the same parameters as for the main playbook), which forces the missing node to be redeployed (the `cluster_suffix` remains the same).
       + If `canary=start`, only the first node is redeployed.  If `canary=finish`, only the remaining (non-first), nodes are redeployed.  If `canary=none`, all nodes are redeployed.
-      + If `canary=filter`, you must also pass `canary_filter_key=regex` where `regex` is a pattern that matches the hostnames of the VMs that you want to target.
+      + If `canary=filter`, you must also pass `canary_filter_regex=regex` where `regex` is a pattern that matches the hostnames of the VMs that you want to target.
       + If the process fails at any point:
         + No further VMs will be deleted or rebuilt - the playbook stops. 
   + **_scheme_addnewvm_rmdisk_rollback**
@@ -205,7 +205,7 @@ The role is designed to run in two modes:
         + Run `predeleterole` on the previous node
         + Shut down the previous node.
       + If `canary=start`, only the first node is redeployed.  If `canary=finish`, only the remaining (non-first), nodes are redeployed.  If `canary=none`, all nodes are redeployed.
-      + If `canary=filter`, you must also pass `canary_filter_key=regex` where `regex` is a pattern that matches the hostnames of the VMs that you want to target.
+      + If `canary=filter`, you must also pass `canary_filter_regex=regex` where `regex` is a pattern that matches the hostnames of the VMs that you want to target.
       + If the process fails for any reason, the old VMs are reinstated, and any new VMs that were built are stopped (rollback)
       + To delete the old VMs, either set '-e canary_tidy_on_success=true', or call redeploy.yml with '-e canary=tidy'
   + **_scheme_addallnew_rmdisk_rollback**
@@ -229,6 +229,6 @@ The role is designed to run in two modes:
         + Run the main cluster.yml to create a new node
         + Attach disks to new node
       + If `canary=start`, only the first node is redeployed.  If `canary=finish`, only the remaining (non-first), nodes are replaced.  If `canary=none`, all nodes are redeployed.
-      + If `canary=filter`, you must also pass `canary_filter_key=regex` where `regex` is a pattern that matches the hostnames of the VMs that you want to target.
+      + If `canary=filter`, you must also pass `canary_filter_regex=regex` where `regex` is a pattern that matches the hostnames of the VMs that you want to target.
       + If the process fails for any reason, the old VMs are reinstated (and the disks reattached to the old nodes), and the new VMs are stopped (rollback)
       + To delete the old VMs, either set '-e canary_tidy_on_success=true', or call redeploy.yml with '-e canary=tidy'

--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ The role is designed to run in two modes:
 #### Redeploy
 + A playbook based on the [redeploy.yml example](https://github.com/sky-uk/clusterverse/tree/master/EXAMPLE/redeploy.yml) will be needed.
 + The `redeploy.yml` sub-role will completely redeploy the cluster; this is useful for example to upgrade the underlying operating system version.
-+ It supports `canary` deploys.  The `canary` extra variable must be defined on the command line set to one of: `start`, `finish`, `none` or `tidy`. 
++ It supports `canary` deploys.  The `canary` extra variable must be defined on the command line set to one of: `start`, `finish`, `filter`, `none` or `tidy`.
 + It contains callback hooks:
   + `mainclusteryml`: This is the name of the deployment playbook.  It is called to deploy nodes for the new cluster, or to rollback a failed deployment.  It should be set to the value of the primary _deploy_ playbook yml (e.g. `cluster.yml`)
   + `predeleterole`: This is the name of a role that should be called prior to deleting VMs; it is used for example to eject nodes from a Couchbase cluster.  It takes a list of `hosts_to_remove` VMs. 
@@ -194,6 +194,8 @@ The role is designed to run in two modes:
         + Run `predeleterole`
         + Delete/ terminate the node (note, this is _irreversible_).
         + Run the main cluster.yml (with the same parameters as for the main playbook), which forces the missing node to be redeployed (the `cluster_suffix` remains the same).
+      + If `canary=start`, only the first node is redeployed.  If `canary=finish`, only the remaining (non-first), nodes are redeployed.  If `canary=none`, all nodes are redeployed.
+      + If `canary=filter`, you must also pass `canary_filter_key=regex` where `regex` is a pattern that matches the hostnames of the VMs that you want to target.
       + If the process fails at any point:
         + No further VMs will be deleted or rebuilt - the playbook stops. 
   + **_scheme_addnewvm_rmdisk_rollback**
@@ -203,6 +205,7 @@ The role is designed to run in two modes:
         + Run `predeleterole` on the previous node
         + Shut down the previous node.
       + If `canary=start`, only the first node is redeployed.  If `canary=finish`, only the remaining (non-first), nodes are redeployed.  If `canary=none`, all nodes are redeployed.
+      + If `canary=filter`, you must also pass `canary_filter_key=regex` where `regex` is a pattern that matches the hostnames of the VMs that you want to target.
       + If the process fails for any reason, the old VMs are reinstated, and any new VMs that were built are stopped (rollback)
       + To delete the old VMs, either set '-e canary_tidy_on_success=true', or call redeploy.yml with '-e canary=tidy'
   + **_scheme_addallnew_rmdisk_rollback**
@@ -212,6 +215,7 @@ The role is designed to run in two modes:
       + If `canary=finish` or `canary=none`:
           + `predeleterole` is called with a list of the old VMs.
           + The old VMs are stopped.
+      + If `canary=filter`, an error message will be shown is this scheme does not support it.
       + If the process fails for any reason, the old VMs are reinstated, and the new VMs stopped (rollback)
       + To delete the old VMs, either set '-e canary_tidy_on_success=true', or call redeploy.yml with '-e canary=tidy'
   + **_scheme_rmvm_keepdisk_rollback**
@@ -225,5 +229,6 @@ The role is designed to run in two modes:
         + Run the main cluster.yml to create a new node
         + Attach disks to new node
       + If `canary=start`, only the first node is redeployed.  If `canary=finish`, only the remaining (non-first), nodes are replaced.  If `canary=none`, all nodes are redeployed.
+      + If `canary=filter`, you must also pass `canary_filter_key=regex` where `regex` is a pattern that matches the hostnames of the VMs that you want to target.
       + If the process fails for any reason, the old VMs are reinstated (and the disks reattached to the old nodes), and the new VMs are stopped (rollback)
       + To delete the old VMs, either set '-e canary_tidy_on_success=true', or call redeploy.yml with '-e canary=tidy'

--- a/redeploy/_scheme_addallnew_rmdisk_rollback/tasks/main.yml
+++ b/redeploy/_scheme_addallnew_rmdisk_rollback/tasks/main.yml
@@ -8,7 +8,7 @@
       when: canary=="start" or canary=="none"
 
     - assert: { that: "myhosttypes is not defined or myhosttypes == ''", fail_msg: "ERROR - This redeploy scheme does not support myhosttypes." }
-    - assert: { that: "canary == 'filter'", fail_msg: "ERROR - This redeploy scheme does not support the filter canary option." }
+    - assert: { that: "canary != 'filter'", fail_msg: "ERROR - This redeploy scheme does not support the filter canary option." }
 
 
 - name: Redeploy by replacing entire cluster; rollback on fail

--- a/redeploy/_scheme_addallnew_rmdisk_rollback/tasks/main.yml
+++ b/redeploy/_scheme_addallnew_rmdisk_rollback/tasks/main.yml
@@ -8,6 +8,7 @@
       when: canary=="start" or canary=="none"
 
     - assert: { that: "myhosttypes is not defined or myhosttypes == ''", fail_msg: "ERROR - This redeploy scheme does not support myhosttypes." }
+    - assert: { that: "canary == 'filter'", fail_msg: "ERROR - This redeploy scheme does not support the filter canary option." }
 
 
 - name: Redeploy by replacing entire cluster; rollback on fail

--- a/redeploy/_scheme_addnewvm_rmdisk_rollback/tasks/redeploy_by_hosttype.yml
+++ b/redeploy/_scheme_addnewvm_rmdisk_rollback/tasks/redeploy_by_hosttype.yml
@@ -8,6 +8,10 @@
   set_fact: hosts_to_redeploy={{(cluster_hosts_target_by_hosttype[hosttype] | sort(attribute='hostname'))[1:]}}
   when: (canary is defined and canary=="finish")
 
+- name: set hosts_to_redeploy if canary==filter
+  set_fact: hosts_to_redeploy={{(cluster_hosts_target_by_hosttype[hosttype] | sort(attribute='hostname')) | selectattr(canary_filter_key, 'search', canary_filter_regex) | list}}
+  when: (canary is defined and canary=="filter")
+
 - name: set hosts_to_redeploy if canary==none
   set_fact: hosts_to_redeploy={{(cluster_hosts_target_by_hosttype[hosttype] | sort(attribute='hostname'))}}
   when: (canary is defined and canary=="none")

--- a/redeploy/_scheme_addnewvm_rmdisk_rollback/tasks/redeploy_by_hosttype.yml
+++ b/redeploy/_scheme_addnewvm_rmdisk_rollback/tasks/redeploy_by_hosttype.yml
@@ -9,7 +9,7 @@
   when: (canary is defined and canary=="finish")
 
 - name: set hosts_to_redeploy if canary==filter
-  set_fact: hosts_to_redeploy={{(cluster_hosts_target_by_hosttype[hosttype] | sort(attribute='hostname')) | selectattr(canary_filter_key, 'search', canary_filter_regex) | list}}
+  set_fact: hosts_to_redeploy={{(cluster_hosts_target_by_hosttype[hosttype] | sort(attribute='hostname')) | selectattr('hostname', 'search', canary_filter_regex) | list}}
   when: (canary is defined and canary=="filter")
 
 - name: set hosts_to_redeploy if canary==none

--- a/redeploy/_scheme_rmvm_keepdisk_rollback/tasks/by_hosttype.yml
+++ b/redeploy/_scheme_rmvm_keepdisk_rollback/tasks/by_hosttype.yml
@@ -9,7 +9,7 @@
   when: (canary is defined and canary=="finish")
 
 - name: set hosts_to_redeploy if canary==filter
-  set_fact: hosts_to_redeploy={{(cluster_hosts_target_by_hosttype[hosttype] | sort(attribute='hostname')) | selectattr(canary_filter_attr, 'search', canary_filter_value)[]}}
+  set_fact: hosts_to_redeploy={{(cluster_hosts_target_by_hosttype[hosttype] | sort(attribute='hostname')) | selectattr(canary_filter_attr, 'search', canary_filter_value) | list}}
   when: (canary is defined and canary=="filter")
 
 - name: set hosts_to_redeploy if canary==none

--- a/redeploy/_scheme_rmvm_keepdisk_rollback/tasks/by_hosttype.yml
+++ b/redeploy/_scheme_rmvm_keepdisk_rollback/tasks/by_hosttype.yml
@@ -8,6 +8,10 @@
   set_fact: hosts_to_redeploy={{(cluster_hosts_target_by_hosttype[hosttype] | sort(attribute='hostname'))[1:]}}
   when: (canary is defined and canary=="finish")
 
+- name: set hosts_to_redeploy if canary==filter
+  set_fact: hosts_to_redeploy={{(cluster_hosts_target_by_hosttype[hosttype] | sort(attribute='hostname')) | selectattr(canary_filter_attr, 'search', canary_filter_value)[]}}
+  when: (canary is defined and canary=="filter")
+
 - name: set hosts_to_redeploy if canary==none
   set_fact: hosts_to_redeploy={{(cluster_hosts_target_by_hosttype[hosttype] | sort(attribute='hostname'))}}
   when: (canary is defined and canary=="none")

--- a/redeploy/_scheme_rmvm_keepdisk_rollback/tasks/by_hosttype.yml
+++ b/redeploy/_scheme_rmvm_keepdisk_rollback/tasks/by_hosttype.yml
@@ -9,7 +9,7 @@
   when: (canary is defined and canary=="finish")
 
 - name: set hosts_to_redeploy if canary==filter
-  set_fact: hosts_to_redeploy={{(cluster_hosts_target_by_hosttype[hosttype] | sort(attribute='hostname')) | selectattr(canary_filter_attr, 'search', canary_filter_value) | list}}
+  set_fact: hosts_to_redeploy={{(cluster_hosts_target_by_hosttype[hosttype] | sort(attribute='hostname')) | selectattr(canary_filter_key, 'search', canary_filter_regex) | list}}
   when: (canary is defined and canary=="filter")
 
 - name: set hosts_to_redeploy if canary==none

--- a/redeploy/_scheme_rmvm_keepdisk_rollback/tasks/by_hosttype.yml
+++ b/redeploy/_scheme_rmvm_keepdisk_rollback/tasks/by_hosttype.yml
@@ -9,7 +9,7 @@
   when: (canary is defined and canary=="finish")
 
 - name: set hosts_to_redeploy if canary==filter
-  set_fact: hosts_to_redeploy={{(cluster_hosts_target_by_hosttype[hosttype] | sort(attribute='hostname')) | selectattr(canary_filter_key, 'search', canary_filter_regex) | list}}
+  set_fact: hosts_to_redeploy={{(cluster_hosts_target_by_hosttype[hosttype] | sort(attribute='hostname')) | selectattr('hostname', 'search', canary_filter_regex) | list}}
   when: (canary is defined and canary=="filter")
 
 - name: set hosts_to_redeploy if canary==none

--- a/redeploy/_scheme_rmvm_keepdisk_rollback/tasks/main.yml
+++ b/redeploy/_scheme_rmvm_keepdisk_rollback/tasks/main.yml
@@ -112,4 +112,4 @@
       when: hosts_to_clean | length == 0
   vars:
     hosts_to_clean: "{{ cluster_hosts_state | json_query(\"[?tagslabels.lifecycle_state!='current' && !(contains('RUNNING,running,poweredOn', instance_state)) && ('\"+ canary + \"' == 'tidy'  ||  '\"+ myhosttypes|default('') + \"' == ''  ||  contains(['\"+ myhosttypes|default('') + \"'], tagslabels.hosttype)) ]\") }}"
-  when: canary=="tidy" or  ((canary=="none" or canary=="finish") and canary_tidy_on_success is defined and canary_tidy_on_success|bool)
+  when: canary=="tidy" or  ((canary=="none" or canary=="finish" or canary=="filter") and canary_tidy_on_success is defined and canary_tidy_on_success|bool)

--- a/redeploy/_scheme_rmvm_keepdisk_rollback/tasks/preflight.yml
+++ b/redeploy/_scheme_rmvm_keepdisk_rollback/tasks/preflight.yml
@@ -33,9 +33,6 @@
     - assert: { that: "_scheme_rmvm_keepdisk_rollback__copy_or_move is defined and _scheme_rmvm_keepdisk_rollback__copy_or_move in ['copy', 'move']", fail_msg: "ERROR - _scheme_rmvm_keepdisk_rollback__copy_or_move must be defined and set to either 'copy' or 'move'"  }
       when: cluster_vars.type == "esxifree"
 
-    - assert: { that: "canary_filter_key is defined and canary_filter_regex is defined and canary_filter_key != '' and canary_filter_regex != ''", fail_msg: "Please define canary_filter_key and canary_filter_regex when using the filter canary option"  }
-      when: canary == "filter"
-
     - assert: { that: "non_current_hosts | length == 0", fail_msg: "ERROR - All VMs must be in the 'current' lifecycle_state.  Those not [{{non_current_hosts | join(',')}}]" }
       vars: { non_current_hosts: "{{ cluster_hosts_state | json_query(\"[?tagslabels.lifecycle_state!='current'].name\") }}" }
       # TODO: remove myhosttypes not defined and replace json_query    "{{ cluster_hosts_state | json_query(\"[?tagslabels.lifecycle_state!='current' && ('\"+ myhosttypes|default('') + \"' == ''  ||  contains(['\"+ myhosttypes|default('') + \"'], tagslabels.hosttype))].name\") }}"

--- a/redeploy/_scheme_rmvm_keepdisk_rollback/tasks/preflight.yml
+++ b/redeploy/_scheme_rmvm_keepdisk_rollback/tasks/preflight.yml
@@ -33,6 +33,9 @@
     - assert: { that: "_scheme_rmvm_keepdisk_rollback__copy_or_move is defined and _scheme_rmvm_keepdisk_rollback__copy_or_move in ['copy', 'move']", fail_msg: "ERROR - _scheme_rmvm_keepdisk_rollback__copy_or_move must be defined and set to either 'copy' or 'move'"  }
       when: cluster_vars.type == "esxifree"
 
+    - assert: { that: "canary_filter_key is defined and canary_filter_regex is defined and canary_filter_key != '' and canary_filter_regex != ''", fail_msg: "Please define canary_filter_key and canary_filter_regex when using the filter canary option"  }
+      when: canary == "filter"
+
     - assert: { that: "non_current_hosts | length == 0", fail_msg: "ERROR - All VMs must be in the 'current' lifecycle_state.  Those not [{{non_current_hosts | join(',')}}]" }
       vars: { non_current_hosts: "{{ cluster_hosts_state | json_query(\"[?tagslabels.lifecycle_state!='current'].name\") }}" }
       # TODO: remove myhosttypes not defined and replace json_query    "{{ cluster_hosts_state | json_query(\"[?tagslabels.lifecycle_state!='current' && ('\"+ myhosttypes|default('') + \"' == ''  ||  contains(['\"+ myhosttypes|default('') + \"'], tagslabels.hosttype))].name\") }}"

--- a/redeploy/_scheme_rmvm_rmdisk_only/tasks/by_hosttype.yml
+++ b/redeploy/_scheme_rmvm_rmdisk_only/tasks/by_hosttype.yml
@@ -9,7 +9,7 @@
   when: (canary is defined and canary=="finish")
 
 - name: set hosts_to_redeploy if canary==filter
-  set_fact: hosts_to_redeploy={{(cluster_hosts_target_by_hosttype[hosttype] | sort(attribute='hostname')) | selectattr(canary_filter_key, 'search', canary_filter_regex) | list}}
+  set_fact: hosts_to_redeploy={{(cluster_hosts_target_by_hosttype[hosttype] | sort(attribute='hostname')) | selectattr('hostname', 'search', canary_filter_regex) | list}}
   when: (canary is defined and canary=="filter")
 
 - name: set hosts_to_del if canary==none

--- a/redeploy/_scheme_rmvm_rmdisk_only/tasks/by_hosttype.yml
+++ b/redeploy/_scheme_rmvm_rmdisk_only/tasks/by_hosttype.yml
@@ -8,6 +8,10 @@
   set_fact: hosts_to_del={{(cluster_hosts_dict[hosttype] | sort(attribute='hostname'))[1:]}}
   when: (canary is defined and canary=="finish")
 
+- name: set hosts_to_redeploy if canary==filter
+  set_fact: hosts_to_redeploy={{(cluster_hosts_target_by_hosttype[hosttype] | sort(attribute='hostname')) | selectattr(canary_filter_key, 'search', canary_filter_regex) | list}}
+  when: (canary is defined and canary=="filter")
+
 - name: set hosts_to_del if canary==none
   set_fact: hosts_to_del={{(cluster_hosts_dict[hosttype] | sort(attribute='hostname'))}}
   when: (canary is defined and canary=="none")

--- a/redeploy/tasks/main.yml
+++ b/redeploy/tasks/main.yml
@@ -3,7 +3,7 @@
 - name: Preflight check - Redeploy
   block:
     - assert: { that: "clean is not defined", msg: "Must not set the 'clean' variable for a redeploy" }
-    - assert: { that: "canary is defined and (canary is defined and canary in ['start', 'finish', 'none', 'tidy'])", msg: "Canary must be 'start', 'finish', 'none' or 'tidy'" }
+    - assert: { that: "canary is defined and (canary is defined and canary in ['start', 'finish', 'filter', 'none', 'tidy'])", msg: "Canary must be 'start', 'finish', 'filter', 'none' or 'tidy'" }
     - assert: { that: "redeploy_scheme is defined and redeploy_scheme in redeploy_schemes_supported" }
     - assert: { that: "cluster_hosts_state | length", msg: "Redeploy only possible with an existing cluster." }
 

--- a/redeploy/tasks/main.yml
+++ b/redeploy/tasks/main.yml
@@ -4,7 +4,7 @@
   block:
     - assert: { that: "clean is not defined", msg: "Must not set the 'clean' variable for a redeploy" }
     - assert: { that: "canary is defined and (canary is defined and canary in ['start', 'finish', 'filter', 'none', 'tidy'])", msg: "Canary must be 'start', 'finish', 'filter', 'none' or 'tidy'" }
-    - assert: { that: "canary_filter_key is defined and canary_filter_regex is defined and canary_filter_key != '' and canary_filter_regex != ''", fail_msg: "Please define canary_filter_key and canary_filter_regex when using the filter canary option"  }
+    - assert: { that: "canary_filter_regex is defined and canary_filter_regex != ''", fail_msg: "Please define canary_filter_regex when using the filter canary option" }
       when: canary == "filter"
     - assert: { that: "redeploy_scheme is defined and redeploy_scheme in redeploy_schemes_supported" }
     - assert: { that: "cluster_hosts_state | length", msg: "Redeploy only possible with an existing cluster." }

--- a/redeploy/tasks/main.yml
+++ b/redeploy/tasks/main.yml
@@ -4,6 +4,8 @@
   block:
     - assert: { that: "clean is not defined", msg: "Must not set the 'clean' variable for a redeploy" }
     - assert: { that: "canary is defined and (canary is defined and canary in ['start', 'finish', 'filter', 'none', 'tidy'])", msg: "Canary must be 'start', 'finish', 'filter', 'none' or 'tidy'" }
+    - assert: { that: "canary_filter_key is defined and canary_filter_regex is defined and canary_filter_key != '' and canary_filter_regex != ''", fail_msg: "Please define canary_filter_key and canary_filter_regex when using the filter canary option"  }
+      when: canary == "filter"
     - assert: { that: "redeploy_scheme is defined and redeploy_scheme in redeploy_schemes_supported" }
     - assert: { that: "cluster_hosts_state | length", msg: "Redeploy only possible with an existing cluster." }
 


### PR DESCRIPTION
- Added support for a new canary option called filter for the _scheme_addnewvm_rmdisk_rollback, _scheme_rmvm_rmdisk_only and _scheme_rmvm_keepdisk_rollback redeploy schemes
- Documented the filter canary option in the README
- Added appropriate checks