### PR TITLE
[UPDATE] Allow Direction selection and priority config for GCP firewall

### DIFF
--- a/create/tasks/create_gcp.yml
+++ b/create/tasks/create_gcp.yml
@@ -61,6 +61,7 @@
         description: "{{ item.description }}"
         source_ranges: "{{ item.source_ranges | default([]) }}"
         source_tags: "{{ item.source_tags | default([]) }}"
+        direction: "{{ item.direction }}"
         network: "{{r__gcp_compute_network_info['resources'][0]}}"
         auth_kind: "serviceaccount"
         service_account_file: "{{gcp_credentials_file}}"

--- a/create/tasks/create_gcp.yml
+++ b/create/tasks/create_gcp.yml
@@ -61,7 +61,7 @@
         description: "{{ item.description }}"
         source_ranges: "{{ item.source_ranges | default([]) }}"
         source_tags: "{{ item.source_tags | default([]) }}"
-        direction: "{{ item.direction | default(INGRESS) }}"
+        direction: "{{ item.direction | default(omit) }}"
         network: "{{r__gcp_compute_network_info['resources'][0]}}"
         auth_kind: "serviceaccount"
         service_account_file: "{{gcp_credentials_file}}"

--- a/create/tasks/create_gcp.yml
+++ b/create/tasks/create_gcp.yml
@@ -61,7 +61,7 @@
         description: "{{ item.description }}"
         source_ranges: "{{ item.source_ranges | default([]) }}"
         source_tags: "{{ item.source_tags | default([]) }}"
-        direction: "{{ item.direction }}"
+        direction: "{{ item.direction | default(INGRESS) }}"
         network: "{{r__gcp_compute_network_info['resources'][0]}}"
         auth_kind: "serviceaccount"
         service_account_file: "{{gcp_credentials_file}}"

--- a/create/tasks/create_gcp.yml
+++ b/create/tasks/create_gcp.yml
@@ -62,6 +62,7 @@
         source_ranges: "{{ item.source_ranges | default([]) }}"
         source_tags: "{{ item.source_tags | default([]) }}"
         direction: "{{ item.direction | default(omit) }}"
+        priority: "{{ item.priority | default(omit) }}"
         network: "{{r__gcp_compute_network_info['resources'][0]}}"
         auth_kind: "serviceaccount"
         service_account_file: "{{gcp_credentials_file}}"


### PR DESCRIPTION
Allow GCP firewall rules to be built with the direction parameter and the priority config. https://docs.ansible.com/ansible/latest/collections/google/cloud/gcp_compute_firewall_module.html#parameter-direction
This allows us to set EGRESS or INGRESS. Default will be INGRESS.

https://docs.ansible.com/ansible/latest/collections/google/cloud/gcp_compute_firewall_module.html#parameter-priority
This allows us to set priority. Default will be 1000.