### PR TITLE
[FEATURE] Give the option to define different instance_profile_name per host type

### DIFF
--- a/EXAMPLE/cluster_defs/aws/testid/eu-west-1/sandbox/cluster_vars__buildenv.yml
+++ b/EXAMPLE/cluster_defs/aws/testid/eu-west-1/sandbox/cluster_vars__buildenv.yml
@@ -36,6 +36,7 @@ cluster_vars:
         auto_volumes: [ ]
         flavor: t4g.nano
 #        image: "ami-0c28049fa5618bca4"              # eu-west-1 20.04 arm64 hvm-ssd 20210820.  Ubuntu images can be located at https://cloud-images.ubuntu.com/locator/
+        instance_profile_name: "instance-profile-name" # instance_profile_namecan be specified either at cluster level or hosttype level
         version: "{{sys_version | default('')}}"
         vms_by_az: { a: 1, b: 0, c: 0 }
 

--- a/create/tasks/create_aws.yml
+++ b/create/tasks/create_aws.yml
@@ -39,7 +39,7 @@
         region: "{{cluster_vars.region}}"
         key_name: "{{cluster_vars[buildenv].key_name}}"
         instance_type: "{{item.flavor}}"
-        instance_profile_name: "{{cluster_vars.instance_profile_name | default(omit)}}"
+        instance_profile_name: "{{cluster_vars[buildenv].hosttype_vars[item.hosttype].instance_profile_name | default(cluster_vars.instance_profile_name | default(omit))}}"
         instance_initiated_shutdown_behavior: "{{cluster_vars[buildenv].hosttype_vars[item.hosttype].instance_initiated_shutdown_behavior | default(omit)}}"
         spot_price: "{{cluster_vars[buildenv].hosttype_vars[item.hosttype].spot.spot_price | default(omit)}}"
         spot_wait_timeout: "{{cluster_vars[buildenv].hosttype_vars[item.hosttype].spot.spot_wait_timeout | default(10800)}}"    #3 hours


### PR DESCRIPTION
This change gives the ability to have `instance_profile_name` defined depending on the host type. The option to have a generic `instance_profile_name` per cluster is kept.

This was successfully tested in the scenarios below:
- 2 different host types with 1 `instance_profile_name` each
- 3 different host types:  1 host type had 1 `instance_profile_name` and other 2 had generic `instance_profile_name`
Regression tests:
- no `instance_profile_name`
- generic `instance_profile_name`