### PR TITLE
[FEATURE] Make ec2 module working in all the regions

### DIFF
--- a/EXAMPLE/cluster_defs/aws/cluster_vars__cloud.yml
+++ b/EXAMPLE/cluster_defs/aws/cluster_vars__cloud.yml
@@ -28,4 +28,4 @@ cluster_vars:
 
 # Some of the regions are not available for aws module boto.ec2. If the region definitely exists, you may need to upgrade boto or extend with endpoints_path
 # Adding the below to ec2 invocation fixes the issue
-aws_endpoint_url: https://ec2.{{region}}.amazonaws.com
+  aws_endpoint_url: https://ec2.{{region}}.amazonaws.com

--- a/EXAMPLE/cluster_defs/aws/cluster_vars__cloud.yml
+++ b/EXAMPLE/cluster_defs/aws/cluster_vars__cloud.yml
@@ -24,3 +24,8 @@ cluster_vars:
 #      ports: ["{{ prometheus_node_exporter_port | default(9100) }}"]
 #      group_name: ["{{buildenv}}-private-sg"]
 #      rule_desc: "Prometheus instances attached to {{buildenv}}-private-sg can access the exporter port(s)."
+
+
+# Some of the regions are not available for aws module boto.ec2. If the region definitely exists, you may need to upgrade boto or extend with endpoints_path
+# Adding the below to ec2 invocation fixes the issue
+aws_endpoint_url: https://ec2.{{region}}.amazonaws.com

--- a/create/tasks/create_aws.yml
+++ b/create/tasks/create_aws.yml
@@ -56,6 +56,7 @@
         volumes: "{{ item.auto_volumes | selectattr('src', 'undefined') | list | default([]) }}"
         count_tag: { Name: "{{item.hostname}}" }
         exact_count: 1
+        ec2_url: "{{ aws_endpoint_url | default(omit) }}"
       vars:
         _instance_tags:
           Name: "{{item.hostname}}"

--- a/create/tasks/create_aws.yml
+++ b/create/tasks/create_aws.yml
@@ -56,7 +56,7 @@
         volumes: "{{ item.auto_volumes | selectattr('src', 'undefined') | list | default([]) }}"
         count_tag: { Name: "{{item.hostname}}" }
         exact_count: 1
-        ec2_url: "{{ aws_endpoint_url | default(omit) }}"
+        ec2_url: "{{ cluster_vars.aws_endpoint_url | default(omit) }}"
       vars:
         _instance_tags:
           Name: "{{item.hostname}}"


### PR DESCRIPTION
Some of the regions are not available for aws module boto.ec2. If the region definitely exists, you may need to upgrade boto or extend with endpoints_path
Specifying `ec2_url` into `ec2` invocation fixes the issue