### PR TITLE
[FEATURE] ec2 to ec2_instance 

### DIFF
--- a/_dependencies/defaults/main.yml
+++ b/_dependencies/defaults/main.yml
@@ -30,3 +30,9 @@ canary_tidy_on_success: false
 
 # External DNS server for lookups when using external IPs (the default AWS resolver will resolve the VPC IPs)
 external_dns_resolver: "8.8.8.8"
+
+# Whether to install chrony (ntp client)
+chrony_install: yes
+
+# NTP servers for chrony
+ntp_servers: "{{ ['169.254.169.123 prefer iburst minpoll 4 maxpoll 4'] if cluster_vars.type == 'aws' else ['metadata.google.internal'] if cluster_vars.type == 'gcp' else ['pool.ntp.org'] }}"

--- a/clean/tasks/aws.yml
+++ b/clean/tasks/aws.yml
@@ -3,7 +3,7 @@
 - name: clean/aws | clean vms
   block:
     - name: clean/aws | Remove instances termination protection
-      ec2:
+      ec2_instance:
         aws_access_key: "{{cluster_vars[buildenv].aws_access_key}}"
         aws_secret_key: "{{cluster_vars[buildenv].aws_secret_key}}"
         region: "{{ cluster_vars.region }}"
@@ -14,7 +14,7 @@
       with_items: "{{ hosts_to_clean | json_query(\"[].{instance_id:instance_id, instance_state: instance_state}\") | default([]) }}"
 
     - name: clean/aws | Delete VMs
-      ec2:
+      ec2_instance:
         aws_access_key: "{{cluster_vars[buildenv].aws_access_key}}"
         aws_secret_key: "{{cluster_vars[buildenv].aws_secret_key}}"
         region: "{{ cluster_vars.region }}"

--- a/clean/tasks/aws.yml
+++ b/clean/tasks/aws.yml
@@ -8,7 +8,7 @@
         aws_secret_key: "{{cluster_vars[buildenv].aws_secret_key}}"
         region: "{{ cluster_vars.region }}"
         state: "{{ item.instance_state }}"
-        termination_protection: "no"
+        termination_protection: false
         instance_ids: ["{{ item.instance_id }}"]
         ec2_url: "{{ cluster_vars.aws_endpoint_url | default(omit) }}"
       with_items: "{{ hosts_to_clean | json_query(\"[].{instance_id:instance_id, instance_state: instance_state}\") | default([]) }}"

--- a/cluster_hosts/tasks/get_cluster_hosts_state_aws.yml
+++ b/cluster_hosts/tasks/get_cluster_hosts_state_aws.yml
@@ -4,7 +4,7 @@
   ec2_instance_info:
     filters:
       "tag:cluster_name": "{{cluster_name}}"
-      "instance-state-name": ["running", "stopped"]
+      "instance-state-name": ["running", "pending", "stopped"]
     aws_access_key: "{{cluster_vars[buildenv].aws_access_key}}"
     aws_secret_key: "{{cluster_vars[buildenv].aws_secret_key}}"
     region: "{{cluster_vars.region}}"

--- a/cluster_hosts/tasks/get_cluster_hosts_state_aws.yml
+++ b/cluster_hosts/tasks/get_cluster_hosts_state_aws.yml
@@ -4,8 +4,7 @@
   ec2_instance_info:
     filters:
       "tag:cluster_name": "{{cluster_name}}"
-      "instance-state-name": ["running", "stopped"]
-#      "instance-state-name": ["running", "pending", "stopped"]
+      "instance-state-name": ["running", "pending", "stopped"]
     aws_access_key: "{{cluster_vars[buildenv].aws_access_key}}"
     aws_secret_key: "{{cluster_vars[buildenv].aws_secret_key}}"
     region: "{{cluster_vars.region}}"

--- a/cluster_hosts/tasks/get_cluster_hosts_state_aws.yml
+++ b/cluster_hosts/tasks/get_cluster_hosts_state_aws.yml
@@ -4,7 +4,8 @@
   ec2_instance_info:
     filters:
       "tag:cluster_name": "{{cluster_name}}"
-      "instance-state-name": ["running", "pending", "stopped"]
+      "instance-state-name": ["running", "stopped"]
+#      "instance-state-name": ["running", "pending", "stopped"]
     aws_access_key: "{{cluster_vars[buildenv].aws_access_key}}"
     aws_secret_key: "{{cluster_vars[buildenv].aws_secret_key}}"
     region: "{{cluster_vars.region}}"

--- a/config/handlers/main.yml
+++ b/config/handlers/main.yml
@@ -14,3 +14,11 @@
     name: metricbeat
     state: restarted
     enabled: yes
+
+
+- name: Chrony | Restart and enable chrony
+  become: yes
+  service:
+    name: chronyd
+    state: restarted
+    enabled: yes

--- a/config/tasks/chrony.yml
+++ b/config/tasks/chrony.yml
@@ -1,0 +1,43 @@
+---
+
+- name: Chrony | Install and Configure - Ubuntu
+  block:
+    - name: Chrony | Ubuntu install
+      become: yes
+      apt:
+        name: chrony
+        update_cache: yes
+        state: present
+  when: ansible_os_family == "Debian"
+
+- name: Chrony | Install and Configure - CentOS
+  block:
+    - name: Chrony | CentOS install
+      become: yes
+      yum:
+        name: chrony
+        state: present
+  when: ansible_os_family == "RedHat"
+
+- name: Configure Chrony
+  become: yes
+  copy:
+    dest: "/etc/{% if ansible_os_family == 'Debian'%}chrony/{% endif %}chrony.conf"
+    backup: yes
+    content: |-
+      {% for ntp_server in ntp_servers %}
+      server {{ ntp_server }}
+      {% endfor %}
+
+      {% if ansible_os_family == 'RedHat' %}
+      keyfile /etc/chrony.keys
+      {% else %}
+      keyfile /etc/chrony/chrony.keys
+      {% endif %}
+
+      driftfile /var/lib/chrony/chrony.drift
+      logdir /var/log/chrony
+      rtcsync
+      makestep 1 3
+  notify:
+    - Chrony | Restart and enable chrony

--- a/config/tasks/create_dns_a.yml
+++ b/config/tasks/create_dns_a.yml
@@ -2,7 +2,7 @@
 
 - block:
     - name: config/dns/a/nsupdate | create/update A records in bind (nsupdate)
-      nsupdate:
+      community.general.nsupdate:
         key_name: "{{cluster_vars[buildenv].nsupdate_cfg.key_name | default(bind9[buildenv].key_name)}}"
         key_secret: "{{cluster_vars[buildenv].nsupdate_cfg.key_secret | default(bind9[buildenv].key_secret)}}"
         server: "{{cluster_vars[buildenv].nsupdate_cfg.server | default(bind9[buildenv].server)}}"

--- a/config/tasks/main.yml
+++ b/config/tasks/main.yml
@@ -85,6 +85,10 @@
   include_tasks: cloud_agents.yml
   when: (cloud_agent is defined and cloud_agent)
 
+- name: Install chrony (NTP client)
+  include_tasks: chrony.yml
+  when: chrony_install|bool
+
 - name: Update packages (when pkgupdate is defined)
   include_tasks: pkgupdate.yml
   when: pkgupdate is defined and (pkgupdate == 'always' or (pkgupdate == 'onCreate' and inventory_hostname in (hostvars['localhost'].cluster_hosts_created | json_query('[].hostname'))))

--- a/create/tasks/create_aws.yml
+++ b/create/tasks/create_aws.yml
@@ -129,7 +129,7 @@
       until: r__async_status__ec2_vol.finished
       delay: 3
       retries: 300
-      with_items: "{{r__ec2_instance_vol.results}}"
+      with_items: "{{r__ec2_vol.results}}"
 
 #    - name: create/aws | r__async_status__ec2_vol
 #      debug: msg={{r__async_status__ec2_vol}}

--- a/create/tasks/create_aws.yml
+++ b/create/tasks/create_aws.yml
@@ -18,7 +18,7 @@
     rules_egress:
       - proto: all
         cidr_ip: 0.0.0.0/0
-  register: r__ec2_group
+  register: r__ec2_instance_group
   when: cluster_vars.secgroup_new | length > 0
 
 - name: create/aws | Create EC2 VMs asynchronously and wait for completion
@@ -33,28 +33,43 @@
       loop: "{{ cluster_hosts_target_denormalised_by_volume | selectattr('auto_volume.src', 'defined') | list }}"
 
     - name: create/aws | Create EC2 VMs asynchronously
-      ec2:
+      ec2_instance:
         aws_access_key: "{{cluster_vars[buildenv].aws_access_key}}"
         aws_secret_key: "{{cluster_vars[buildenv].aws_secret_key}}"
         region: "{{cluster_vars.region}}"
         key_name: "{{cluster_vars[buildenv].key_name}}"
         instance_type: "{{item.flavor}}"
-        instance_profile_name: "{{cluster_vars[buildenv].hosttype_vars[item.hosttype].instance_profile_name | default(cluster_vars.instance_profile_name | default(omit))}}"
+        instance_role: "{{cluster_vars[buildenv].hosttype_vars[item.hosttype].instance_profile_name | default(cluster_vars.instance_profile_name | default(omit))}}"
         instance_initiated_shutdown_behavior: "{{cluster_vars[buildenv].hosttype_vars[item.hosttype].instance_initiated_shutdown_behavior | default(omit)}}"
-        spot_price: "{{cluster_vars[buildenv].hosttype_vars[item.hosttype].spot.spot_price | default(omit)}}"
-        spot_wait_timeout: "{{cluster_vars[buildenv].hosttype_vars[item.hosttype].spot.spot_wait_timeout | default(10800)}}"    #3 hours
-        spot_launch_group: "{{cluster_vars[buildenv].hosttype_vars[item.hosttype].spot.spot_launch_group | default(omit)}}"
-        spot_type: "{{cluster_vars[buildenv].hosttype_vars[item.hosttype].spot.spot_type | default('persistent')}}"
-        image: "{{ item.image }}"
+#        spot_price: "{{cluster_vars[buildenv].hosttype_vars[item.hosttype].spot.spot_price | default(omit)}}" # spot instance tpyes cannot be used with the ec2_instance module at this time
+#        spot_wait_timeout: "{{cluster_vars[buildenv].hosttype_vars[item.hosttype].spot.spot_wait_timeout | default(10800)}}"    #3 hours
+#        spot_launch_group: "{{cluster_vars[buildenv].hosttype_vars[item.hosttype].spot.spot_launch_group | default(omit)}}"
+#        spot_type: "{{cluster_vars[buildenv].hosttype_vars[item.hosttype].spot.spot_type | default('persistent')}}"
+        image_id: "{{ item.image }}"
         vpc_subnet_id: "{{item.vpc_subnet_id}}"
-        assign_public_ip: "{{cluster_vars.assign_public_ip}}"
-        group: "{{ cluster_vars.secgroups_existing }} {%- if cluster_vars.secgroup_new | length > 0 -%} + {{ ([r__ec2_group.group_name | default()] | default())}} {%- endif -%}"
+        network:
+          assign_public_ip: "{{cluster_vars.assign_public_ip}}"
+        security_groups: "{{ cluster_vars.secgroups_existing }} {%- if cluster_vars.secgroup_new | length > 0 -%} + {{ ([r__ec2_instance_group.group_name | default()] | default())}} {%- endif -%}"
         wait: yes
-        instance_tags: "{{ _instance_tags | combine(cluster_vars.custom_tagslabels | default({})) }}"
+        tags: "{{ _instance_tags | combine(cluster_vars.custom_tagslabels | default({})) }}"
         termination_protection: "{{cluster_vars[buildenv].termination_protection}}"
         user_data: "{{ cluster_vars.user_data | default(omit) }}"
-        volumes: "{{ item.auto_volumes | selectattr('src', 'undefined') | list | default([]) }}"
-        count_tag: { Name: "{{item.hostname}}" }
+        volumes: |
+          {%- set res = [] -%}
+          {%- for vol in item.auto_volumes -%}
+            {%- if 'src' not in vol -%}
+              {%- if 'volume_type' in vol and vol.volume_type == 'ephemeral' -%}
+                {%- set _dummy = res.append({ 'device_name': vol.device_name, 'volume_name': vol.ephemeral }) -%}
+              {%- else -%}
+                {%- set _dummy = res.append({ 'device_name': vol.device_name, 'ebs': {'volume_type': vol.volume_type, 'volume_size': vol.volume_size } }) -%}
+                {%- if 'iops' in vol -%} {%- set _dummy = res[res|length-1].ebs.update({'iops': vol.iops}) -%} {%- endif -%}
+                {%- if 'snapshot' in vol -%} {%- set _dummy = res[res|length-1].ebs.update({'snapshot_id': vol.snapshot}) -%} {%- endif -%}
+                {%- if 'encrypted' in vol -%} {%- set _dummy = res[res|length-1].ebs.update({'encrypted': vol.encrypted}) -%} {%- endif -%}
+                {%- if 'delete_on_termination' in vol -%} {%- set _dummy = res[res|length-1].ebs.update({'delete_on_termination': vol.delete_on_termination}) -%} {%- endif -%}
+              {%- endif -%}
+            {%- endif -%}
+          {%- endfor %}
+          {{ res }}
         exact_count: 1
         ec2_url: "{{ cluster_vars.aws_endpoint_url | default(omit) }}"
       vars:
@@ -72,7 +87,7 @@
       loop: "{{ cluster_hosts_target }}"
       async: 7200
       poll: 0
-      register: r__ec2
+      register: r__ec2_instance
 
     - name: create/aws | Wait for aws instance creation to complete
       async_status: { jid: "{{ item.ansible_job_id }}" }
@@ -80,7 +95,7 @@
       until: r__async_status__ec2.finished
       delay: 3
       retries: 300
-      with_items: "{{r__ec2.results}}"
+      with_items: "{{r__ec2_instance.results}}"
 
 #    - name: create/aws | r__async_status__ec2.results
 #      debug: msg={{r__async_status__ec2.results}}
@@ -106,7 +121,7 @@
       loop: "{{ cluster_hosts_target_denormalised_by_volume | selectattr('auto_volume.src', 'defined') | list }}"
       async: 7200
       poll: 0
-      register: r__ec2_vol
+      register: r__ec2_instance_vol
 
     - name: create/aws | Wait for volume creation/ attachment to complete
       async_status: { jid: "{{ item.ansible_job_id }}" }
@@ -114,7 +129,7 @@
       until: r__async_status__ec2_vol.finished
       delay: 3
       retries: 300
-      with_items: "{{r__ec2_vol.results}}"
+      with_items: "{{r__ec2_instance_vol.results}}"
 
 #    - name: create/aws | r__async_status__ec2_vol
 #      debug: msg={{r__async_status__ec2_vol}}

--- a/create/tasks/create_aws.yml
+++ b/create/tasks/create_aws.yml
@@ -70,7 +70,7 @@
             {%- endif -%}
           {%- endfor %}
           {{ res }}
-        filters: { "tag:Name": "{{item.hostname}}", "instance-state-name": ["running", "pending"] }
+#        filters: { "tag:Name": "{{item.hostname}}", "instance-state-name": ["running", "pending"] }
         exact_count: 1
         ec2_url: "{{ cluster_vars.aws_endpoint_url | default(omit) }}"
       vars:
@@ -90,8 +90,8 @@
       poll: 0
       register: r__ec2
 
-    - name: ec2_instance keys debug check
-      debug: msg={{aws_access_key}}
+#    - name: ec2_instance keys debug check
+#      debug: msg={{aws_access_key}}
 
     - name: create/aws | Wait for aws instance creation to complete
       async_status: { jid: "{{ item.ansible_job_id }}" }

--- a/create/tasks/create_aws.yml
+++ b/create/tasks/create_aws.yml
@@ -70,7 +70,7 @@
             {%- endif -%}
           {%- endfor %}
           {{ res }}
-#        filters: { "tag:Name": "{{item.hostname}}", "instance-state-name": ["running", "pending"] }
+        filters: { "tag:Name": "{{item.hostname}}", "instance-state-name": ["running", "pending"] }
         exact_count: 1
         ec2_url: "{{ cluster_vars.aws_endpoint_url | default(omit) }}"
       vars:

--- a/create/tasks/create_aws.yml
+++ b/create/tasks/create_aws.yml
@@ -33,7 +33,7 @@
       loop: "{{ cluster_hosts_target_denormalised_by_volume | selectattr('auto_volume.src', 'defined') | list }}"
 
     - name: create/aws | Create EC2 VMs asynchronously
-      ec2_instance:
+      amazon.aws.ec2_instance:
         aws_access_key: "{{cluster_vars[buildenv].aws_access_key}}"
         aws_secret_key: "{{cluster_vars[buildenv].aws_secret_key}}"
         region: "{{cluster_vars.region}}"
@@ -90,6 +90,9 @@
       poll: 0
       register: r__ec2
 
+    - name: ec2_instance keys debug check
+      debug: msg={{aws_access_key}}
+
     - name: create/aws | Wait for aws instance creation to complete
       async_status: { jid: "{{ item.ansible_job_id }}" }
       register: r__async_status__ec2
@@ -98,8 +101,8 @@
       retries: 300
       with_items: "{{r__ec2.results}}"
 
-#    - name: create/aws | r__async_status__ec2.results
-#      debug: msg={{r__async_status__ec2.results}}
+    - name: create/aws | r__async_status__ec2.results
+      debug: msg={{r__async_status__ec2.results}}
 
     - name: create/aws | Set a fact containing the newly-created hosts
       set_fact:

--- a/create/tasks/create_aws.yml
+++ b/create/tasks/create_aws.yml
@@ -70,6 +70,7 @@
             {%- endif -%}
           {%- endfor %}
           {{ res }}
+        filters: { "tag:Name": "{{item.hostname}}", "instance-state-name": ["running", "pending"] }
         exact_count: 1
         ec2_url: "{{ cluster_vars.aws_endpoint_url | default(omit) }}"
       vars:

--- a/create/tasks/create_aws.yml
+++ b/create/tasks/create_aws.yml
@@ -49,7 +49,7 @@
         vpc_subnet_id: "{{item.vpc_subnet_id}}"
         network:
           assign_public_ip: "{{cluster_vars.assign_public_ip | bool}}"
-        security_groups: "{{ cluster_vars.secgroups_existing }} {%- if cluster_vars.secgroup_new | length > 0 -%} + {{ ([r__ec2_instance_group.group_name | default()] | default())}} {%- endif -%}"
+        security_groups: "{{ cluster_vars.secgroups_existing }} {%- if cluster_vars.secgroup_new | length > 0 -%} + {{ ([r__ec2_group.group_name | default()] | default())}} {%- endif -%}"
         wait: yes
         tags: "{{ _instance_tags | combine(cluster_vars.custom_tagslabels | default({})) }}"
         termination_protection: "{{cluster_vars[buildenv].termination_protection}}"

--- a/create/tasks/create_aws.yml
+++ b/create/tasks/create_aws.yml
@@ -18,7 +18,7 @@
     rules_egress:
       - proto: all
         cidr_ip: 0.0.0.0/0
-  register: r__ec2_instance_group
+  register: r__ec2_group
   when: cluster_vars.secgroup_new | length > 0
 
 - name: create/aws | Create EC2 VMs asynchronously and wait for completion
@@ -87,7 +87,7 @@
       loop: "{{ cluster_hosts_target }}"
       async: 7200
       poll: 0
-      register: r__ec2_instance
+      register: r__ec2
 
     - name: create/aws | Wait for aws instance creation to complete
       async_status: { jid: "{{ item.ansible_job_id }}" }
@@ -95,7 +95,7 @@
       until: r__async_status__ec2.finished
       delay: 3
       retries: 300
-      with_items: "{{r__ec2_instance.results}}"
+      with_items: "{{r__ec2.results}}"
 
 #    - name: create/aws | r__async_status__ec2.results
 #      debug: msg={{r__async_status__ec2.results}}
@@ -121,7 +121,7 @@
       loop: "{{ cluster_hosts_target_denormalised_by_volume | selectattr('auto_volume.src', 'defined') | list }}"
       async: 7200
       poll: 0
-      register: r__ec2_instance_vol
+      register: r__ec2_vol
 
     - name: create/aws | Wait for volume creation/ attachment to complete
       async_status: { jid: "{{ item.ansible_job_id }}" }

--- a/create/tasks/create_aws.yml
+++ b/create/tasks/create_aws.yml
@@ -48,7 +48,7 @@
         image_id: "{{ item.image }}"
         vpc_subnet_id: "{{item.vpc_subnet_id}}"
         network:
-          assign_public_ip: "{{cluster_vars.assign_public_ip}}"
+          assign_public_ip: "{{cluster_vars.assign_public_ip | bool}}"
         security_groups: "{{ cluster_vars.secgroups_existing }} {%- if cluster_vars.secgroup_new | length > 0 -%} + {{ ([r__ec2_instance_group.group_name | default()] | default())}} {%- endif -%}"
         wait: yes
         tags: "{{ _instance_tags | combine(cluster_vars.custom_tagslabels | default({})) }}"

--- a/create/tasks/create_aws.yml
+++ b/create/tasks/create_aws.yml
@@ -90,9 +90,6 @@
       poll: 0
       register: r__ec2
 
-#    - name: ec2_instance keys debug check
-#      debug: msg={{aws_access_key}}
-
     - name: create/aws | Wait for aws instance creation to complete
       async_status: { jid: "{{ item.ansible_job_id }}" }
       register: r__async_status__ec2

--- a/create/tasks/create_aws.yml
+++ b/create/tasks/create_aws.yml
@@ -51,6 +51,7 @@
           assign_public_ip: "{{cluster_vars.assign_public_ip | bool}}"
         security_groups: "{{ cluster_vars.secgroups_existing }} {%- if cluster_vars.secgroup_new | length > 0 -%} + {{ ([r__ec2_group.group_name | default()] | default())}} {%- endif -%}"
         wait: yes
+        state: running
         tags: "{{ _instance_tags | combine(cluster_vars.custom_tagslabels | default({})) }}"
         termination_protection: "{{cluster_vars[buildenv].termination_protection}}"
         user_data: "{{ cluster_vars.user_data | default(omit) }}"

--- a/redeploy/_scheme_rmvm_keepdisk_rollback/tasks/preflight.yml
+++ b/redeploy/_scheme_rmvm_keepdisk_rollback/tasks/preflight.yml
@@ -5,7 +5,7 @@
     - block:
         - name: Preflight check | get ec2_instance_info for current disk information
           ec2_instance_info:
-            filters: { "instance-state-name": [ "running", "stopped" ], "tag:cluster_name": "{{cluster_name}}", "tag:lifecycle_state": "current" }
+            filters: { "instance-state-name": [ "running", "pending", "stopped" ], "tag:cluster_name": "{{cluster_name}}", "tag:lifecycle_state": "current" }
             aws_access_key: "{{cluster_vars[buildenv].aws_access_key}}"
             aws_secret_key: "{{cluster_vars[buildenv].aws_secret_key}}"
             region: "{{cluster_vars.region}}"

--- a/redeploy/_scheme_rmvm_keepdisk_rollback/tasks/preflight.yml
+++ b/redeploy/_scheme_rmvm_keepdisk_rollback/tasks/preflight.yml
@@ -5,7 +5,8 @@
     - block:
         - name: Preflight check | get ec2_instance_info for current disk information
           ec2_instance_info:
-            filters: { "instance-state-name": [ "running", "pending", "stopped" ], "tag:cluster_name": "{{cluster_name}}", "tag:lifecycle_state": "current" }
+#            filters: { "instance-state-name": [ "running", "pending", "stopped" ], "tag:cluster_name": "{{cluster_name}}", "tag:lifecycle_state": "current" }
+            filters: { "instance-state-name": [ "running", "stopped" ], "tag:cluster_name": "{{cluster_name}}", "tag:lifecycle_state": "current" }
             aws_access_key: "{{cluster_vars[buildenv].aws_access_key}}"
             aws_secret_key: "{{cluster_vars[buildenv].aws_secret_key}}"
             region: "{{cluster_vars.region}}"

--- a/redeploy/_scheme_rmvm_keepdisk_rollback/tasks/preflight.yml
+++ b/redeploy/_scheme_rmvm_keepdisk_rollback/tasks/preflight.yml
@@ -5,8 +5,7 @@
     - block:
         - name: Preflight check | get ec2_instance_info for current disk information
           ec2_instance_info:
-#            filters: { "instance-state-name": [ "running", "pending", "stopped" ], "tag:cluster_name": "{{cluster_name}}", "tag:lifecycle_state": "current" }
-            filters: { "instance-state-name": [ "running", "stopped" ], "tag:cluster_name": "{{cluster_name}}", "tag:lifecycle_state": "current" }
+            filters: { "instance-state-name": [ "running", "pending", "stopped" ], "tag:cluster_name": "{{cluster_name}}", "tag:lifecycle_state": "current" }
             aws_access_key: "{{cluster_vars[buildenv].aws_access_key}}"
             aws_secret_key: "{{cluster_vars[buildenv].aws_secret_key}}"
             region: "{{cluster_vars.region}}"


### PR DESCRIPTION
Move from ec2 to `amazon.aws.ec2_instance` module.
volumes structure changed for `ec2_instance`; maintain old syntax in `cluster_defs`.
Spot instances no longer supported

`Chrony` changes showing although already merged