### PR TITLE
Allow automatic selection of latest cloud OS image; add ARM64 support.

### DIFF
--- a/EXAMPLE/ansible.cfg
+++ b/EXAMPLE/ansible.cfg
@@ -1,16 +1,17 @@
 [defaults]
 forks = 50
-force_handlers = True
+force_handlers = yes
 vault_password_file = .vaultpass-client.py
 ;vault_identity_list = sandbox@.vaultpass-client.py, tools@.vaultpass-client.py, dev@.vaultpass-client.py, stage@.vaultpass-client.py, prod@.vaultpass-client.py
-host_key_checking = False
+host_key_checking = no
 force_valid_group_names = ignore
 roles_path = ./roles
 interpreter_python = auto
+callbacks_enabled = ansible.posix.profile_tasks
+pipelining = yes
 
 [ssh_connection]
-retries=5
+retries=10
 ssh_args = -o 'UserKnownHostsFile=/dev/null' -o 'ControlMaster=auto' -o 'ControlPersist=60s'
 #ssh_args = -o 'UserKnownHostsFile=/dev/null' -o 'ControlMaster=auto' -o 'ControlPersist=60s' -o ProxyCommand="ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i <proxy_cert> -W %h:%p -q <user>@<host>>"      ##To use with bastion
-pipelining = True
 control_path_dir=/tmp/.ansible/cp

--- a/EXAMPLE/cluster_defs/aws/testid/eu-west-1/cluster_vars__region.yml
+++ b/EXAMPLE/cluster_defs/aws/testid/eu-west-1/cluster_vars__region.yml
@@ -1,8 +1,12 @@
 ---
 
-_ubuntu2004image: "ami-03caf24deed650e2c"                # eu-west-1 20.04, amd64, hvm-ssd, 20210621.  Ubuntu images can be located at https://cloud-images.ubuntu.com/locator/
-_centos7image: "ami-01f35c358a86763b2"                   # eu-west-1 CentOS 7 by Banzai Cloud
-_alma8image: "ami-05d7345cebf7a784f"                     # eu-west-1 Official AlmaLinux 8.x OS image
+_ubuntu2004image: "099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-*"     # Latest official Canonical Ubuntu Focal (20.04.x) image
+_centos7image: "161831738826/centos-7-pke-*"                                    # Latest 'Banzai Cloud' CentOS 7.x image
+_alma8image: "764336703387/AlmaLinux OS 8.*"                                    # Latest official AlmaLinux 8.x OS image
+
+#_ubuntu2004image: "ami-05db7ab97b239b0ac"                # eu-west-1 20.04 amd64 hvm-ssd 20210820.  Ubuntu images can be located at https://cloud-images.ubuntu.com/locator/
+#_centos7image: "ami-01f35c358a86763b2"                   # eu-west-1 CentOS 7 by Banzai Cloud
+#_alma8image: "ami-05d7345cebf7a784f"                     # eu-west-1 Official AlmaLinux 8.x OS image
 
 cluster_vars:
   image: "{{_ubuntu2004image}}"

--- a/EXAMPLE/cluster_defs/aws/testid/eu-west-1/sandbox/cluster_vars__buildenv.yml
+++ b/EXAMPLE/cluster_defs/aws/testid/eu-west-1/sandbox/cluster_vars__buildenv.yml
@@ -32,6 +32,24 @@ cluster_vars:
         version: "{{sys_version | default('')}}"
         vms_by_az: { a: 1, b: 1, c: 0 }
 
+      sysarm:
+        auto_volumes: [ ]
+        flavor: t4g.nano
+#        image: "ami-0c28049fa5618bca4"              # eu-west-1 20.04 arm64 hvm-ssd 20210820.  Ubuntu images can be located at https://cloud-images.ubuntu.com/locator/
+        version: "{{sys_version | default('')}}"
+        vms_by_az: { a: 1, b: 0, c: 0 }
+
+      sysarmdiskslvm:
+        auto_volumes:
+          - { device_name: "/dev/sda1", mountpoint: "/", fstype: "ext4", volume_type: "gp2", volume_size: 8, encrypted: True, delete_on_termination: true }
+          - { device_name: "/dev/sdf", mountpoint: "/media/mysvc", fstype: "ext4", volume_type: "gp2", volume_size: 1, encrypted: True, delete_on_termination: true }
+          - { device_name: "/dev/sdg", mountpoint: "/media/mysvc", fstype: "ext4", volume_type: "gp2", volume_size: 1, encrypted: True, delete_on_termination: true }
+        lvmparams: { vg_name: "vg0", lv_name: "lv0", lv_size: "100%VG" }
+        flavor: t4g.nano
+#        image: "ami-0c28049fa5618bca4"              # eu-west-1 20.04 arm64 hvm-ssd 20210820.  Ubuntu images can be located at https://cloud-images.ubuntu.com/locator/
+        version: "{{sys_version | default('')}}"
+        vms_by_az: { a: 1, b: 0, c: 0 }
+
       sysspot:
         auto_volumes: [ ]
         flavor: t3a.nano

--- a/EXAMPLE/cluster_defs/gcp/cluster_vars__cloud.yml
+++ b/EXAMPLE/cluster_defs/gcp/cluster_vars__cloud.yml
@@ -1,8 +1,12 @@
 ---
 
-_ubuntu2004image: "projects/ubuntu-os-cloud/global/images/ubuntu-2004-focal-v20210702"
-_centos7image: "projects/centos-cloud/global/images/centos-7-v20210701"
-_alma8image: "projects/almalinux-cloud/global/images/almalinux-8-v20210701"
+_ubuntu2004image: "projects/ubuntu-os-cloud/global/images/ubuntu-2004-focal-*"   # Latest Ubuntu Focal (20.04.x) image
+_centos7image: "projects/centos-cloud/global/images/centos-7-*"                  # Latest CentOS 7.x image
+_alma8image: "projects/almalinux-cloud/global/images/almalinux-8-*"              # Latest AlmaLinux 8.x OS image
+
+#_ubuntu2004image: "projects/ubuntu-os-cloud/global/images/ubuntu-2004-focal-v20210820"   #europe-west4 20.04 amd64 20210820.  Ubuntu images can be located at https://cloud-images.ubuntu.com/locator/
+#_centos7image: "projects/centos-cloud/global/images/centos-7-v20210721"
+#_alma8image: "projects/almalinux-cloud/global/images/almalinux-8-v20210701"
 
 cluster_vars:
   image: "{{_ubuntu2004image}}"

--- a/EXAMPLE/cluster_defs/gcp/testid/europe-west4/sandbox/cluster_vars__buildenv.yml
+++ b/EXAMPLE/cluster_defs/gcp/testid/europe-west4/sandbox/cluster_vars__buildenv.yml
@@ -29,16 +29,16 @@ cluster_vars:
         auto_volumes: [ ]
         flavor: "e2-micro"
         version: "{{sys_version | default('')}}"
-        vms_by_az: { d: 1, b: 1, c: 0 }
+        vms_by_az: { a: 1, b: 1, c: 0 }
 
       sysdisks2:
         auto_volumes:
-          - { auto_delete: true, interface: "SCSI", volume_size: 1, mountpoint: "/media/mysvc", fstype: "ext4", perms: { owner: "root", group: "root", mode: "775" } }
+          - { auto_delete: true, interface: "SCSI", volume_size: 1, mountpoint: "/media/mysvc1", fstype: "ext4", perms: { owner: "root", group: "root", mode: "775" } }
           - { auto_delete: true, interface: "SCSI", volume_size: 1, mountpoint: "/media/mysvc2", fstype: "ext4" }
         flavor: "e2-micro"
         rootvol_size: "25"              # This is optional, and if set, MUST be bigger than the original image size (20GB on GCP)
         version: "{{sysdisks_version | default('')}}"
-        vms_by_az: { d: 1, b: 1, c: 0 }
+        vms_by_az: { a: 1, b: 1, c: 0 }
 
       sysdiskslvm:
         auto_volumes:
@@ -48,7 +48,7 @@ cluster_vars:
         flavor: "e2-micro"
         rootvol_size: "25"              # This is optional, and if set, MUST be bigger than the original image size (20GB on GCP)
         version: "{{sysdisks_version | default('')}}"
-        vms_by_az: { d: 1, b: 1, c: 0 }
+        vms_by_az: { a: 1, b: 1, c: 0 }
 
 _gcp_service_account_rawtext: *gcp_service_account_rawtext
 _host_ssh_connection_cfg: { <<: *host_ssh_connection_cfg }

--- a/EXAMPLE/cluster_defs/test_aws_euw1/cluster_vars.yml
+++ b/EXAMPLE/cluster_defs/test_aws_euw1/cluster_vars.yml
@@ -50,8 +50,13 @@ cluster_name: "{{app_name}}-{{buildenv}}"       # Identifies the cluster within 
 
 cluster_vars:
   type: &cloud_type "aws"
-  image: "ami-03caf24deed650e2c"      # eu-west-1 20.04 amd64 hvm-ssd 20210621.  Ubuntu images can be located at https://cloud-images.ubuntu.com/locator/
-#  image: "ami-0b850cf02cc00fdc8"      # eu-west-1, CentOS7
+  # Either specify absolute image AMIs, or find the latest images based on location name filter.
+  image: "099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-*"     # Latest official Canonical Ubuntu Focal (20.04.x) image
+  #image: "161831738826/centos-7-pke-*"                                 # Latest 'Banzai Cloud' CentOS 7.x image
+  #image: "764336703387/AlmaLinux OS 8.*"                               # Latest official AlmaLinux 8.x OS image
+  #image: "ami-03caf24deed650e2c"                   # eu-west-1 20.04 amd64 hvm-ssd 20210621.  Ubuntu images can be located at https://cloud-images.ubuntu.com/locator/
+  #image: "ami-01f35c358a86763b2"                   # eu-west-1 CentOS 7 by Banzai Cloud
+  #image: "ami-05d7345cebf7a784f"                   # eu-west-1 Official AlmaLinux 8.x OS image
   region: &region "eu-west-1"
   dns_cloud_internal_domain: "{{_region}}.compute.internal"       # The cloud-internal zone as defined by the cloud provider (e.g. GCP, AWS)
   dns_nameserver_zone: &dns_nameserver_zone ""                    # The zone that dns_server will operate on.  gcloud dns needs a trailing '.'.  Leave blank if no external DNS (use IPs only)

--- a/EXAMPLE/cluster_defs/test_gcp_euw1/cluster_vars.yml
+++ b/EXAMPLE/cluster_defs/test_gcp_euw1/cluster_vars.yml
@@ -50,9 +50,13 @@ cluster_name: "{{app_name}}-{{buildenv}}"       # Identifies the cluster within 
 
 cluster_vars:
   type: &cloud_type "gcp"
-  image: "projects/ubuntu-os-cloud/global/images/ubuntu-2004-focal-v20210623"                     # Ubuntu images can be located at https://cloud-images.ubuntu.com/locator/
-#  image: "projects/ubuntu-os-cloud/global/images/centos-7-v20201216
-  region: &region "europe-west1"
+  image: "projects/ubuntu-os-cloud/global/images/ubuntu-2004-focal-*"      # Latest Ubuntu Focal (20.04.x) image
+  #image: "projects/centos-cloud/global/images/centos-7-*"                  # Latest CentOS 7.x image
+  #image: "projects/almalinux-cloud/global/images/almalinux-8-*"            # Latest AlmaLinux 8.x OS image
+  #image: "projects/ubuntu-os-cloud/global/images/ubuntu-2004-focal-v20210702"
+  #image: "projects/centos-cloud/global/images/centos-7-v20210701"
+  #image: "projects/almalinux-cloud/global/images/almalinux-8-v20210701"
+  region: &region "europe-west4"
   dns_cloud_internal_domain: "c.{{ (_gcp_service_account_rawtext | string | from_json).project_id }}.internal"         # The cloud-internal zone as defined by the cloud provider (e.g. GCP, AWS)
   dns_nameserver_zone: &dns_nameserver_zone ""                                                    # The zone that dns_server will operate on.  gcloud dns needs a trailing '.'.  Leave blank if no external DNS (use IPs only)
   dns_user_domain: "{%- if _dns_nameserver_zone -%}{{_cloud_type}}-{{_region}}.{{app_class}}.{{buildenv}}.{{_dns_nameserver_zone}}{%- endif -%}"         # A user-defined _domain_ part of the FDQN, (if more prefixes are required before the dns_nameserver_zone)
@@ -90,9 +94,9 @@ cluster_vars:
       description: "Prometheus instances attached to {{cluster_name}}-nwtag can access the exporter port(s)."
   sandbox:
     hosttype_vars:
-      sys: {vms_by_az: {d: 1, b: 1, c: 0}, flavor: e2-micro, version: '{{sys_version | default('''')}}', auto_volumes: []}
-      sysdisks2: {vms_by_az: {d: 1, b: 1, c: 0}, flavor: e2-micro, version: '{{sysdisks_version | default('''')}}', rootvol_size: '25', auto_volumes: [{auto_delete: true, interface: SCSI, volume_size: 1, mountpoint: /media/mysvc, fstype: ext4, perms: {owner: root, group: root, mode: '775'}}, {auto_delete: true, interface: SCSI, volume_size: 1, mountpoint: /media/mysvc2, fstype: ext4}]}
-      sysdisks3: {vms_by_az: {d: 1, b: 1, c: 0}, flavor: e2-micro, version: '{{sysdisks_version | default('''')}}', auto_volumes: [{auto_delete: true, interface: SCSI, volume_size: 1, mountpoint: /media/mysvc, fstype: ext4}, {auto_delete: true, interface: SCSI, volume_size: 1, mountpoint: /media/mysvc2, fstype: ext4}, {auto_delete: true, interface: SCSI, volume_size: 3, mountpoint: /media/mysvc3, fstype: ext4}]}
+      sys: {vms_by_az: {a: 1, b: 1, c: 0}, flavor: e2-micro, version: '{{sys_version | default('''')}}', auto_volumes: []}
+      sysdisks2: {vms_by_az: {a: 1, b: 1, c: 0}, flavor: e2-micro, version: '{{sysdisks_version | default('''')}}', rootvol_size: '25', auto_volumes: [{auto_delete: true, interface: SCSI, volume_size: 1, mountpoint: /media/mysvc, fstype: ext4, perms: {owner: root, group: root, mode: '775'}}, {auto_delete: true, interface: SCSI, volume_size: 1, mountpoint: /media/mysvc2, fstype: ext4}]}
+      sysdisks3: {vms_by_az: {a: 1, b: 1, c: 0}, flavor: e2-micro, version: '{{sysdisks_version | default('''')}}', auto_volumes: [{auto_delete: true, interface: SCSI, volume_size: 1, mountpoint: /media/mysvc, fstype: ext4}, {auto_delete: true, interface: SCSI, volume_size: 1, mountpoint: /media/mysvc2, fstype: ext4}, {auto_delete: true, interface: SCSI, volume_size: 3, mountpoint: /media/mysvc3, fstype: ext4}]}
     gcp_service_account_rawtext: &gcp_service_account_rawtext !vault |
       $ANSIBLE_VAULT;1.2;AES256;sandbox
       7669080460651349243347331538721104778691266429457726036813912140404310

--- a/EXAMPLE/jenkinsfiles/Jenkinsfile_ops
+++ b/EXAMPLE/jenkinsfiles/Jenkinsfile_ops
@@ -101,7 +101,7 @@ node {
         //  docker.build("cvops", "--build-arg JENKINS_USERNAME=${jenkins_username} --build-arg JENKINS_UID=${jenkins_uid} --build-arg JENKINS_GID=${jenkins_gid} ./jenkinsfiles").inside("${docker_parent_net_str} -e JENKINS_HOME=${env.JENKINS_HOME}") {
 
         /*** Create a custom docker image within this Jenkinsfile ***/
-        create_custom_image("ubuntu_cvtest", "").inside("${docker_parent_net_str}") {
+        create_custom_image("ubuntu_cvtest", "").inside("--init ${docker_parent_net_str}") {
             stage('Setup Environment') {
                 sh 'printenv | sort'
                 println("common_deploy_vars params:" + params)

--- a/EXAMPLE/roles/testrole/tasks/main.yml
+++ b/EXAMPLE/roles/testrole/tasks/main.yml
@@ -3,5 +3,7 @@
 - name: Debug role path
   debug: msg="{{role_path}}"
 
-- name: Debug hosttype_vars
-  debug: msg="{{cluster_vars[buildenv].hosttype_vars}}"
+- name: Forcibly fail (-e testfail=fail_3)
+  fail:
+    msg: testfail=fail_3
+  when: testfail is defined and testfail == "fail_3"

--- a/_dependencies/defaults/main.yml
+++ b/_dependencies/defaults/main.yml
@@ -6,17 +6,17 @@ release_version: ""
 # Default Prometheus node exporter configurations
 prometheus_node_exporter_install: true                    # Whether to install the prometheus node_exporter tool
 prometheus_node_exporter_port: "19100"                    # Port to export metrics to.  The default (9100), conflicts with a Couchbase port, and prevents couchbase working.
-prometheus_node_exporter_version: 0.18.1                  # Version of prometheus node_exporter tool to install
+prometheus_node_exporter_version: 1.2.2                   # Version of prometheus node_exporter tool to install
 prometheus_node_exporter_options: "--collector.systemd "  # Extra options for node_exporter
 prometheus_set_unset_maintenance_mode: true               # Whether a maintenance_mode tag is set on creation, and removed on completion.  This tag is checked for in Prometheus config, and alerting is disabled for such VMs.
 
 # Default Filebeat agent settings - specifics to be provided by app playbooks
 filebeat_install: true
-filebeat_version: 7.5.0
+filebeat_version: 7.12.1          # 7.12.0 first version to support ARM architecture
 
 # Default Metricbeat agent settings - specifics to be provided by app playbooks
 metricbeat_install: true
-metricbeat_version: 7.5.0
+metricbeat_version: 7.12.1
 
 # Default packages configurations
 pkgupdate: ""                                             # "always" or "onCreate".  Leave empty to prevent updating packages.

--- a/_dependencies/filter_plugins/custom.py
+++ b/_dependencies/filter_plugins/custom.py
@@ -39,33 +39,10 @@ def iplookup(fqdn):
         import dns.resolver
         return to_text(dns.resolver.query(fqdn, 'A')[0])
 
-# Returns a json object from a loosely defined string (e.g. encoded using single quotes instead of double), or an object containing "AnsibleUnsafeText"
-def json_loads_loose(inStr):
-    import re, json, sys
-
-    display.vv(u"json_loads_loose - input type: %s; value %s" % (type(inStr), inStr))
-    if type(inStr) is dict or type(inStr) is list:
-        json_object = json.loads((to_text(json.dumps(inStr))).encode('utf-8'))
-    else:
-        try:
-            json_object = json.loads(inStr)
-        except (ValueError, AttributeError, TypeError) as e:
-            try:
-                json_object = json.loads(to_text(re.sub(r'\'(.*?)\'([,:}])', r'"\1"\2', inStr).replace(': True', ': "True"').replace(': False', ': "False"')).encode('utf-8'))
-            except (ValueError, AttributeError, TypeError) as e:
-                display.warning(u"json_loads_loose - WARNING: could not parse attribute string (%s) as json: %s" % (to_native(inStr), to_native(e)))
-                return inStr
-        except:
-            e = sys.exc_info()[0]
-            display.warning(u"json_loads_loose - WARNING: could not parse attribute string (%s) as json: %s" % (to_native(inStr), to_native(e)))
-            return inStr
-    return json_object
-
 
 class FilterModule(object):
     def filters(self):
         return {
             'dict_agg': dict_agg,
-            'iplookup': iplookup,
-            'json_loads_loose': json_loads_loose
+            'iplookup': iplookup
         }

--- a/_dependencies/library/ec2_instance_type_info.py
+++ b/_dependencies/library/ec2_instance_type_info.py
@@ -1,0 +1,181 @@
+#!/usr/bin/python
+# Copyright (c) 2017 Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+DOCUMENTATION = '''
+---
+module: ec2_instance_type_info
+version_added: 1.0.0
+short_description: EC2 instance type info
+description:
+    - List details of EC2 instance types.
+    - Uses the boto describe_instance_types API
+author: "Dougal Seeley (@dseeley)"
+options:
+  filters:
+    instance_types:
+      description: One or more instance types.
+      type: list
+      elements: str
+    description:
+      - A dict of filters to apply. Each dict item consists of a filter key and filter
+        value.  See U(https://docs.aws.amazon.com/cli/latest/reference/ec2/describe-instance-types.html#options)
+        for possible filters. Filter names and values are case sensitive.
+    required: false
+    default: {}
+    type: dict
+extends_documentation_fragment:
+- amazon.aws.aws
+- amazon.aws.ec2
+
+'''
+
+EXAMPLES = r'''
+# Note: These examples do not set authentication details,
+# see the AWS Guide for details.
+
+- name: List all instance_type in the current region.
+  community.aws.ec2_instance_type_info:
+  register: regional_eip_addresses
+
+- name: List all instance_type for a VM.
+  community.aws.ec2_instance_type_info:
+    instance_types: ["t3a.nano", "t4g.nano"]
+    filters:
+      hypervisor: "nitro"
+  register: r__ec2_instance_type_info
+
+- ansible.builtin.debug:
+    msg: "{{ r__ec2_instance_type_info }}"
+'''
+
+RETURN = '''
+instance_types:
+  description: Properties of all instances matching the instance_types and provided filters. Each element is a dict with all the information related to an instance.
+  returned: on success
+  type: list
+  sample: [{
+            "auto_recovery_supported": false,
+            "bare_metal": false,
+            "burstable_performance_supported": true,
+            "current_generation": true,
+            "dedicated_hosts_supported": false,
+            "ebs_info": {
+                "ebs_optimized_info": {
+                    "baseline_bandwidth_in_mbps": 43,
+                    "baseline_iops": 250,
+                    "baseline_throughput_in_m_bps": 5.375,
+                    "maximum_bandwidth_in_mbps": 2085,
+                    "maximum_iops": 11800,
+                    "maximum_throughput_in_m_bps": 260.625
+                },
+                "ebs_optimized_support": "default",
+                "encryption_support": "supported",
+                "nvme_support": "required"
+            },
+            "free_tier_eligible": false,
+            "hibernation_supported": false,
+            "hypervisor": "nitro",
+            "instance_storage_supported": false,
+            "instance_type": "t4g.nano",
+            "memory_info": {
+                "size_in_mi_b": 512
+            },
+            "network_info": {
+                "default_network_card_index": 0,
+                "efa_supported": false,
+                "ena_support": "required",
+                "ipv4_addresses_per_interface": 2,
+                "ipv6_addresses_per_interface": 2,
+                "ipv6_supported": true,
+                "maximum_network_cards": 1,
+                "maximum_network_interfaces": 2,
+                "network_cards": [
+                    {
+                        "maximum_network_interfaces": 2,
+                        "network_card_index": 0,
+                        "network_performance": "Up to 5 Gigabit"
+                    }
+                ],
+                "network_performance": "Up to 5 Gigabit"
+            },
+            "placement_group_info": {
+                "supported_strategies": [
+                    "partition",
+                    "spread"
+                ]
+            },
+            "processor_info": {
+                "supported_architectures": [
+                    "arm64"
+                ],
+                "sustained_clock_speed_in_ghz": 2.5
+            },
+            "supported_boot_modes": [
+                "uefi"
+            ],
+            "supported_root_device_types": [
+                "ebs"
+            ],
+            "supported_usage_classes": [
+                "on-demand",
+                "spot"
+            ],
+            "supported_virtualization_types": [
+                "hvm"
+            ],
+            "v_cpu_info": {
+                "default_cores": 2,
+                "default_threads_per_core": 1,
+                "default_v_cpus": 2,
+                "valid_cores": [
+                    1,
+                    2
+                ],
+                "valid_threads_per_core": [
+                    1
+                ]
+        }]
+'''
+
+from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import (ansible_dict_to_boto3_filter_list,
+                                                                     boto3_tag_list_to_ansible_dict,
+                                                                     camel_dict_to_snake_dict
+                                                                     )
+
+try:
+    from botocore.exceptions import (BotoCoreError, ClientError)
+except ImportError:
+    pass  # caught by imported AnsibleAWSModule
+
+
+def get_describe_instance_types(module):
+    connection = module.client('ec2')
+    try:
+        response = connection.describe_instance_types(InstanceTypes=module.params.get("instance_types"), Filters=ansible_dict_to_boto3_filter_list(module.params.get("filters")))
+    except (BotoCoreError, ClientError) as e:
+        module.fail_json_aws(e, msg="Error retrieving InstanceTypes")
+
+    instance_types = camel_dict_to_snake_dict(response)['instance_types']
+    return instance_types
+
+
+def main():
+    module = AnsibleAWSModule(
+        argument_spec=dict(
+            instance_types=dict(default=[], type='list', elements='str', aliases=['instance_type']),
+            filters=dict(type='dict', default={})
+        ),
+        supports_check_mode=True
+    )
+
+    module.exit_json(changed=False, instance_types=get_describe_instance_types(module))
+
+
+if __name__ == '__main__':
+    main()

--- a/_dependencies/library/warn_str.py
+++ b/_dependencies/library/warn_str.py
@@ -1,0 +1,35 @@
+# Copyright 2021 Dougal Seeley <github@dougalseeley.com>
+# BSD 3-Clause License
+
+from __future__ import (absolute_import, division, print_function)
+
+__metaclass__ = type
+
+DOCUMENTATION = '''
+---
+module: warn_str
+version_added: 1.0.0
+description:
+    - Print a deprecation warning to the console on demand
+authors:
+    - Dougal Seeley <github@dougalseeley.com>
+'''
+
+EXAMPLES = '''
+- warn_str:
+    msg: "asdf is not really a word"
+'''
+
+from ansible.module_utils.basic import AnsibleModule
+
+
+def main():
+    module = AnsibleModule(argument_spec={"msg": {"type": "str", "default": "Warn, world"}})
+
+    module.warn(module.params['msg'])
+
+    module.exit_json(changed=False)
+
+
+if __name__ == '__main__':
+    main()

--- a/_dependencies/tasks/main.yml
+++ b/_dependencies/tasks/main.yml
@@ -19,12 +19,19 @@
         - deprecate_str: { msg: "Loading variables via group_vars/clusterid is deprecated.  Please use merge_vars via cluster_defs in future" }
       when: merge_dict_vars_list is not defined
 
+    - name: argv
+      debug: msg={{ argv }}
+
+    - name: cluster_vars_override
+      debug: msg={{cluster_vars_override}}
+      when: cluster_vars_override is defined
 
     - name: Combine command-line cluster_vars_override into the loaded cluster_vars
       set_fact:
-        cluster_vars: "{{cluster_vars | combine(_cluster_vars_override_templated, recursive=True)}}"
+        cluster_vars: "{{cluster_vars | combine({item.key: item.value | from_yaml}, recursive=True)}}"      # Do the combine with individually parsed variables, because sometimes, the 'value' field of an individual dict is still a string (e.g. during redeploy, which passes the cluster_vars_override again).
       vars:
-        _cluster_vars_override_templated: "{{cluster_vars_override}}"     #This pre-templating technique is needed because sometimes the command-line parameters are interpolated as a string, sometimes as a dict - this normalises them as a dict (which the 'combine' filter, above, requires).
+        _cluster_vars_override_templated: "{{cluster_vars_override}}"     #This pre-templating technique is needed because sometimes the command-line is interpolated as a string, sometimes as a dict - this normalises it as a dict (which the 'combine' filter, above, requires), however the nested parameters may *still* be stringified (as above).
+      with_dict: "{{_cluster_vars_override_templated}}"
       when: cluster_vars is defined and cluster_vars_override is defined and cluster_vars_override != ''
 
 

--- a/clean/tasks/dns.yml
+++ b/clean/tasks/dns.yml
@@ -23,7 +23,7 @@
             server: "{{cluster_vars[buildenv].nsupdate_cfg.server | default(bind9[buildenv].server)}}"
             zone: "{{cluster_vars.dns_nameserver_zone}}"
             record: "{{item.name | regex_replace('-(?!.*-).*')}}.{{cluster_vars.dns_user_domain | regex_replace('^(.*?)\\.?' + cluster_vars.dns_nameserver_zone, '\\1')}}"
-            value:  "{{item.name}}.{{cluster_vars.dns_user_domain | regex_replace('^(.*?)\\.?' + cluster_vars.dns_nameserver_zone, '\\1')}}"
+            value: "{{item.name}}.{{cluster_vars.dns_user_domain | regex_replace('^(.*?)\\.?' + cluster_vars.dns_nameserver_zone, '\\1')}}"
             type: CNAME
             state: absent
           with_items: "{{ hosts_to_clean }}"

--- a/cluster_hosts/tasks/get_cluster_hosts_state_aws.yml
+++ b/cluster_hosts/tasks/get_cluster_hosts_state_aws.yml
@@ -14,4 +14,4 @@
 
 - name: get_cluster_hosts_state/aws | Set cluster_hosts_state
   set_fact:
-    cluster_hosts_state: "{{r__ec2_instance_info.instances | json_query(\"[].{name: tags.Name, regionzone: placement.availability_zone, tagslabels: tags, instance_id: instance_id, instance_state: state.name, ipv4: {private: private_ip_address, public: public_ip_address}, disk_info_cloud: block_device_mappings }\") }}"
+    cluster_hosts_state: "{{r__ec2_instance_info.instances | json_query(\"[].{name: tags.Name, regionzone: placement.availability_zone, tagslabels: tags, instance_id: instance_id, instance_state: state.name, ipv4: {private: private_ip_address, public: public_ip_address}, disk_info_cloud: block_device_mappings, image: image_id }\") }}"

--- a/cluster_hosts/tasks/get_cluster_hosts_state_gcp.yml
+++ b/cluster_hosts/tasks/get_cluster_hosts_state_gcp.yml
@@ -3,8 +3,7 @@
 - name: get_cluster_hosts_state/gcp | Get existing instance info (per AZ)
   gcp_compute_instance_info:
     zone: "{{cluster_vars.region}}-{{item}}"
-    filters:
-      - "labels.cluster_name = {{cluster_name}}"
+    filters: [ "labels.cluster_name = {{cluster_name}}" ]
     project: "{{cluster_vars[buildenv].vpc_project_id}}"
     auth_kind: "serviceaccount"
     service_account_file: "{{gcp_credentials_file}}"
@@ -14,13 +13,24 @@
   delegate_to: localhost
   run_once: true
 
+- name: get_cluster_hosts_state/gcp | Get root volume info (for image)
+  gcp_compute_disk_info:
+    zone: "{{item.zone | basename }}"
+    filters: [ "name = {{ item.bootdisk }}" ]
+    project: "{{cluster_vars[buildenv].vpc_project_id}}"
+    auth_kind: "serviceaccount"
+    service_account_file: "{{gcp_credentials_file}}"
+    scopes: ["https://www.googleapis.com/auth/compute.readonly"]
+  register: r__gcp_compute_disk_info
+  with_items: "{{ r__gcp_compute_instance_info.results | json_query(\"[?resources[?labels]].resources[].{name: name, bootdisk: disks[?boot].deviceName | [0], zone: zone }\") }}"
+  delegate_to: localhost
+  run_once: true
+
 - name: get_cluster_hosts_state/gcp | Set cluster_hosts_state with correct regionzone (remove url)
   set_fact:
     cluster_hosts_state: |
-      {% set res = _cluster_hosts_state__urlregion -%}
+      {% set res = r__gcp_compute_instance_info.results | json_query('[?resources[?labels]].resources[].{name: name, regionzone: zone, tagslabels: labels, instance_id: id, instance_state: status, ipv4: {private: networkInterfaces[0].networkIP, public: networkInterfaces[0].accessConfigs[0].natIP}, disk_info_cloud: disks}') -%}
         {%- for cluster_host in res -%}
-           {%- set _ = cluster_host.update({'regionzone': cluster_host.regionzone | regex_replace('^.*/(.*)$', '\\1') }) -%}
+          {%- set _ = cluster_host.update({'regionzone': cluster_host.regionzone | basename, 'image': r__gcp_compute_disk_info.results | json_query('[?item.name==\'' + cluster_host.name + '\'].resources[].sourceImage | [0]') }) -%}
         {%- endfor -%}
       {{ res }}
-  vars:
-    _cluster_hosts_state__urlregion: "{{r__gcp_compute_instance_info.results | json_query(\"[?resources[?labels]].resources[].{name: name, regionzone: zone, tagslabels: labels, instance_id: id, instance_state: status, ipv4: {private: networkInterfaces[0].networkIP, public: networkInterfaces[0].accessConfigs[0].natIP}, disk_info_cloud: disks }\") }}"

--- a/cluster_hosts/tasks/get_cluster_hosts_target.yml
+++ b/cluster_hosts/tasks/get_cluster_hosts_target.yml
@@ -5,20 +5,46 @@
   set_fact:
     cluster_hosts_target: |
       {% set res = [] -%}
-      {%- for hostttype in cluster_vars[buildenv].hosttype_vars.keys() -%}
-        {%- for azname in cluster_vars[buildenv].hosttype_vars[hostttype].vms_by_az.keys() -%}
-          {%- for azcount in range(0,cluster_vars[buildenv].hosttype_vars[hostttype].vms_by_az[azname]|int) -%}
+      {%- for hosttype in cluster_vars[buildenv].hosttype_vars.keys() -%}
+        {%- for azname in cluster_vars[buildenv].hosttype_vars[hosttype].vms_by_az.keys() -%}
+          {%- for azcount in range(0,cluster_vars[buildenv].hosttype_vars[hosttype].vms_by_az[azname]|int) -%}
             {% set _dummy = res.extend([{
-              'hosttype': hostttype,
-              'hostname': cluster_name + '-' + hostttype + '-' + azname|string + azcount|string + '-' + cluster_suffix|string,
+              'hosttype': hosttype,
+              'hostname': cluster_name + '-' + hosttype + '-' + azname|string + azcount|string + '-' + cluster_suffix|string,
               'az_name': azname|string,
-              'flavor': cluster_vars[buildenv].hosttype_vars[hostttype].flavor,
-              'auto_volumes': cluster_vars[buildenv].hosttype_vars[hostttype].auto_volumes
+              'flavor': cluster_vars[buildenv].hosttype_vars[hosttype].flavor,
+              'image': cluster_vars[buildenv].hosttype_vars[hosttype].image | default(cluster_vars.image),
+              'auto_volumes': cluster_vars[buildenv].hosttype_vars[hosttype].auto_volumes
               }]) -%}
           {%- endfor %}
         {%- endfor %}
       {%- endfor %}
       {{ res }}
+
+
+- name: get_cluster_hosts_target | cluster_hosts_target
+  debug: msg={{cluster_hosts_target}}
+  delegate_to: localhost
+  run_once: true
+
+- name: get_cluster_hosts_target | Update cluster_hosts_target image (per hosttype) with the image used in an existing cluster (when existing cluster)
+  block:
+    - set_fact: { __orig_cluster_hosts_target: "{{ cluster_hosts_target }}" }         ## NOTE: We cannot use a 'vars:' variable at the block-level in place of a 'set_fact:' variable here, because a 'vars:' assignment only does a shallow-copy, (so cluster_hosts_target becomes the same as __orig_cluster_hosts_target), whereas 'set_fact:' does a deep-copy
+
+    - name: get_cluster_hosts_target | Update cluster_hosts_target image (per hosttype) with the image used in an existing cluster
+      set_fact:
+        cluster_hosts_target: |
+          {%- for host in cluster_hosts_target -%}
+            {%- set _existing_image_per_hosttype = cluster_hosts_state | json_query('[?tagslabels.hosttype==\'' + host.hosttype + '\' && tagslabels.lifecycle_state==\'current\' && image].image') -%}
+            {%- if _existing_image_per_hosttype | length -%}
+              {%- set _dummy = host.update({'image': _existing_image_per_hosttype[0]}) -%}
+            {%- endif -%}
+          {%- endfor %}
+          {{ cluster_hosts_target }}
+
+    - warn_str: msg="get_cluster_hosts_target | Replaced some base images to ensure consistency across hosttype. {{cluster_hosts_target | symmetric_difference(__orig_cluster_hosts_target)}}"
+      when: (cluster_hosts_target | symmetric_difference(__orig_cluster_hosts_target))
+  when: (cluster_hosts_state | json_query('[?tagslabels.lifecycle_state==\'current\']') | length)
 
 
 - name: get_cluster_hosts_target | Augment with cloud-specific parameters (if necessary)

--- a/cluster_hosts/tasks/get_cluster_hosts_target_aws.yml
+++ b/cluster_hosts/tasks/get_cluster_hosts_target_aws.yml
@@ -1,7 +1,7 @@
 ---
 
 # Dynamically look up VPC ID by name from aws
-- name: get_cluster_hosts_target | Looking up VPC facts to extract ID
+- name: get_cluster_hosts_target/aws | Looking up VPC facts to extract ID
   ec2_vpc_net_info:
     region: "{{ cluster_vars.region }}"
     aws_access_key: "{{ cluster_vars[buildenv].aws_access_key }}"
@@ -12,31 +12,36 @@
   delegate_to: localhost
   run_once: true
 
-- name: get_cluster_hosts_target/aws | Set VPC ID in variable
+- name: get_cluster_hosts_target/aws | Set VPC ID in global variable
   set_fact:
     vpc_id: "{{ r__ec2_vpc_net_info.vpcs[0].id }}"
 
-- name: get_cluster_hosts_target/aws | Look up proxy subnet facts
-  ec2_vpc_subnet_info:
-    region: "{{ cluster_vars.region }}"
-    aws_access_key: "{{ cluster_vars[buildenv].aws_access_key }}"
-    aws_secret_key: "{{ cluster_vars[buildenv].aws_secret_key }}"
-    filters:
-      vpc-id: "{{ vpc_id }}"
-  register: r__ec2_vpc_subnet_info
-  delegate_to: localhost
-  run_once: true
 
-- name: get_cluster_hosts_target/aws | Update cluster_hosts_target with subnet_ids
-  set_fact:
-    cluster_hosts_target: |
-      {%- for host in cluster_hosts_target -%}
-        {%- set subnet_id = r__ec2_vpc_subnet_info | to_json | from_json | json_query('subnets[?starts_with(tags.Name, \'' + cluster_vars[buildenv].vpc_subnet_name_prefix + host.az_name +'\')].subnet_id|[0]') -%}
-        {%- set _dummy = host.update({'vpc_subnet_id': subnet_id | string}) -%}
-      {%- endfor %}
-      {{ cluster_hosts_target }}
+- name: get_cluster_hosts_target/aws | Add subnet ids to cluster_hosts_target
+  block:
+    - name: get_cluster_hosts_target/aws | Look up proxy subnet facts
+      ec2_vpc_subnet_info:
+        region: "{{ cluster_vars.region }}"
+        aws_access_key: "{{ cluster_vars[buildenv].aws_access_key }}"
+        aws_secret_key: "{{ cluster_vars[buildenv].aws_secret_key }}"
+        filters:
+          vpc-id: "{{ vpc_id }}"
+      register: r__ec2_vpc_subnet_info
+      delegate_to: localhost
+      run_once: true
 
-- block:
+    - name: get_cluster_hosts_target/aws | Update cluster_hosts_target with subnet_ids
+      set_fact:
+        cluster_hosts_target: |
+          {%- for host in cluster_hosts_target -%}
+            {%- set subnet_id = r__ec2_vpc_subnet_info | to_json | from_json | json_query('subnets[?starts_with(tags.Name, \'' + cluster_vars[buildenv].vpc_subnet_name_prefix + host.az_name +'\')].subnet_id|[0]') -%}
+            {%- set _dummy = host.update({'vpc_subnet_id': subnet_id | string}) -%}
+          {%- endfor %}
+          {{ cluster_hosts_target }}
+
+
+- name: get_cluster_hosts_target/aws | Add snapshot info (if found) to cluster_hosts_target
+  block:
     - name: get_cluster_hosts_target/aws | Get snapshots info
       ec2_snapshot_info:
         aws_access_key: "{{cluster_vars[buildenv].aws_access_key}}"
@@ -76,3 +81,82 @@
   vars:
     _snapshot_tags: "{{ cluster_vars[buildenv].hosttype_vars|json_query('*.auto_volumes[].snapshot_tags')  }}"
   when: _snapshot_tags|length > 0
+
+
+- name: get_cluster_hosts_target/aws | cluster_vars.image can either be an AMI in its own right, or a 'manifest-location' filter to the latest AMI.
+  block:
+    - name: get_cluster_hosts_target/aws | Attempt to evaluate the image as an AMI
+      ec2_ami_info:
+        aws_access_key: "{{cluster_vars[buildenv].aws_access_key}}"
+        aws_secret_key: "{{cluster_vars[buildenv].aws_secret_key}}"
+        region: "{{cluster_vars.region}}"
+        filters: { image-id: "{{ item__ec2_ami_info__by_imageid.image }}" }
+      register: r__ec2_ami_info__by_imageid
+      loop: "{{ cluster_hosts_target }}"
+      loop_control: { loop_var: item__ec2_ami_info__by_imageid }
+      delegate_to: localhost
+      run_once: true
+
+    - name: get_cluster_hosts_target/aws | Create block variable '_cluster_hosts_targets__no_ami' that is the cluster_hosts_targets whose 'image' defintion is not an AMI; we'll try to evaluate it as a 'manifest-location' filter to the latest AMI instead.
+      block:
+        - name: get_cluster_hosts_target/aws | _cluster_hosts_targets__no_ami
+          debug: msg="{{ _cluster_hosts_targets__no_ami }}"
+          delegate_to: localhost
+          run_once: true
+          
+        - name: get_cluster_hosts_target/aws | Search the instance type info for the flavor of each hosttype's ami (to get architecture, needed for ec2_ami_info)
+          ec2_instance_type_info:
+            aws_access_key: "{{cluster_vars[buildenv].aws_access_key}}"
+            aws_secret_key: "{{cluster_vars[buildenv].aws_secret_key}}"
+            region: "{{cluster_vars.region}}"
+            instance_types: "{{ _cluster_hosts_targets__no_ami | json_query(\"[].flavor\") | unique }}"
+          register: r__ec2_instance_type_info
+          delegate_to: localhost
+          run_once: true
+
+        - name: get_cluster_hosts_target/aws | Get the AMI per hosttype and filtered on 'manifest-location'
+          ec2_ami_info:
+            aws_access_key: "{{cluster_vars[buildenv].aws_access_key}}"
+            aws_secret_key: "{{cluster_vars[buildenv].aws_secret_key}}"
+            region: "{{cluster_vars.region}}"
+            filters:
+              manifest-location: "{{ item__ec2_ami_info__by_location.image }}"
+              architecture: "{{ item__ec2_ami_info__by_location.derived_architecture | default('x86_64') }}"
+          loop: "{{ _cluster_hosts_targets__derived_arch }}"
+          loop_control: { loop_var: item__ec2_ami_info__by_location }
+          vars:
+            _cluster_hosts_targets__derived_arch: |-
+              {% set _cluster_hosts_targets__derived_arch = _cluster_hosts_targets__no_ami -%}
+              {%- for host in _cluster_hosts_targets__derived_arch -%}
+                {%- set hosttype_archs_ec2_instance_type_info = r__ec2_instance_type_info.instance_types | json_query('[?instance_type==\'' + host.flavor + '\'].processor_info.supported_architectures[]') -%}
+                {%- if hosttype_archs_ec2_instance_type_info | length == 1 -%}
+                  {%- set _dummy = host.update({'derived_architecture': hosttype_archs_ec2_instance_type_info[0] }) -%}
+                {%- elif hosttype_archs_ec2_instance_type_info | symmetric_difference(['i386','x86_64']) | length == 0 -%}
+                  {%- set _dummy = host.update({'derived_architecture': 'x86_64' }) -%}
+                {%- endif -%}
+              {%- endfor %}
+              {{ _cluster_hosts_targets__derived_arch }}
+          register: r__ec2_ami_info__by_location
+          delegate_to: localhost
+          run_once: true
+
+        - name: get_cluster_hosts_target/aws | Replace image with the latest AMI found at 'manifest-location'
+          set_fact:
+            cluster_hosts_target: |
+              {%- for cht_host in cluster_hosts_target -%}
+                {%- for r__ec2_ami_info_host in r__ec2_ami_info__by_location.results -%}
+                  {%- if r__ec2_ami_info_host[r__ec2_ami_info_host.ansible_loop_var].hostname == cht_host.hostname -%}
+                    {%- set _dummy = cht_host.update({'image': (r__ec2_ami_info_host.images | sort(attribute='creation_date'))[-1].image_id }) -%}
+                  {%- endif %}
+                {%- endfor %}
+              {%- endfor %}
+              {{ cluster_hosts_target }}
+      vars:
+        _cluster_hosts_targets__no_ami: |
+          {% set _cluster_hosts_targets__no_ami = [] -%}
+          {%- for host in r__ec2_ami_info__by_imageid.results -%}
+            {%- if 'images' in host and host.images | length == 0 -%}
+              {%- set _dummy = _cluster_hosts_targets__no_ami.extend([host[host.ansible_loop_var]]) -%}
+            {%- endif -%}
+          {%- endfor %}
+          {{ _cluster_hosts_targets__no_ami }}

--- a/cluster_hosts/tasks/get_cluster_hosts_target_gcp.yml
+++ b/cluster_hosts/tasks/get_cluster_hosts_target_gcp.yml
@@ -15,3 +15,38 @@
         {%- endfor %}
       {%- endfor %}
       {{ cluster_hosts_target }}
+
+
+- name: get_cluster_hosts_target/gcp | cluster_vars.image can either be an AMI in its own right, or a filter to the latest AMI.
+  block:
+    - name: get_cluster_hosts_target/gcp | Find the image as either an discrete image or a filter
+      gcp_compute_image_info:
+        filters: [ "name = {{_image.name}}" ]
+        project: "{{_image.project}}"
+        auth_kind: "serviceaccount"
+        service_account_file: "{{gcp_credentials_file}}"
+      loop: "{{ cluster_hosts_target }}"
+      register: r__gcp_compute_image_info__by_imageid
+      vars:
+        _image:
+          project: "{{item.image | regex_replace('.*projects/(.*?)/.*$', '\\1') }}"
+          name: "{{item.image | regex_replace('.*?images/(.*?)$', '\\1') | default('*') }}"
+      delegate_to: localhost
+      run_once: true
+
+    - name: get_cluster_hosts_target/gcp | r__gcp_compute_image_info__by_imageid
+      debug: msg="{{ r__gcp_compute_image_info__by_imageid }}"
+      delegate_to: localhost
+      run_once: true
+
+    - name: get_cluster_hosts_target/gcp | If more than one image is found per host, it is a filter, otherwise only one will be found.  We can replace cluster_hosts_target.item.image with the latest found in either case.
+      set_fact:
+        cluster_hosts_target: |
+          {%- for cht_host in cluster_hosts_target -%}
+            {%- for r__gcp_compute_image_info_host in r__gcp_compute_image_info__by_imageid.results -%}
+              {%- if r__gcp_compute_image_info_host[r__gcp_compute_image_info_host.ansible_loop_var].hostname == cht_host.hostname -%}
+                {%- set _dummy = cht_host.update({'image': (r__gcp_compute_image_info_host.resources | sort(attribute='creationTimestamp'))[-1].selfLink }) -%}
+              {%- endif %}
+            {%- endfor %}
+          {%- endfor %}
+          {{ cluster_hosts_target }}

--- a/config/tasks/cloud_agents.yml
+++ b/config/tasks/cloud_agents.yml
@@ -30,7 +30,7 @@
         url: "{{ qualys_release_file.location }}"
         dest: "/tmp/{{ cloud_agent.qualys.bin_name }}"
         mode: 0755
-    
+
     - name: cloud_agents | Remove existing Qualys cloud agent pkg Debian
       become: yes
       apt:
@@ -44,7 +44,7 @@
         deb: "/tmp/{{ cloud_agent.qualys.bin_name }}"
         state: present
       when: ansible_os_family == 'Debian'
-    
+
     - name: cloud_agents | Remove existing Qualys cloud agent pkg RedHat
       become: yes
       yum:

--- a/config/tasks/disks_auto_cloud.yml
+++ b/config/tasks/disks_auto_cloud.yml
@@ -1,23 +1,23 @@
 ---
 
-- name: disks_auto_aws_gcp | cluster_hosts_target(inventory_hostname)
+- name: disks_auto_cloud | cluster_hosts_target(inventory_hostname)
   debug: msg={{ cluster_hosts_target | json_query(\"[?hostname == '\" + inventory_hostname + \"'] \") }}
 
-- name: disks_auto_aws_gcp | Mount block devices as individual disks
+- name: disks_auto_cloud | Mount block devices as individual disks
   block:
-    - name: disks_auto_aws_gcp | auto_vols
+    - name: disks_auto_cloud | auto_vols
       debug: msg={{ auto_vols }}
 
-    - name: disks_auto_aws_gcp | Get the block device information (pre-filesystem create)
+    - name: disks_auto_cloud | Get the block device information (pre-filesystem create)
       blockdevmap:
         cloud_type: "{{cluster_vars.type}}"
       become: yes
       register: r__blockdevmap
 
-    - name: disks_auto_aws_gcp | r__blockdevmap (pre-filesystem create)
+    - name: disks_auto_cloud | r__blockdevmap (pre-filesystem create)
       debug: msg={{r__blockdevmap}}
 
-    - name: disks_auto_aws_gcp | Create filesystem (partitionless)
+    - name: disks_auto_cloud | Create filesystem (partitionless)
       become: yes
       filesystem:
         fstype: "{{ item.fstype }}"
@@ -27,16 +27,16 @@
         _dev: "{{ r__blockdevmap.device_map | json_query(\"[?device_name_cloud == '\" + item.device_name + \"' && TYPE=='disk' && parttable_type=='' && FSTYPE=='' && MOUNTPOINT==''].device_name_os | [0]\") }}"
       when: _dev is defined and _dev != ''
 
-    - name: disks_auto_aws_gcp | Get the block device information (post-filesystem create), to get the block IDs for mounting
+    - name: disks_auto_cloud | Get the block device information (post-filesystem create), to get the block IDs for mounting
       blockdevmap:
         cloud_type: "{{cluster_vars.type}}"
       become: yes
       register: r__blockdevmap
 
-    - name: disks_auto_aws_gcp | r__blockdevmap (post-filesystem create)
+    - name: disks_auto_cloud | r__blockdevmap (post-filesystem create)
       debug: msg={{r__blockdevmap}}
 
-    - name: disks_auto_aws_gcp | Mount created filesytem(s) persistently
+    - name: disks_auto_cloud | Mount created filesytem(s) persistently
       become: yes
       mount:
         path: "{{ item.mountpoint }}"
@@ -49,7 +49,7 @@
         _UUID: "{{ r__blockdevmap.device_map | json_query(\"[?device_name_cloud == '\" + item.device_name + \"' && TYPE=='disk' && parttable_type=='' && MOUNTPOINT==''].UUID | [0]\") }}"
       when: _UUID is defined and _UUID != ''
 
-    - name: disks_auto_aws_gcp | change ownership of mountpoint (if set)
+    - name: disks_auto_cloud | change ownership of mountpoint (if set)
       become: yes
       file:
         path: "{{ item.mountpoint }}"
@@ -59,16 +59,16 @@
         group: "{{ item.perms.group | default(omit)}}"
       loop: "{{auto_vols}}"
 
-    - name: disks_auto_aws_gcp | Check that we haven't mounted disks in the wrong place.  Especially useful for redeploys when we're moving disks.
+    - name: disks_auto_cloud | Check that we haven't mounted disks in the wrong place.  Especially useful for redeploys when we're moving disks.
       block:
-        - name: "disks_auto_aws_gcp | Touch a file with the mountpoint and device name for testing that disk attachment is correct.  Note: Use a unique filename here instead of writing to a file, so that more than one file per device is an error.  Note: don't add device_name for GCP, because we can't rename the disks when redeploying and keeping disks (_scheme_rmvm_keepdisk_rollback)"
+        - name: "disks_auto_cloud | Touch a file with the mountpoint and device name for testing that disk attachment is correct.  Note: Use a unique filename here instead of writing to a file, so that more than one file per device is an error.  Note: don't add device_name for GCP, because we can't rename the disks when redeploying and keeping disks (_scheme_rmvm_keepdisk_rollback)"
           become: yes
           file:
             path: "{{item.mountpoint}}/.clusterversetest__{{inventory_hostname | regex_replace('-(?!.*-).*')}}__{{ item.mountpoint | regex_replace('\\/', '_') }}{%- if cluster_vars.type != 'gcp'-%}__{{ item.device_name | regex_replace('\/', '_') }}{%- endif -%}"
             state: touch
           loop: "{{auto_vols}}"
 
-        - name: disks_auto_aws_gcp | Find all .clusterversetest__ files in mounted disks
+        - name: disks_auto_cloud | Find all .clusterversetest__ files in mounted disks
           find:
             paths: "{{item.mountpoint}}"
             hidden: yes
@@ -76,12 +76,12 @@
           loop: "{{auto_vols}}"
           register: r__find_test
 
-        - name: disks_auto_aws_gcp | Check that there is only one .clusterversetest__ file per device in mounted disks.
+        - name: disks_auto_cloud | Check that there is only one .clusterversetest__ file per device in mounted disks.
           block:
-            - name: disks_auto_aws_gcp | testdevicedescriptor
+            - name: disks_auto_cloud | testdevicedescriptor
               debug: msg={{testdevicedescriptor}}
 
-            - name: disks_auto_aws_gcp | assert that only one device descriptor file exists per disk (otherwise, indicates that this run has mapped either more than one device per mount, or a different one to previous)
+            - name: disks_auto_cloud | assert that only one device descriptor file exists per disk (otherwise, indicates that this run has mapped either more than one device per mount, or a different one to previous)
               assert: { that: "testdevicedescriptor | json_query(\"[?length(files) > `1`]\") | length == 0", fail_msg: "ERROR - Exactly one file should exist per storage device.  In error [{{testdevicedescriptor | json_query(\"[?length(files) > `1`]\")}}]" }
           vars:
             testdevicedescriptor: "{{ r__find_test | json_query(\"results[].{hostname: '\" + inventory_hostname + \"', device_name: item.device_name, mountpoint: item.mountpoint, files: files[].path}\") }}"
@@ -92,52 +92,60 @@
 
 
 # The following block mounts all attached volumes that have a single, common mountpoint, by creating a logical volume
-- name: disks_auto_aws_gcp/lvm | Mount block devices in a single LVM mountpoint through LV/VG
+- name: disks_auto_cloud/lvm | Mount block devices in a single LVM mountpoint through LV/VG
   block:
-    - name: disks_auto_aws_gcp/lvm | raid_vols
+    - name: disks_auto_cloud/lvm | raid_vols
       debug: msg={{ raid_vols }}
 
-    - name: disks_auto_aws_gcp/lvm | Install logical volume management tooling. (yum - RedHat/CentOS)
+    - name: disks_auto_cloud/lvm | Install logical volume management tooling. (apt - Debian/Ubuntu)
+      become: true
+      apt:
+        update_cache: yes
+        name: "lvm2"
+      when: ansible_os_family == 'Debian'
+
+    - name: disks_auto_cloud/lvm | Install logical volume management tooling. (yum - RedHat/CentOS)
       become: true
       yum:
         name: "lvm*"
         state: present
       when: ansible_os_family == 'RedHat'
 
-    - name: disks_auto_aws_gcp/lvm | Get the device information (pre-filesystem create)
+    - name: disks_auto_cloud/lvm | Get the device information (pre-filesystem create)
       blockdevmap:
         cloud_type: "{{cluster_vars.type}}"
       become: yes
       register: r__blockdevmap
 
-    - name: disks_auto_aws_gcp/lvm | r__blockdevmap (pre raid create)
+    - name: disks_auto_cloud/lvm | r__blockdevmap (pre raid create)
       debug: msg={{r__blockdevmap}}
 
     - block:
-        - name: disks_auto_aws_gcp/lvm | raid_vols_devices
+        - name: disks_auto_cloud/lvm | raid_vols_devices
           debug: msg={{ raid_vols_devices }}
 
-        - name: disks_auto_aws_gcp/lvm | Create a volume group from all block devices
+        - name: disks_auto_cloud/lvm | Create a volume group from all block devices
           become: yes
           lvg:
-            vg:  "{{ lvmparams.vg_name }}"
-            pvs: "{{ raid_vols_devices | map(attribute='device_name_os') | sort  | join(',') }}"
-    
-        - name: disks_auto_aws_gcp/lvm | Create a logical volume from volume group
+            vg: "{{ lvmparams.vg_name }}"
+            pvs: "{{ raid_vols_devices | map(attribute='device_name_os') | sort | join(',') }}"
+
+        - name: disks_auto_cloud/lvm | Create a logical volume from volume group
           become: yes
           lvol:
             vg: "{{ lvmparams.vg_name }}"
             lv: "{{ lvmparams.lv_name }}"
             size: "{{ lvmparams.lv_size }}"
-    
-        - name: disks_auto_aws_gcp/lvm | Create filesystem(s) on attached volume(s)
+
+        - name: disks_auto_cloud/lvm | Create filesystem(s) on attached volume(s)
           become: yes
           filesystem:
             fstype: "{{ raid_vols[0].fstype }}"
             dev: "/dev/{{ lvmparams.vg_name }}/{{ lvmparams.lv_name }}"
-            force: no
-    
-        - name: disks_auto_aws_gcp/lvm | Mount created filesytem(s) persistently
+            force: no       # This doesn't appear to prevent the '-F' option being sent to mkfs
+          when: (raid_vols_devices | json_query('[?FSTYPE==``]') | length) == (raid_vols_devices | length)
+
+        - name: disks_auto_cloud/lvm | Mount created filesytem(s) persistently
           become: yes
           mount:
             path: "{{ raid_vols[0].mountpoint }}"
@@ -145,25 +153,25 @@
             fstype: "{{ raid_vols[0].fstype }}"
             state: mounted
             opts: _netdev
-    
-        - name: disks_auto_aws_gcp/lvm | Check that we haven't mounted disks in the wrong place.  Especially useful for redeploys when we're moving disks.
+
+        - name: disks_auto_cloud/lvm | Check that we haven't mounted disks in the wrong place.  Especially useful for redeploys when we're moving disks.
           block:
-            - name: "disks_auto_aws_gcp/lvm | Touch a file with the mountpoint for testing that disk attachment is correct.  Note: Use a unique filename here instead of writing to a file, so that more than one file per device is an error."
+            - name: "disks_auto_cloud/lvm | Touch a file with the mountpoint for testing that disk attachment is correct.  Note: Use a unique filename here instead of writing to a file, so that more than one file per device is an error."
               become: yes
               file:
                 path: "{{ raid_vols[0].mountpoint }}/.clusterversetest__{{inventory_hostname | regex_replace('-(?!.*-).*')}}__{{ raid_vols[0].mountpoint | regex_replace('\\/', '_') }}"
                 state: touch
-    
-            - name: disks_auto_aws_gcp/lvm | Find all .clusterversetest__ files in mounted disks
+
+            - name: disks_auto_cloud/lvm | Find all .clusterversetest__ files in mounted disks
               find:
                 paths: "{{ raid_vols[0].mountpoint }}"
                 hidden: yes
                 patterns: ".clusterversetest__*"
               register: r__find_test
-    
+
             - debug: msg={{r__find_test}}
-    
-            - name: disks_auto_aws_gcp/lvm | assert that only one device descriptor file exists per disk (otherwise, indicates that this run has mapped either more than one device per mount, or a different one to previous)
+
+            - name: disks_auto_cloud/lvm | assert that only one device descriptor file exists per disk (otherwise, indicates that this run has mapped either more than one device per mount, or a different one to previous)
               assert: { that: "'files' in r__find_test != ''  and  r__find_test.files | length == 1", fail_msg: "ERROR - Exactly one file should exist per LVM." }
           when: test_touch_disks is defined and test_touch_disks|bool
       vars:

--- a/config/tasks/disks_auto_generic.yml
+++ b/config/tasks/disks_auto_generic.yml
@@ -9,9 +9,9 @@
 - name: disks_auto_generic | r__blockdevmap
   debug: msg={{ r__blockdevmap }}
 
-- name: disks_auto_generic | Create 'hostvols' fact that contains a list of available host devices (lsblk) mapped to the mountpoints defined in cluster_vars.  Allow for multiple disks with same size.
+- name: disks_auto_generic | Create 'disks_auto_generic__hostvols' fact that contains a list of available host devices (lsblk) mapped to the mountpoints defined in cluster_vars.  Allow for multiple disks with same size.
   set_fact:
-    hostvols: |
+    disks_auto_generic__hostvols: |
       {% set res = [] -%}
       {% set tmp_blkvols = r__blockdevmap.device_map | selectattr('TYPE', '==', 'disk') | selectattr('parttable_type', '==', '') | selectattr('MOUNTPOINT', '==', '') | list -%}
       {% set inventory_hostname__no_suffix = inventory_hostname | regex_replace('-(?!.*-).*') -%}
@@ -27,38 +27,95 @@
       {%- endfor -%}
       {{ res }}
 
-- name: disks_auto_generic | hostvols
-  debug: msg={{hostvols}}
+- name: disks_auto_generic | disks_auto_generic__hostvols
+  debug: msg={{disks_auto_generic__hostvols}}
 
-# Create partition-less filesystems.
-- name: disks_auto_generic | Create filesystem(s) on attached volume(s)
-  become: yes
-  filesystem:
-    fstype: "{{ item.fstype }}"
-    dev: "{{ item.device }}"
-    force: no
-  with_items: "{{ hostvols }}"
-  register: created_filesystem
-  retries: 5
-  delay: 1
-  until: created_filesystem is not failed
+- name: disks_auto_generic | Mount block devices as individual disks
+  block:
+    # Create partition-less filesystems.
+    - name: disks_auto_generic | Create filesystem(s) on attached volume(s)
+      become: yes
+      filesystem:
+        fstype: "{{ item.fstype }}"
+        dev: "{{ item.device }}"
+        force: no
+      with_items: "{{ disks_auto_generic__hostvols }}"
 
-- name: disks_auto_generic | Mount created filesytem(s) persistently
-  become: yes
-  mount:
-    path: "{{ item.mountpoint }}"
-    src: "{{ item.device }}"
-    fstype: "{{ item.fstype }}"
-    state: mounted
-    opts: _netdev
-  with_items: "{{ hostvols }}"
+    - name: disks_auto_generic | Mount created filesytem(s) persistently
+      become: yes
+      mount:
+        path: "{{ item.mountpoint }}"
+        src: "{{ item.device }}"
+        fstype: "{{ item.fstype }}"
+        state: mounted
+        opts: _netdev
+      with_items: "{{ disks_auto_generic__hostvols }}"
 
-- name: disks_auto_generic | change ownership of mountpoint (if set)
-  become: yes
-  file:
-    path: "{{ item.mountpoint }}"
-    state: directory
-    mode: "{{ item.perms.mode | default(omit)}}"
-    owner: "{{ item.perms.owner | default(omit)}}"
-    group: "{{ item.perms.group | default(omit)}}"
-  with_items: "{{ hostvols }}"
+    - name: disks_auto_generic | change ownership of mountpoint (if set)
+      become: yes
+      file:
+        path: "{{ item.mountpoint }}"
+        state: directory
+        mode: "{{ item.perms.mode | default(omit)}}"
+        owner: "{{ item.perms.owner | default(omit)}}"
+        group: "{{ item.perms.group | default(omit)}}"
+      with_items: "{{ disks_auto_generic__hostvols }}"
+  when: (disks_auto_generic__hostvols | map(attribute='mountpoint') | list | unique | count == disks_auto_generic__hostvols | map(attribute='mountpoint') | list | count)
+
+# The following block mounts all attached volumes that have a single, common mountpoint, by creating a logical volume
+- name: disks_auto_generic/lvm | Mount block devices in a single LVM mountpoint through LV/VG
+  block:
+    - name: disks_auto_cloud/lvm | Install logical volume management tooling. (apt - Debian/Ubuntu)
+      become: true
+      apt:
+        update_cache: yes
+        name: "lvm2"
+      when: ansible_os_family == 'Debian'
+
+    - name: disks_auto_cloud/lvm | Install logical volume management tooling. (yum - RedHat/CentOS)
+      become: true
+      yum:
+        name: "lvm*"
+        state: present
+      when: ansible_os_family == 'RedHat'
+
+    - block:
+        - name: disks_auto_generic/lvm | raid_vols_devices
+          debug: msg={{ raid_vols_devices }}
+
+        - name: disks_auto_generic/lvm | Create a volume group from all block devices
+          become: yes
+          lvg:
+            vg: "{{ lvmparams.vg_name }}"
+            pvs: "{{ raid_vols_devices | sort | join(',') }}"
+
+        - name: disks_auto_generic/lvm | Create a logical volume from volume group
+          become: yes
+          lvol:
+            vg: "{{ lvmparams.vg_name }}"
+            lv: "{{ lvmparams.lv_name }}"
+            size: "{{ lvmparams.lv_size }}"
+
+        - name: disks_auto_generic/lvm | Create filesystem(s) on attached volume(s)
+          become: yes
+          filesystem:
+            fstype: "{{ disks_auto_generic__hostvols[0].fstype }}"
+            dev: "/dev/{{ lvmparams.vg_name }}/{{ lvmparams.lv_name }}"
+            force: no
+
+        - name: disks_auto_generic/lvm | Mount created filesytem(s) persistently
+          become: yes
+          mount:
+            path: "{{ disks_auto_generic__hostvols[0].mountpoint }}"
+            src: "/dev/{{ lvmparams.vg_name }}/{{ lvmparams.lv_name }}"
+            fstype: "{{ disks_auto_generic__hostvols[0].fstype }}"
+            state: mounted
+            opts: _netdev
+      vars:
+        raid_vols_devices: "{{ disks_auto_generic__hostvols | map(attribute='device') | list }}"
+      when: raid_vols_devices | length
+
+  when: (lvmparams is defined and lvmparams != {})  and  (disks_auto_generic__hostvols | map(attribute='mountpoint') | list | unique | count == 1) and (disks_auto_generic__hostvols | map(attribute='mountpoint') | list | count >= 2) and (disks_auto_generic__hostvols | map(attribute='fstype') | list | unique | count == 1)
+  vars:
+    _hosttype_vars: "{{ cluster_hosts_target | json_query(\"[?hostname == '\" + inventory_hostname + \"'] | [0]\") }}"
+    lvmparams: "{{ (cluster_vars[buildenv].hosttype_vars[_hosttype_vars.hosttype].lvmparams | default({})) if _hosttype_vars.hosttype is defined else {} }}"

--- a/config/tasks/filebeat.yml
+++ b/config/tasks/filebeat.yml
@@ -3,7 +3,7 @@
 - name: Filebeat | Download and install filebeat from elastic.co
   become: yes
   apt:
-    deb: "https://artifacts.elastic.co/downloads/beats/filebeat/filebeat-{{ filebeat_version }}-amd64.deb"
+    deb: "https://artifacts.elastic.co/downloads/beats/filebeat/filebeat-{{ filebeat_version }}-{{ 'amd64' if ansible_architecture == 'x86_64' else 'arm64' if ansible_architecture == 'aarch64' else ansible_architecture }}.deb"
   register: apt_jobs
   until: apt_jobs is success
   retries: 5
@@ -12,7 +12,7 @@
 - name: Filebeat | Download and install filebeat from elastic.co
   become: yes
   yum:
-    name: "https://artifacts.elastic.co/downloads/beats/filebeat/filebeat-{{ filebeat_version }}-x86_64.rpm"
+    name: "https://artifacts.elastic.co/downloads/beats/filebeat/filebeat-{{ filebeat_version }}-{{ ansible_architecture }}.rpm"
   register: yum_jobs
   until: yum_jobs is success
   retries: 5
@@ -34,6 +34,6 @@
         dest: "/lib/systemd/system/filebeat.service"
       notify: Filebeat | Restart and enable filebeat
 
-    - deprecate_str: {msg: "beats_target_hosts is deprecated.  Please use beats_config.filebeat.output_logstash_hosts in future", version: "6"}
+    - deprecate_str: { msg: "beats_target_hosts is deprecated.  Please use beats_config.filebeat.output_logstash_hosts in future", version: "6" }
       when: (beats_target_hosts is defined and (beats_target_hosts | length))
   when: (beats_target_hosts is defined and (beats_target_hosts | length)) or (beats_config.filebeat.output_logstash_hosts is defined and (beats_config.filebeat.output_logstash_hosts | length))

--- a/config/tasks/main.yml
+++ b/config/tasks/main.yml
@@ -57,13 +57,13 @@
     mode: 0755
   when: (static_journal is defined and static_journal|bool)
 
-- name: Create partition table, format and attach volumes - AWS or GCP
-  include_tasks: disks_auto_aws_gcp.yml
-  when: cluster_vars.type == "aws" or cluster_vars.type == "gcp"
+- name: Create partition table, format and attach volumes - AWS, GCP or Azure
+  include_tasks: disks_auto_cloud.yml
+  when: cluster_vars.type in ["aws", "gcp", "azure"]
 
 - name: Create partition table, format and attach volumes - generic
   include_tasks: disks_auto_generic.yml
-  when: cluster_vars.type != "aws" and cluster_vars.type != "gcp"
+  when: cluster_vars.type not in ["aws", "gcp", "azure"]
 
 - name: install prometheus node exporter daemon
   include_tasks: prometheus_node_exporter.yml

--- a/config/tasks/metricbeat.yml
+++ b/config/tasks/metricbeat.yml
@@ -3,7 +3,7 @@
 - name: Metricbeat | Download and install metricbeat from elastic.co
   become: yes
   apt:
-    deb: "https://artifacts.elastic.co/downloads/beats/metricbeat/metricbeat-{{ metricbeat_version }}-amd64.deb"
+    deb: "https://artifacts.elastic.co/downloads/beats/metricbeat/metricbeat-{{ metricbeat_version }}-{{ 'amd64' if ansible_architecture == 'x86_64' else 'arm64' if ansible_architecture == 'aarch64' else ansible_architecture }}.deb"
   register: apt_jobs
   until: apt_jobs is success
   retries: 5
@@ -12,7 +12,7 @@
 - name: Metricbeat | Download and install filebeat from elastic.co
   become: yes
   yum:
-    name: "https://artifacts.elastic.co/downloads/beats/metricbeat/metricbeat-{{ metricbeat_version }}-x86_64.rpm"
+    name: "https://artifacts.elastic.co/downloads/beats/metricbeat/metricbeat-{{ metricbeat_version }}-{{ ansible_architecture }}.rpm"
   register: yum_jobs
   until: yum_jobs is success
   retries: 5
@@ -41,6 +41,6 @@
         dest: "/lib/systemd/system/metricbeat.service"
       notify: Metricbeat | Restart and enable metricbeat
 
-    - deprecate_str: {msg: "beats_target_hosts is deprecated.  Please use beats_config.metricbeat.output_logstash_hosts in future", version: "6"}
+    - deprecate_str: { msg: "beats_target_hosts is deprecated.  Please use beats_config.metricbeat.output_logstash_hosts in future", version: "6" }
       when: (beats_target_hosts is defined and (beats_target_hosts | length))
   when: (beats_target_hosts is defined and (beats_target_hosts | length)) or (beats_config.metricbeat.output_logstash_hosts is defined and (beats_config.metricbeat.output_logstash_hosts | length))

--- a/config/tasks/prometheus_node_exporter.yml
+++ b/config/tasks/prometheus_node_exporter.yml
@@ -13,7 +13,6 @@
     comment: prometheus node_exporter deamon
     shell: /bin/false
     system: yes
-    append: yes
 
 - name: prometheus node_exporter | install systemd service file
   become: yes

--- a/config/tasks/prometheus_node_exporter.yml
+++ b/config/tasks/prometheus_node_exporter.yml
@@ -2,7 +2,7 @@
 - name: prometheus node_exporter | download release archive from github.com
   become: yes
   unarchive:
-    src: "https://github.com/prometheus/node_exporter/releases/download/v{{prometheus_node_exporter_version}}/node_exporter-{{prometheus_node_exporter_version}}.linux-amd64.tar.gz"
+    src: "https://github.com/prometheus/node_exporter/releases/download/v{{prometheus_node_exporter_version}}/node_exporter-{{prometheus_node_exporter_version}}.linux-{{ 'amd64' if ansible_architecture == 'x86_64' else 'arm64' if ansible_architecture == 'aarch64' else ansible_architecture }}.tar.gz"
     dest: /opt
     remote_src: yes
 

--- a/config/templates/etc/systemd/system/prometheus_node_exporter.service.j2
+++ b/config/templates/etc/systemd/system/prometheus_node_exporter.service.j2
@@ -3,7 +3,7 @@ Description=Prometheus Node Exporter
 
 [Service]
 User=node_exporter
-ExecStart=/opt/node_exporter-{{prometheus_node_exporter_version}}.linux-amd64/node_exporter --web.listen-address=:{{ prometheus_node_exporter_port }} {{prometheus_node_exporter_options}}
+ExecStart=/opt/node_exporter-{{ prometheus_node_exporter_version }}.linux-{{ 'amd64' if ansible_architecture == 'x86_64' else 'arm64' if ansible_architecture == 'aarch64' else ansible_architecture }}/node_exporter --web.listen-address=:{{ prometheus_node_exporter_port }} {{ prometheus_node_exporter_options }}
 
 [Install]
 WantedBy=default.target

--- a/create/tasks/create_aws.yml
+++ b/create/tasks/create_aws.yml
@@ -45,7 +45,7 @@
         spot_wait_timeout: "{{cluster_vars[buildenv].hosttype_vars[item.hosttype].spot.spot_wait_timeout | default(10800)}}"    #3 hours
         spot_launch_group: "{{cluster_vars[buildenv].hosttype_vars[item.hosttype].spot.spot_launch_group | default(omit)}}"
         spot_type: "{{cluster_vars[buildenv].hosttype_vars[item.hosttype].spot.spot_type | default('persistent')}}"
-        image: "{{cluster_vars.image}}"
+        image: "{{ item.image }}"
         vpc_subnet_id: "{{item.vpc_subnet_id}}"
         assign_public_ip: "{{cluster_vars.assign_public_ip}}"
         group: "{{ cluster_vars.secgroups_existing }} {%- if cluster_vars.secgroup_new | length > 0 -%} + {{ ([r__ec2_group.group_name | default()] | default())}} {%- endif -%}"

--- a/create/tasks/create_gcp.yml
+++ b/create/tasks/create_gcp.yml
@@ -103,7 +103,7 @@
         state: present
         deletion_protection: "{{cluster_vars[buildenv].deletion_protection}}"
       vars:
-        _bootdisk: {auto_delete: true, boot: true, device_name: "{{ item.hostname }}--boot", initialize_params: {source_image: "{{cluster_vars.image}}", disk_name: "{{ item.hostname }}--boot", disk_size_gb: "{{ cluster_vars[buildenv].hosttype_vars[item.hosttype].rootvol_size | default(omit) }}"}}
+        _bootdisk: {auto_delete: true, boot: true, device_name: "{{ item.hostname }}--boot", initialize_params: {source_image: "{{item.image}}", disk_name: "{{ item.hostname }}--boot", disk_size_gb: "{{ cluster_vars[buildenv].hosttype_vars[item.hosttype].rootvol_size | default(omit) }}"}}
         _autodisks: "{{item.auto_volumes | json_query(\"[].{auto_delete: auto_delete, interface: interface, device_name: device_name, initialize_params: initialize_params, source: {selfLink: src.source_url}}\") }}"
         _labels:
           name: "{{item.hostname}}"

--- a/create/tasks/main.yml
+++ b/create/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
 
-- name: Ensure that the 'release' tag/label is consistent within a cluster.  Perform this here (rather than roles/clusterverse/cluster_hosts/) to allow redeploy to change the version.
+- name: Ensure that the 'release' tag/label is consistent within a cluster.  Perform this here (rather than roles/clusterverse/cluster_hosts/) to allow redeploy to change the version (i.e. after lifecycle_state is set to retiring).
   block:
     - name: current_release_versions
       debug: msg="{{current_release_versions}}"
@@ -22,9 +22,9 @@
 
 
 - name: "Create {{cluster_vars.type}} cluster"
-  include_tasks: "{{cluster_vars.type}}.yml"
+  include_tasks: "create_{{cluster_vars.type}}.yml"
   vars:
-    # auto_volumes are normally a list of volumes per host.  We cannot iterate this within a non-nested ansible loop(with_items), so we denormalise/ flatten it into a new one-dimensional list, of each volume, as well as all the parent host information.
+    # auto_volumes are normally a list of volumes per host (list of list).  We cannot iterate this within a non-nested ansible loop (with_items), so we denormalise/ flatten it into a new one-dimensional list, of each volume, as well as all the parent host information.
     cluster_hosts_target_denormalised_by_volume: |
       {% set res = [] -%}
       {%- for cht_host in cluster_hosts_target -%}

--- a/jenkinsfiles/Jenkinsfile_testsuite
+++ b/jenkinsfiles/Jenkinsfile_testsuite
@@ -110,14 +110,14 @@ println("User-supplied 'params': \n" + params.inspect() + "\n")
 // A class to hold the status of each stage, so we can fail a stage and be able to run the clean at the end if needed
 class cStageBuild {
     public String result = 'SUCCESS'
-    public HashMap userParams = [:]
+    public HashMap extraVars = [:]
 
-    String getUserParamsString() {
-        String userParamsString = ""
-        this.userParams.each({ paramName, paramVal ->
-            userParamsString += " -e ${paramName}=${paramVal}"
+    String getExtraVarsString() {
+        String extraVarsString = ""
+        this.extraVars.each({ paramName, paramVal ->
+            extraVarsString += " -e ${paramName}=${paramVal}"
         })
-        return (userParamsString + " -vvvv")
+        return (extraVarsString + " -vvvv")
     }
 }
 
@@ -216,13 +216,13 @@ CVTEST_NOMYHOSTTYPES = new MatrixBuilder([
 
                     if (env.IMAGE_TESTED) {
                         cluster_vars_override += [image: "{{${env.IMAGE_TESTED}}}"]
-                        stageBuild.userParams.put("cluster_vars_override", "\\\'" + groovy.json.JsonOutput.toJson(cluster_vars_override).replace("\"", "\\\"") + "\\\'")   //NOTE: NO SPACES are allowed in this!!
+                        stageBuild.extraVars.put("cluster_vars_override", "\\\'" + groovy.json.JsonOutput.toJson(cluster_vars_override).replace("\"", "\\\"") + "\\\'")   // Quote the quotes.  NOTE: NO SPACES are allowed in this!!
                     }
 
-                    stageBuild.userParams.put("skip_release_version_check", "true")
-                    stageBuild.userParams.put("release_version", "1_0_0")
+                    stageBuild.extraVars.put("skip_release_version_check", "true")
+                    stageBuild.extraVars.put("release_version", "1_0_0")
                     stage_cvops('deploy', stageBuild, {
-                        build job: 'clusterverse/clusterverse-ops', parameters: [string(name: 'APP_NAME', value: "cvtest-${BUILD_NUMBER}-${env.BUILD_HASH}"), string(name: 'CLOUD_REGION', value: env.CLOUD_REGION), string(name: 'BUILDENV', value: env.BUILDENV), string(name: 'CLUSTER_ID', value: env.CLUSTER_ID), booleanParam(name: 'DNS_FORCE_DISABLE', value: env.DNS_FORCE_DISABLE), string(name: 'DEPLOY_TYPE', value: 'deploy'), string(name: 'REDEPLOY_SCHEME', value: ''), string(name: 'CANARY', value: 'none'), booleanParam(name: 'CANARY_TIDY_ON_SUCCESS', value: true), string(name: 'MYHOSTTYPES', value: ''), string(name: 'CV_GIT_URL', value: CV_OPS_GIT_URL), string(name: 'CV_GIT_BRANCH', value: CV_OPS_GIT_BRANCH), string(name: 'USER_CMDLINE_VARS', value: stageBuild.getUserParamsString())]
+                        build job: 'clusterverse/clusterverse-ops', parameters: [string(name: 'APP_NAME', value: "cvtest-${BUILD_NUMBER}-${env.BUILD_HASH}"), string(name: 'CLOUD_REGION', value: env.CLOUD_REGION), string(name: 'BUILDENV', value: env.BUILDENV), string(name: 'CLUSTER_ID', value: env.CLUSTER_ID), booleanParam(name: 'DNS_FORCE_DISABLE', value: env.DNS_FORCE_DISABLE), string(name: 'DEPLOY_TYPE', value: 'deploy'), string(name: 'REDEPLOY_SCHEME', value: ''), string(name: 'CANARY', value: 'none'), booleanParam(name: 'CANARY_TIDY_ON_SUCCESS', value: true), string(name: 'MYHOSTTYPES', value: ''), string(name: 'CV_GIT_URL', value: CV_OPS_GIT_URL), string(name: 'CV_GIT_BRANCH', value: CV_OPS_GIT_BRANCH), string(name: 'USER_CMDLINE_VARS', value: stageBuild.getExtraVarsString())]
                     })
 
                     // Update the clustervars with new scaled cluster size
@@ -233,30 +233,30 @@ CVTEST_NOMYHOSTTYPES = new MatrixBuilder([
                     }
 
                     if (cluster_vars_override.size()) {
-                        stageBuild.userParams.put("cluster_vars_override", "\\\'" + groovy.json.JsonOutput.toJson(cluster_vars_override).replace("\"", "\\\"") + "\\\'")   //NOTE: NO SPACES are allowed in this!!
+                        stageBuild.extraVars.put("cluster_vars_override", "\\\'" + groovy.json.JsonOutput.toJson(cluster_vars_override).replace("\"", "\\\"") + "\\\'")   // Quote the quotes.  NOTE: NO SPACES are allowed in this!!
                     }
 
                     if (env.REDEPLOY_SCHEME) {
-                        stageBuild.userParams.put("release_version", "2_0_0")
+                        stageBuild.extraVars.put("release_version", "2_0_0")
                         stage_cvops('redeploy canary=start', stageBuild, {
-                            build job: 'clusterverse/clusterverse-ops', parameters: [string(name: 'APP_NAME', value: "cvtest-${env.BUILD_NUMBER}-${env.BUILD_HASH}"), string(name: 'CLOUD_REGION', value: env.CLOUD_REGION), string(name: 'BUILDENV', value: env.BUILDENV), string(name: 'CLUSTER_ID', value: env.CLUSTER_ID), booleanParam(name: 'DNS_FORCE_DISABLE', value: env.DNS_FORCE_DISABLE), string(name: 'DEPLOY_TYPE', value: 'redeploy'), string(name: 'REDEPLOY_SCHEME', value: (env.REDEPLOY_SCHEME ? env.REDEPLOY_SCHEME : '')), string(name: 'CANARY', value: 'start'), booleanParam(name: 'CANARY_TIDY_ON_SUCCESS', value: false), string(name: 'MYHOSTTYPES', value: ''), string(name: 'CV_GIT_URL', value: CV_OPS_GIT_URL), string(name: 'CV_GIT_BRANCH', value: CV_OPS_GIT_BRANCH), string(name: 'USER_CMDLINE_VARS', value: stageBuild.getUserParamsString())]
+                            build job: 'clusterverse/clusterverse-ops', parameters: [string(name: 'APP_NAME', value: "cvtest-${env.BUILD_NUMBER}-${env.BUILD_HASH}"), string(name: 'CLOUD_REGION', value: env.CLOUD_REGION), string(name: 'BUILDENV', value: env.BUILDENV), string(name: 'CLUSTER_ID', value: env.CLUSTER_ID), booleanParam(name: 'DNS_FORCE_DISABLE', value: env.DNS_FORCE_DISABLE), string(name: 'DEPLOY_TYPE', value: 'redeploy'), string(name: 'REDEPLOY_SCHEME', value: (env.REDEPLOY_SCHEME ? env.REDEPLOY_SCHEME : '')), string(name: 'CANARY', value: 'start'), booleanParam(name: 'CANARY_TIDY_ON_SUCCESS', value: false), string(name: 'MYHOSTTYPES', value: ''), string(name: 'CV_GIT_URL', value: CV_OPS_GIT_URL), string(name: 'CV_GIT_BRANCH', value: CV_OPS_GIT_BRANCH), string(name: 'USER_CMDLINE_VARS', value: stageBuild.getExtraVarsString())]
                         })
 
                         stage_cvops('redeploy canary=finish', stageBuild, {
-                            build job: 'clusterverse/clusterverse-ops', parameters: [string(name: 'APP_NAME', value: "cvtest-${env.BUILD_NUMBER}-${env.BUILD_HASH}"), string(name: 'CLOUD_REGION', value: env.CLOUD_REGION), string(name: 'BUILDENV', value: env.BUILDENV), string(name: 'CLUSTER_ID', value: env.CLUSTER_ID), booleanParam(name: 'DNS_FORCE_DISABLE', value: env.DNS_FORCE_DISABLE), string(name: 'DEPLOY_TYPE', value: 'redeploy'), string(name: 'REDEPLOY_SCHEME', value: (env.REDEPLOY_SCHEME ? env.REDEPLOY_SCHEME : '')), string(name: 'CANARY', value: 'finish'), booleanParam(name: 'CANARY_TIDY_ON_SUCCESS', value: false), string(name: 'MYHOSTTYPES', value: ''), string(name: 'CV_GIT_URL', value: CV_OPS_GIT_URL), string(name: 'CV_GIT_BRANCH', value: CV_OPS_GIT_BRANCH), string(name: 'USER_CMDLINE_VARS', value: stageBuild.getUserParamsString())]
+                            build job: 'clusterverse/clusterverse-ops', parameters: [string(name: 'APP_NAME', value: "cvtest-${env.BUILD_NUMBER}-${env.BUILD_HASH}"), string(name: 'CLOUD_REGION', value: env.CLOUD_REGION), string(name: 'BUILDENV', value: env.BUILDENV), string(name: 'CLUSTER_ID', value: env.CLUSTER_ID), booleanParam(name: 'DNS_FORCE_DISABLE', value: env.DNS_FORCE_DISABLE), string(name: 'DEPLOY_TYPE', value: 'redeploy'), string(name: 'REDEPLOY_SCHEME', value: (env.REDEPLOY_SCHEME ? env.REDEPLOY_SCHEME : '')), string(name: 'CANARY', value: 'finish'), booleanParam(name: 'CANARY_TIDY_ON_SUCCESS', value: false), string(name: 'MYHOSTTYPES', value: ''), string(name: 'CV_GIT_URL', value: CV_OPS_GIT_URL), string(name: 'CV_GIT_BRANCH', value: CV_OPS_GIT_BRANCH), string(name: 'USER_CMDLINE_VARS', value: stageBuild.getExtraVarsString())]
                         })
 
                         stage_cvops('redeploy canary=tidy', stageBuild, {
-                            build job: 'clusterverse/clusterverse-ops', parameters: [string(name: 'APP_NAME', value: "cvtest-${env.BUILD_NUMBER}-${env.BUILD_HASH}"), string(name: 'CLOUD_REGION', value: env.CLOUD_REGION), string(name: 'BUILDENV', value: env.BUILDENV), string(name: 'CLUSTER_ID', value: env.CLUSTER_ID), booleanParam(name: 'DNS_FORCE_DISABLE', value: env.DNS_FORCE_DISABLE), string(name: 'DEPLOY_TYPE', value: 'redeploy'), string(name: 'REDEPLOY_SCHEME', value: (env.REDEPLOY_SCHEME ? env.REDEPLOY_SCHEME : '')), string(name: 'CANARY', value: 'tidy'), booleanParam(name: 'CANARY_TIDY_ON_SUCCESS', value: false), string(name: 'MYHOSTTYPES', value: ''), string(name: 'CV_GIT_URL', value: CV_OPS_GIT_URL), string(name: 'CV_GIT_BRANCH', value: CV_OPS_GIT_BRANCH), string(name: 'USER_CMDLINE_VARS', value: stageBuild.getUserParamsString())]
+                            build job: 'clusterverse/clusterverse-ops', parameters: [string(name: 'APP_NAME', value: "cvtest-${env.BUILD_NUMBER}-${env.BUILD_HASH}"), string(name: 'CLOUD_REGION', value: env.CLOUD_REGION), string(name: 'BUILDENV', value: env.BUILDENV), string(name: 'CLUSTER_ID', value: env.CLUSTER_ID), booleanParam(name: 'DNS_FORCE_DISABLE', value: env.DNS_FORCE_DISABLE), string(name: 'DEPLOY_TYPE', value: 'redeploy'), string(name: 'REDEPLOY_SCHEME', value: (env.REDEPLOY_SCHEME ? env.REDEPLOY_SCHEME : '')), string(name: 'CANARY', value: 'tidy'), booleanParam(name: 'CANARY_TIDY_ON_SUCCESS', value: false), string(name: 'MYHOSTTYPES', value: ''), string(name: 'CV_GIT_URL', value: CV_OPS_GIT_URL), string(name: 'CV_GIT_BRANCH', value: CV_OPS_GIT_BRANCH), string(name: 'USER_CMDLINE_VARS', value: stageBuild.getExtraVarsString())]
                         })
 
                         //Need to redeploy original cluster (without scaling), to test that scaling works with next redeploy test (canary=none)
                         if (env.SCALEUPDOWN == 'scaleup' || env.SCALEUPDOWN == 'scaledown') {
                             cluster_vars_override.remove("${env.BUILDENV}")
-                            stageBuild.userParams.put("cluster_vars_override", "\\\'" + groovy.json.JsonOutput.toJson(cluster_vars_override).replace("\"", "\\\"") + "\\\'")
-                            stageBuild.userParams.put("release_version", "2_5_0")
+                            stageBuild.extraVars.put("cluster_vars_override", "\\\'" + groovy.json.JsonOutput.toJson(cluster_vars_override).replace("\"", "\\\"") + "\\\'")   // Quote the quotes.  NOTE: NO SPACES are allowed in this!!
+                            stageBuild.extraVars.put("release_version", "2_5_0")
                             stage_cvops('deploy clean original (unscaled) for next test', stageBuild, {
-                                build job: 'clusterverse/clusterverse-ops', parameters: [string(name: 'APP_NAME', value: "cvtest-${BUILD_NUMBER}-${env.BUILD_HASH}"), string(name: 'CLOUD_REGION', value: env.CLOUD_REGION), string(name: 'BUILDENV', value: env.BUILDENV), string(name: 'CLUSTER_ID', value: env.CLUSTER_ID), booleanParam(name: 'DNS_FORCE_DISABLE', value: env.DNS_FORCE_DISABLE), string(name: 'DEPLOY_TYPE', value: 'deploy'), string(name: 'REDEPLOY_SCHEME', value: ''), string(name: 'CANARY', value: 'none'), booleanParam(name: 'CANARY_TIDY_ON_SUCCESS', value: true), string(name: 'MYHOSTTYPES', value: ''), string(name: 'CV_GIT_URL', value: CV_OPS_GIT_URL), string(name: 'CV_GIT_BRANCH', value: CV_OPS_GIT_BRANCH), string(name: 'USER_CMDLINE_VARS', value: stageBuild.getUserParamsString() + " -e clean=_all_")]
+                                build job: 'clusterverse/clusterverse-ops', parameters: [string(name: 'APP_NAME', value: "cvtest-${BUILD_NUMBER}-${env.BUILD_HASH}"), string(name: 'CLOUD_REGION', value: env.CLOUD_REGION), string(name: 'BUILDENV', value: env.BUILDENV), string(name: 'CLUSTER_ID', value: env.CLUSTER_ID), booleanParam(name: 'DNS_FORCE_DISABLE', value: env.DNS_FORCE_DISABLE), string(name: 'DEPLOY_TYPE', value: 'deploy'), string(name: 'REDEPLOY_SCHEME', value: ''), string(name: 'CANARY', value: 'none'), booleanParam(name: 'CANARY_TIDY_ON_SUCCESS', value: true), string(name: 'MYHOSTTYPES', value: ''), string(name: 'CV_GIT_URL', value: CV_OPS_GIT_URL), string(name: 'CV_GIT_BRANCH', value: CV_OPS_GIT_BRANCH), string(name: 'USER_CMDLINE_VARS', value: stageBuild.getExtraVarsString() + " -e clean=_all_")]
                             })
 
                             //Re-add the scaleup/down cmdline for next redeploy test (canary=none)
@@ -265,13 +265,13 @@ CVTEST_NOMYHOSTTYPES = new MatrixBuilder([
                             } else if (env.SCALEUPDOWN == 'scaledown') {
                                 cluster_vars_override += ["${env.BUILDENV}": [hosttype_vars: [sys: [vms_by_az: [b: 0, c: 0]]]]]     // AZ 'b' is set normally
                             }
-                            stageBuild.userParams.put("cluster_vars_override", "\\\'" + groovy.json.JsonOutput.toJson(cluster_vars_override).replace("\"", "\\\"") + "\\\'")
+                            stageBuild.extraVars.put("cluster_vars_override", "\\\'" + groovy.json.JsonOutput.toJson(cluster_vars_override).replace("\"", "\\\"") + "\\\'")   // Quote the quotes.  NOTE: NO SPACES are allowed in this!!
                         }
 
                         // Run the canary=none redeploy
-                        stageBuild.userParams.put("release_version", "3_0_0")
+                        stageBuild.extraVars.put("release_version", "3_0_0")
                         stage_cvops('redeploy canary=none (tidy_on_success)', stageBuild, {
-                            build job: 'clusterverse/clusterverse-ops', parameters: [string(name: 'APP_NAME', value: "cvtest-${env.BUILD_NUMBER}-${env.BUILD_HASH}"), string(name: 'CLOUD_REGION', value: env.CLOUD_REGION), string(name: 'BUILDENV', value: env.BUILDENV), string(name: 'CLUSTER_ID', value: env.CLUSTER_ID), booleanParam(name: 'DNS_FORCE_DISABLE', value: env.DNS_FORCE_DISABLE), string(name: 'DEPLOY_TYPE', value: 'redeploy'), string(name: 'REDEPLOY_SCHEME', value: (env.REDEPLOY_SCHEME ? env.REDEPLOY_SCHEME : '')), string(name: 'CANARY', value: 'none'), booleanParam(name: 'CANARY_TIDY_ON_SUCCESS', value: true), string(name: 'MYHOSTTYPES', value: ''), string(name: 'CV_GIT_URL', value: CV_OPS_GIT_URL), string(name: 'CV_GIT_BRANCH', value: CV_OPS_GIT_BRANCH), string(name: 'USER_CMDLINE_VARS', value: stageBuild.getUserParamsString())]
+                            build job: 'clusterverse/clusterverse-ops', parameters: [string(name: 'APP_NAME', value: "cvtest-${env.BUILD_NUMBER}-${env.BUILD_HASH}"), string(name: 'CLOUD_REGION', value: env.CLOUD_REGION), string(name: 'BUILDENV', value: env.BUILDENV), string(name: 'CLUSTER_ID', value: env.CLUSTER_ID), booleanParam(name: 'DNS_FORCE_DISABLE', value: env.DNS_FORCE_DISABLE), string(name: 'DEPLOY_TYPE', value: 'redeploy'), string(name: 'REDEPLOY_SCHEME', value: (env.REDEPLOY_SCHEME ? env.REDEPLOY_SCHEME : '')), string(name: 'CANARY', value: 'none'), booleanParam(name: 'CANARY_TIDY_ON_SUCCESS', value: true), string(name: 'MYHOSTTYPES', value: ''), string(name: 'CV_GIT_URL', value: CV_OPS_GIT_URL), string(name: 'CV_GIT_BRANCH', value: CV_OPS_GIT_BRANCH), string(name: 'USER_CMDLINE_VARS', value: stageBuild.getExtraVarsString())]
                         })
                     } else {
                         stage_cvops('Redeploy not requested', stageBuild, {
@@ -280,7 +280,7 @@ CVTEST_NOMYHOSTTYPES = new MatrixBuilder([
                     }
 
                     stage_cvops('deploy on top', stageBuild, {
-                        build job: 'clusterverse/clusterverse-ops', parameters: [string(name: 'APP_NAME', value: "cvtest-${env.BUILD_NUMBER}-${env.BUILD_HASH}"), string(name: 'CLOUD_REGION', value: env.CLOUD_REGION), string(name: 'BUILDENV', value: env.BUILDENV), string(name: 'CLUSTER_ID', value: env.CLUSTER_ID), booleanParam(name: 'DNS_FORCE_DISABLE', value: env.DNS_FORCE_DISABLE), string(name: 'DEPLOY_TYPE', value: 'deploy'), string(name: 'REDEPLOY_SCHEME', value: ''), string(name: 'CANARY', value: 'none'), booleanParam(name: 'CANARY_TIDY_ON_SUCCESS', value: true), string(name: 'MYHOSTTYPES', value: ''), string(name: 'CV_GIT_URL', value: CV_OPS_GIT_URL), string(name: 'CV_GIT_BRANCH', value: CV_OPS_GIT_BRANCH), string(name: 'USER_CMDLINE_VARS', value: stageBuild.getUserParamsString())]
+                        build job: 'clusterverse/clusterverse-ops', parameters: [string(name: 'APP_NAME', value: "cvtest-${env.BUILD_NUMBER}-${env.BUILD_HASH}"), string(name: 'CLOUD_REGION', value: env.CLOUD_REGION), string(name: 'BUILDENV', value: env.BUILDENV), string(name: 'CLUSTER_ID', value: env.CLUSTER_ID), booleanParam(name: 'DNS_FORCE_DISABLE', value: env.DNS_FORCE_DISABLE), string(name: 'DEPLOY_TYPE', value: 'deploy'), string(name: 'REDEPLOY_SCHEME', value: ''), string(name: 'CANARY', value: 'none'), booleanParam(name: 'CANARY_TIDY_ON_SUCCESS', value: true), string(name: 'MYHOSTTYPES', value: ''), string(name: 'CV_GIT_URL', value: CV_OPS_GIT_URL), string(name: 'CV_GIT_BRANCH', value: CV_OPS_GIT_BRANCH), string(name: 'USER_CMDLINE_VARS', value: stageBuild.getExtraVarsString())]
                     })
 
                     if (stageBuild.result == 'SUCCESS' || params.CLEAN_ON_FAILURE == 'true') {
@@ -289,7 +289,7 @@ CVTEST_NOMYHOSTTYPES = new MatrixBuilder([
                                 echo "Stage failure: Running clean-up on cluster..."
                             }
                             catchError {
-                                build job: 'clusterverse/clusterverse-ops', parameters: [string(name: 'APP_NAME', value: "cvtest-${env.BUILD_NUMBER}-${env.BUILD_HASH}"), string(name: 'CLOUD_REGION', value: env.CLOUD_REGION), string(name: 'BUILDENV', value: env.BUILDENV), string(name: 'CLUSTER_ID', value: env.CLUSTER_ID), booleanParam(name: 'DNS_FORCE_DISABLE', value: env.DNS_FORCE_DISABLE), string(name: 'DEPLOY_TYPE', value: 'clean'), string(name: 'REDEPLOY_SCHEME', value: ''), string(name: 'CANARY', value: 'none'), booleanParam(name: 'CANARY_TIDY_ON_SUCCESS', value: true), string(name: 'MYHOSTTYPES', value: ''), string(name: 'CV_GIT_URL', value: CV_OPS_GIT_URL), string(name: 'CV_GIT_BRANCH', value: CV_OPS_GIT_BRANCH), string(name: 'USER_CMDLINE_VARS', value: stageBuild.getUserParamsString())]
+                                build job: 'clusterverse/clusterverse-ops', parameters: [string(name: 'APP_NAME', value: "cvtest-${env.BUILD_NUMBER}-${env.BUILD_HASH}"), string(name: 'CLOUD_REGION', value: env.CLOUD_REGION), string(name: 'BUILDENV', value: env.BUILDENV), string(name: 'CLUSTER_ID', value: env.CLUSTER_ID), booleanParam(name: 'DNS_FORCE_DISABLE', value: env.DNS_FORCE_DISABLE), string(name: 'DEPLOY_TYPE', value: 'clean'), string(name: 'REDEPLOY_SCHEME', value: ''), string(name: 'CANARY', value: 'none'), booleanParam(name: 'CANARY_TIDY_ON_SUCCESS', value: true), string(name: 'MYHOSTTYPES', value: ''), string(name: 'CV_GIT_URL', value: CV_OPS_GIT_URL), string(name: 'CV_GIT_BRANCH', value: CV_OPS_GIT_BRANCH), string(name: 'USER_CMDLINE_VARS', value: stageBuild.getExtraVarsString())]
                             }
                         }
                     }
@@ -332,7 +332,7 @@ CVTEST_MYHOSTTYPES = new MatrixBuilder([
 
                     if (env.IMAGE_TESTED) {
                         cluster_vars_override += [image: "{{${env.IMAGE_TESTED}}}"]
-                        stageBuild.userParams.put("cluster_vars_override", "\\\'" + groovy.json.JsonOutput.toJson(cluster_vars_override).replace("\"", "\\\"") + "\\\'")   //NOTE: NO SPACES are allowed in this!!
+                        stageBuild.extraVars.put("cluster_vars_override", "\\\'" + groovy.json.JsonOutput.toJson(cluster_vars_override).replace("\"", "\\\"") + "\\\'")   // Quote the quotes.  NOTE: NO SPACES are allowed in this!!
                     }
 
                     if (env.REDEPLOY_SCHEME) {
@@ -342,10 +342,10 @@ CVTEST_MYHOSTTYPES = new MatrixBuilder([
                             unstable('Stage failed!  Error was: ' + err)       // OR:  'error "Stage failure"' or 'throw new org.jenkinsci.plugins.workflow.steps.FlowInterruptedException(hudson.model.Result.FAILURE)', but both of these fail all future stages, preventing us calling the clean.
                         }
 
-                        stageBuild.userParams.put("skip_release_version_check", "true")
-                        stageBuild.userParams.put("release_version", "1_0_0")
+                        stageBuild.extraVars.put("skip_release_version_check", "true")
+                        stageBuild.extraVars.put("release_version", "1_0_0")
                         stage_cvops('deploy', stageBuild, {
-                            build job: 'clusterverse/clusterverse-ops', parameters: [string(name: 'APP_NAME', value: "cvtest-${BUILD_NUMBER}-${env.BUILD_HASH}"), string(name: 'CLOUD_REGION', value: env.CLOUD_REGION), string(name: 'BUILDENV', value: env.BUILDENV), string(name: 'CLUSTER_ID', value: env.CLUSTER_ID), booleanParam(name: 'DNS_FORCE_DISABLE', value: env.DNS_FORCE_DISABLE), string(name: 'DEPLOY_TYPE', value: 'deploy'), string(name: 'REDEPLOY_SCHEME', value: ''), string(name: 'CANARY', value: 'none'), booleanParam(name: 'CANARY_TIDY_ON_SUCCESS', value: true), string(name: 'MYHOSTTYPES', value: ''), string(name: 'CV_GIT_URL', value: CV_OPS_GIT_URL), string(name: 'CV_GIT_BRANCH', value: CV_OPS_GIT_BRANCH), string(name: 'USER_CMDLINE_VARS', value: stageBuild.getUserParamsString())]
+                            build job: 'clusterverse/clusterverse-ops', parameters: [string(name: 'APP_NAME', value: "cvtest-${BUILD_NUMBER}-${env.BUILD_HASH}"), string(name: 'CLOUD_REGION', value: env.CLOUD_REGION), string(name: 'BUILDENV', value: env.BUILDENV), string(name: 'CLUSTER_ID', value: env.CLUSTER_ID), booleanParam(name: 'DNS_FORCE_DISABLE', value: env.DNS_FORCE_DISABLE), string(name: 'DEPLOY_TYPE', value: 'deploy'), string(name: 'REDEPLOY_SCHEME', value: ''), string(name: 'CANARY', value: 'none'), booleanParam(name: 'CANARY_TIDY_ON_SUCCESS', value: true), string(name: 'MYHOSTTYPES', value: ''), string(name: 'CV_GIT_URL', value: CV_OPS_GIT_URL), string(name: 'CV_GIT_BRANCH', value: CV_OPS_GIT_BRANCH), string(name: 'USER_CMDLINE_VARS', value: stageBuild.getExtraVarsString())]
                         })
 
                         // Update the clustervars with new scaled cluster size
@@ -356,32 +356,32 @@ CVTEST_MYHOSTTYPES = new MatrixBuilder([
                         }
 
                         if (cluster_vars_override.size()) {
-                            stageBuild.userParams.put("cluster_vars_override", "\\\'" + groovy.json.JsonOutput.toJson(cluster_vars_override).replace("\"", "\\\"") + "\\\'")   //NOTE: NO SPACES are allowed in this!!
+                            stageBuild.extraVars.put("cluster_vars_override", "\\\'" + groovy.json.JsonOutput.toJson(cluster_vars_override).replace("\"", "\\\"") + "\\\'")   // Quote the quotes.  NOTE: NO SPACES are allowed in this!!
                         }
 
                         // Run the split redeploy over all hosttypes
-                        stageBuild.userParams.put("release_version", "2_0_0")
+                        stageBuild.extraVars.put("release_version", "2_0_0")
                         params.MYHOSTTYPES_LIST.split(',').each({ my_host_type ->
                             stage_cvops("redeploy canary=start ($my_host_type)", stageBuild, {
-                                build job: 'clusterverse/clusterverse-ops', parameters: [string(name: 'APP_NAME', value: "cvtest-${env.BUILD_NUMBER}-${env.BUILD_HASH}"), string(name: 'CLOUD_REGION', value: env.CLOUD_REGION), string(name: 'BUILDENV', value: env.BUILDENV), string(name: 'CLUSTER_ID', value: env.CLUSTER_ID), booleanParam(name: 'DNS_FORCE_DISABLE', value: env.DNS_FORCE_DISABLE), string(name: 'DEPLOY_TYPE', value: 'redeploy'), string(name: 'REDEPLOY_SCHEME', value: (env.REDEPLOY_SCHEME ? env.REDEPLOY_SCHEME : '')), string(name: 'CANARY', value: 'start'), booleanParam(name: 'CANARY_TIDY_ON_SUCCESS', value: false), string(name: 'MYHOSTTYPES', value: my_host_type), string(name: 'CV_GIT_URL', value: CV_OPS_GIT_URL), string(name: 'CV_GIT_BRANCH', value: CV_OPS_GIT_BRANCH), string(name: 'USER_CMDLINE_VARS', value: stageBuild.getUserParamsString())]
+                                build job: 'clusterverse/clusterverse-ops', parameters: [string(name: 'APP_NAME', value: "cvtest-${env.BUILD_NUMBER}-${env.BUILD_HASH}"), string(name: 'CLOUD_REGION', value: env.CLOUD_REGION), string(name: 'BUILDENV', value: env.BUILDENV), string(name: 'CLUSTER_ID', value: env.CLUSTER_ID), booleanParam(name: 'DNS_FORCE_DISABLE', value: env.DNS_FORCE_DISABLE), string(name: 'DEPLOY_TYPE', value: 'redeploy'), string(name: 'REDEPLOY_SCHEME', value: (env.REDEPLOY_SCHEME ? env.REDEPLOY_SCHEME : '')), string(name: 'CANARY', value: 'start'), booleanParam(name: 'CANARY_TIDY_ON_SUCCESS', value: false), string(name: 'MYHOSTTYPES', value: my_host_type), string(name: 'CV_GIT_URL', value: CV_OPS_GIT_URL), string(name: 'CV_GIT_BRANCH', value: CV_OPS_GIT_BRANCH), string(name: 'USER_CMDLINE_VARS', value: stageBuild.getExtraVarsString())]
                             })
 
                             stage_cvops("redeploy canary=finish ($my_host_type)", stageBuild, {
-                                build job: 'clusterverse/clusterverse-ops', parameters: [string(name: 'APP_NAME', value: "cvtest-${env.BUILD_NUMBER}-${env.BUILD_HASH}"), string(name: 'CLOUD_REGION', value: env.CLOUD_REGION), string(name: 'BUILDENV', value: env.BUILDENV), string(name: 'CLUSTER_ID', value: env.CLUSTER_ID), booleanParam(name: 'DNS_FORCE_DISABLE', value: env.DNS_FORCE_DISABLE), string(name: 'DEPLOY_TYPE', value: 'redeploy'), string(name: 'REDEPLOY_SCHEME', value: (env.REDEPLOY_SCHEME ? env.REDEPLOY_SCHEME : '')), string(name: 'CANARY', value: 'finish'), booleanParam(name: 'CANARY_TIDY_ON_SUCCESS', value: false), string(name: 'MYHOSTTYPES', value: my_host_type), string(name: 'CV_GIT_URL', value: CV_OPS_GIT_URL), string(name: 'CV_GIT_BRANCH', value: CV_OPS_GIT_BRANCH), string(name: 'USER_CMDLINE_VARS', value: stageBuild.getUserParamsString())]
+                                build job: 'clusterverse/clusterverse-ops', parameters: [string(name: 'APP_NAME', value: "cvtest-${env.BUILD_NUMBER}-${env.BUILD_HASH}"), string(name: 'CLOUD_REGION', value: env.CLOUD_REGION), string(name: 'BUILDENV', value: env.BUILDENV), string(name: 'CLUSTER_ID', value: env.CLUSTER_ID), booleanParam(name: 'DNS_FORCE_DISABLE', value: env.DNS_FORCE_DISABLE), string(name: 'DEPLOY_TYPE', value: 'redeploy'), string(name: 'REDEPLOY_SCHEME', value: (env.REDEPLOY_SCHEME ? env.REDEPLOY_SCHEME : '')), string(name: 'CANARY', value: 'finish'), booleanParam(name: 'CANARY_TIDY_ON_SUCCESS', value: false), string(name: 'MYHOSTTYPES', value: my_host_type), string(name: 'CV_GIT_URL', value: CV_OPS_GIT_URL), string(name: 'CV_GIT_BRANCH', value: CV_OPS_GIT_BRANCH), string(name: 'USER_CMDLINE_VARS', value: stageBuild.getExtraVarsString())]
                             })
 
                             stage_cvops("redeploy canary=tidy ($my_host_type)", stageBuild, {
-                                build job: 'clusterverse/clusterverse-ops', parameters: [string(name: 'APP_NAME', value: "cvtest-${env.BUILD_NUMBER}-${env.BUILD_HASH}"), string(name: 'CLOUD_REGION', value: env.CLOUD_REGION), string(name: 'BUILDENV', value: env.BUILDENV), string(name: 'CLUSTER_ID', value: env.CLUSTER_ID), booleanParam(name: 'DNS_FORCE_DISABLE', value: env.DNS_FORCE_DISABLE), string(name: 'DEPLOY_TYPE', value: 'redeploy'), string(name: 'REDEPLOY_SCHEME', value: (env.REDEPLOY_SCHEME ? env.REDEPLOY_SCHEME : '')), string(name: 'CANARY', value: 'tidy'), booleanParam(name: 'CANARY_TIDY_ON_SUCCESS', value: false), string(name: 'MYHOSTTYPES', value: my_host_type), string(name: 'CV_GIT_URL', value: CV_OPS_GIT_URL), string(name: 'CV_GIT_BRANCH', value: CV_OPS_GIT_BRANCH), string(name: 'USER_CMDLINE_VARS', value: stageBuild.getUserParamsString())]
+                                build job: 'clusterverse/clusterverse-ops', parameters: [string(name: 'APP_NAME', value: "cvtest-${env.BUILD_NUMBER}-${env.BUILD_HASH}"), string(name: 'CLOUD_REGION', value: env.CLOUD_REGION), string(name: 'BUILDENV', value: env.BUILDENV), string(name: 'CLUSTER_ID', value: env.CLUSTER_ID), booleanParam(name: 'DNS_FORCE_DISABLE', value: env.DNS_FORCE_DISABLE), string(name: 'DEPLOY_TYPE', value: 'redeploy'), string(name: 'REDEPLOY_SCHEME', value: (env.REDEPLOY_SCHEME ? env.REDEPLOY_SCHEME : '')), string(name: 'CANARY', value: 'tidy'), booleanParam(name: 'CANARY_TIDY_ON_SUCCESS', value: false), string(name: 'MYHOSTTYPES', value: my_host_type), string(name: 'CV_GIT_URL', value: CV_OPS_GIT_URL), string(name: 'CV_GIT_BRANCH', value: CV_OPS_GIT_BRANCH), string(name: 'USER_CMDLINE_VARS', value: stageBuild.getExtraVarsString())]
                             })
                         })
 
                         //Need to redeploy original cluster (without scaling), to test that scaling works with next redeploy test (canary=none)
                         if (env.SCALEUPDOWN == 'scaleup' || env.SCALEUPDOWN == 'scaledown') {
                             cluster_vars_override.remove("${env.BUILDENV}")
-                            stageBuild.userParams.put("cluster_vars_override", "\\\'" + groovy.json.JsonOutput.toJson(cluster_vars_override).replace("\"", "\\\"") + "\\\'")
-                            stageBuild.userParams.put("release_version", "2_5_0")
+                            stageBuild.extraVars.put("cluster_vars_override", "\\\'" + groovy.json.JsonOutput.toJson(cluster_vars_override).replace("\"", "\\\"") + "\\\'")   // Quote the quotes.  NOTE: NO SPACES are allowed in this!!
+                            stageBuild.extraVars.put("release_version", "2_5_0")
                             stage_cvops('deploy clean original (unscaled) for next test', stageBuild, {
-                                build job: 'clusterverse/clusterverse-ops', parameters: [string(name: 'APP_NAME', value: "cvtest-${BUILD_NUMBER}-${env.BUILD_HASH}"), string(name: 'CLOUD_REGION', value: env.CLOUD_REGION), string(name: 'BUILDENV', value: env.BUILDENV), string(name: 'CLUSTER_ID', value: env.CLUSTER_ID), booleanParam(name: 'DNS_FORCE_DISABLE', value: env.DNS_FORCE_DISABLE), string(name: 'DEPLOY_TYPE', value: 'deploy'), string(name: 'REDEPLOY_SCHEME', value: ''), string(name: 'CANARY', value: 'none'), booleanParam(name: 'CANARY_TIDY_ON_SUCCESS', value: true), string(name: 'MYHOSTTYPES', value: ''), string(name: 'CV_GIT_URL', value: CV_OPS_GIT_URL), string(name: 'CV_GIT_BRANCH', value: CV_OPS_GIT_BRANCH), string(name: 'USER_CMDLINE_VARS', value: stageBuild.getUserParamsString() + " -e clean=_all_")]
+                                build job: 'clusterverse/clusterverse-ops', parameters: [string(name: 'APP_NAME', value: "cvtest-${BUILD_NUMBER}-${env.BUILD_HASH}"), string(name: 'CLOUD_REGION', value: env.CLOUD_REGION), string(name: 'BUILDENV', value: env.BUILDENV), string(name: 'CLUSTER_ID', value: env.CLUSTER_ID), booleanParam(name: 'DNS_FORCE_DISABLE', value: env.DNS_FORCE_DISABLE), string(name: 'DEPLOY_TYPE', value: 'deploy'), string(name: 'REDEPLOY_SCHEME', value: ''), string(name: 'CANARY', value: 'none'), booleanParam(name: 'CANARY_TIDY_ON_SUCCESS', value: true), string(name: 'MYHOSTTYPES', value: ''), string(name: 'CV_GIT_URL', value: CV_OPS_GIT_URL), string(name: 'CV_GIT_BRANCH', value: CV_OPS_GIT_BRANCH), string(name: 'USER_CMDLINE_VARS', value: stageBuild.getExtraVarsString() + " -e clean=_all_")]
                             })
 
                             //Re-add the scaleup/down cmdline for next redeploy test (canary=none)
@@ -390,14 +390,14 @@ CVTEST_MYHOSTTYPES = new MatrixBuilder([
                             } else if (env.SCALEUPDOWN == 'scaledown') {
                                 cluster_vars_override += ["${env.BUILDENV}": [hosttype_vars: [sys: [vms_by_az: [b: 0, c: 0]]]]]     // AZ 'b' is set normally
                             }
-                            stageBuild.userParams.put("cluster_vars_override", "\\\'" + groovy.json.JsonOutput.toJson(cluster_vars_override).replace("\"", "\\\"") + "\\\'")
+                            stageBuild.extraVars.put("cluster_vars_override", "\\\'" + groovy.json.JsonOutput.toJson(cluster_vars_override).replace("\"", "\\\"") + "\\\'")   // Quote the quotes.  NOTE: NO SPACES are allowed in this!!
                         }
 
                         // Run the canary=none redeploy over all hosttypes
-                        stageBuild.userParams.put("release_version", "3_0_0")
+                        stageBuild.extraVars.put("release_version", "3_0_0")
                         params.MYHOSTTYPES_LIST.split(',').each({ my_host_type ->
                             stage_cvops("redeploy canary=none ($my_host_type) (tidy_on_success)", stageBuild, {
-                                build job: 'clusterverse/clusterverse-ops', parameters: [string(name: 'APP_NAME', value: "cvtest-${env.BUILD_NUMBER}-${env.BUILD_HASH}"), string(name: 'CLOUD_REGION', value: env.CLOUD_REGION), string(name: 'BUILDENV', value: env.BUILDENV), string(name: 'CLUSTER_ID', value: env.CLUSTER_ID), booleanParam(name: 'DNS_FORCE_DISABLE', value: env.DNS_FORCE_DISABLE), string(name: 'DEPLOY_TYPE', value: 'redeploy'), string(name: 'REDEPLOY_SCHEME', value: (env.REDEPLOY_SCHEME ? env.REDEPLOY_SCHEME : '')), string(name: 'CANARY', value: 'none'), booleanParam(name: 'CANARY_TIDY_ON_SUCCESS', value: true), string(name: 'MYHOSTTYPES', value: my_host_type), string(name: 'CV_GIT_URL', value: CV_OPS_GIT_URL), string(name: 'CV_GIT_BRANCH', value: CV_OPS_GIT_BRANCH), string(name: 'USER_CMDLINE_VARS', value: stageBuild.getUserParamsString())]
+                                build job: 'clusterverse/clusterverse-ops', parameters: [string(name: 'APP_NAME', value: "cvtest-${env.BUILD_NUMBER}-${env.BUILD_HASH}"), string(name: 'CLOUD_REGION', value: env.CLOUD_REGION), string(name: 'BUILDENV', value: env.BUILDENV), string(name: 'CLUSTER_ID', value: env.CLUSTER_ID), booleanParam(name: 'DNS_FORCE_DISABLE', value: env.DNS_FORCE_DISABLE), string(name: 'DEPLOY_TYPE', value: 'redeploy'), string(name: 'REDEPLOY_SCHEME', value: (env.REDEPLOY_SCHEME ? env.REDEPLOY_SCHEME : '')), string(name: 'CANARY', value: 'none'), booleanParam(name: 'CANARY_TIDY_ON_SUCCESS', value: true), string(name: 'MYHOSTTYPES', value: my_host_type), string(name: 'CV_GIT_URL', value: CV_OPS_GIT_URL), string(name: 'CV_GIT_BRANCH', value: CV_OPS_GIT_BRANCH), string(name: 'USER_CMDLINE_VARS', value: stageBuild.getExtraVarsString())]
                             })
                         })
 
@@ -407,7 +407,7 @@ CVTEST_MYHOSTTYPES = new MatrixBuilder([
                                     echo "Stage failure: Running clean-up on cluster..."
                                 }
                                 catchError {
-                                    build job: 'clusterverse/clusterverse-ops', parameters: [string(name: 'APP_NAME', value: "cvtest-${env.BUILD_NUMBER}-${env.BUILD_HASH}"), string(name: 'CLOUD_REGION', value: env.CLOUD_REGION), string(name: 'BUILDENV', value: env.BUILDENV), string(name: 'CLUSTER_ID', value: env.CLUSTER_ID), booleanParam(name: 'DNS_FORCE_DISABLE', value: env.DNS_FORCE_DISABLE), string(name: 'DEPLOY_TYPE', value: 'clean'), string(name: 'REDEPLOY_SCHEME', value: ''), string(name: 'CANARY', value: 'none'), booleanParam(name: 'CANARY_TIDY_ON_SUCCESS', value: true), string(name: 'MYHOSTTYPES', value: ''), string(name: 'CV_GIT_URL', value: CV_OPS_GIT_URL), string(name: 'CV_GIT_BRANCH', value: CV_OPS_GIT_BRANCH), string(name: 'USER_CMDLINE_VARS', value: stageBuild.getUserParamsString())]
+                                    build job: 'clusterverse/clusterverse-ops', parameters: [string(name: 'APP_NAME', value: "cvtest-${env.BUILD_NUMBER}-${env.BUILD_HASH}"), string(name: 'CLOUD_REGION', value: env.CLOUD_REGION), string(name: 'BUILDENV', value: env.BUILDENV), string(name: 'CLUSTER_ID', value: env.CLUSTER_ID), booleanParam(name: 'DNS_FORCE_DISABLE', value: env.DNS_FORCE_DISABLE), string(name: 'DEPLOY_TYPE', value: 'clean'), string(name: 'REDEPLOY_SCHEME', value: ''), string(name: 'CANARY', value: 'none'), booleanParam(name: 'CANARY_TIDY_ON_SUCCESS', value: true), string(name: 'MYHOSTTYPES', value: ''), string(name: 'CV_GIT_URL', value: CV_OPS_GIT_URL), string(name: 'CV_GIT_BRANCH', value: CV_OPS_GIT_BRANCH), string(name: 'USER_CMDLINE_VARS', value: stageBuild.getExtraVarsString())]
                                 }
                             }
                         }

--- a/readiness/tasks/remove_maintenance_mode_gcp.yml
+++ b/readiness/tasks/remove_maintenance_mode_gcp.yml
@@ -5,7 +5,7 @@
   gcp_compute_instance:
     name: "{{item.name}}"
     project: "{{cluster_vars[buildenv].vpc_project_id}}"
-    zone: "{{ item.regionzone | regex_replace('^.*/(.*)$', '\\1') }}"
+    zone: "{{ item.regionzone | basename }}"
     auth_kind: "serviceaccount"
     service_account_file: "{{gcp_credentials_file}}"
     deletion_protection: "{{cluster_vars[buildenv].deletion_protection}}"

--- a/redeploy/_scheme_addallnew_rmdisk_rollback/tasks/redeploy.yml
+++ b/redeploy/_scheme_addallnew_rmdisk_rollback/tasks/redeploy.yml
@@ -1,5 +1,8 @@
 ---
 
+- name: argv
+  debug: msg="{{ argv }}"
+
 - name: canary==start or canary==none
   block:
     - assert: { that: "non_current_hosts | length == 0", msg: "ERROR - There must be no machines not in the 'current' lifecycle_state.  [non_current_hosts | join(',')]"  }


### PR DESCRIPTION
+ Allow automatic selection of latest base image by a location filter for AWS and GCP
+ Adds image to cluster_hosts_target, because it is now hosttype-specific (for AWS).
+ If a cluster already exists (e.g. we are adding or fixing a node), look-up the base image for existing cluster, to prevent added cluster members from having different base images.
+ Add support for ARM64 flavoured images (AWS only - no GCP ARM images available yet).
  + AWS AMIs are defined specific to the processor architecture, so:
  + Add a new library: "ec2_instance_type_info.py", which calls the boto3 describe_instance_types API to get the architecture for a given flavor.
  + Use this information to find the latest image for that architecture.
  + Update metricbeat/filebeat/prometheus_node_exporter to select correct ARM64 packages (ARM packages exist for beats >7.12).