### PR TITLE
Filebeat support for external inputs

### DIFF
--- a/config/templates/etc/filebeat/filebeat.yml.j2
+++ b/config/templates/etc/filebeat/filebeat.yml.j2
@@ -30,7 +30,7 @@ filebeat.inputs:
     - /var/log/messages
     - /var/log/secure
     - /var/log/dmesg
-{% if beats_config.filebeat.extra_logs_paths %}
+{% if beats_config.filebeat.extra_logs_paths is defined %}
 {% for logpath in beats_config.filebeat.extra_logs_paths %}
     - {{ logpath }}
 {% endfor %}

--- a/config/templates/etc/filebeat/filebeat.yml.j2
+++ b/config/templates/etc/filebeat/filebeat.yml.j2
@@ -258,3 +258,9 @@ logging.json: true
 
 # This allows to enable 6.7 migration aliases
 #migration.6_to_7.enabled: true
+
+#=========================== External Inputs ===================================
+filebeat.config.inputs:
+  enabled: true
+  path: inputs.d/*.yml
+

--- a/config/templates/etc/filebeat/filebeat.yml.j2
+++ b/config/templates/etc/filebeat/filebeat.yml.j2
@@ -261,6 +261,5 @@ logging.json: true
 
 #=========================== External Inputs ===================================
 filebeat.config.inputs:
-  enabled: true
+  enabled: {{ beats_config.filebeat.enable_external_inputs | default('false') }}
   path: inputs.d/*.yml
-


### PR DESCRIPTION
- Enables external inputs in Filebeat for configuring multiple application specific logs.
- Fixes extra_logs_paths as optional variable.