### PR TITLE
[FIX] Fixed metricbeat service restart step

### DIFF
--- a/config/handlers/main.yml
+++ b/config/handlers/main.yml
@@ -13,4 +13,4 @@
   service:
     name: metricbeat
     state: restarted
-    enabled: true
+    enabled: yes


### PR DESCRIPTION
Fixes an edge-case where recent versions of Ansible do not enable / start metricbeat when `service.enabled` is set to `true` instead of `yes`.