### PR TITLE
amended delay

### DIFF
--- a/config/tasks/create_dns_a.yml
+++ b/config/tasks/create_dns_a.yml
@@ -47,7 +47,7 @@
         jid: "{{ item.ansible_job_id }}"
       register: route53_jobs
       until: route53_jobs.finished
-      delay: 1
+      delay: "{{ 10 | random }}"
       retries: 300
       run_once: true
       with_items: "{{r__route53.results}}"


### PR DESCRIPTION
1s to (10 | random). Statistically this will avoid exceeding AWS resource limits at the cost of a task that will take 5x longer to complete.