### PR TITLE
[FIX] Allow file override for cloud agents install

### DIFF
--- a/config/tasks/cloud_agents.yml
+++ b/config/tasks/cloud_agents.yml
@@ -30,6 +30,7 @@
         url: "{{ qualys_release_file.location }}"
         dest: "/tmp/{{ cloud_agent.qualys.bin_name }}"
         mode: 0755
+        force: true
 
     - name: cloud_agents | Remove existing Qualys cloud agent pkg Debian
       become: yes
@@ -114,6 +115,7 @@
         url: "{{ tenable_release_file.location }}"
         dest: "/tmp/{{ cloud_agent.tenable.debpackage }}"
         mode: 0755
+        force: true
 
     - name: cloud_agents | Remove existing Tenable Nessus cloud agent pkg Debian
       become: yes


### PR DESCRIPTION
This change helps making sure the latest version of the cloud agent is downloaded and installed 