### PR TITLE
[FIX] Add ability to ignore deprecated AMI

### DIFF
--- a/EXAMPLE/cluster_defs/cluster_vars.yml
+++ b/EXAMPLE/cluster_defs/cluster_vars.yml
@@ -1,5 +1,7 @@
 ---
 
+override_deprecated_ami: true # If set true will prevent the playbook to fail in case any of the existing VM has a deprecated AMI.
+
 redeploy_schemes_supported: ['_scheme_addallnew_rmdisk_rollback', '_scheme_addnewvm_rmdisk_rollback', '_scheme_rmvm_rmdisk_only', '_scheme_rmvm_keepdisk_rollback', '_noredeploy_scale_in_only']
 
 #redeploy_scheme: _scheme_addallnew_rmdisk_rollback

--- a/cluster_hosts/tasks/get_cluster_hosts_target.yml
+++ b/cluster_hosts/tasks/get_cluster_hosts_target.yml
@@ -44,7 +44,7 @@
 
     - warn_str: msg="get_cluster_hosts_target | Replaced some base images to ensure consistency across hosttype. {{cluster_hosts_target | symmetric_difference(__orig_cluster_hosts_target)}}"
       when: (cluster_hosts_target | symmetric_difference(__orig_cluster_hosts_target))
-  when: (cluster_hosts_state | json_query('[?tagslabels.lifecycle_state==\'current\']') | length)
+  when: (cluster_hosts_state | json_query('[?tagslabels.lifecycle_state==\'current\']') | length and not override_deprecated_ami | bool)
 
 
 - name: get_cluster_hosts_target | Augment with cloud-specific parameters (if necessary)


### PR DESCRIPTION
This is raised to deal with the fact that AWS AMIs have 2 years life, after which, AMIs are not available anymore. 
```
TASK [cluster_hosts : get_cluster_hosts_target/aws | Replace image with the latest AMI found at 'manifest-location'] ***
 'image': AnsibleUndefined
```
Setting `override_deprecated_ami: true` allows to have clusters with mix of new and deprecated AMIs.
