### PR TITLE
[FIX] Qualys installation to include zip file

### DIFF
--- a/config/tasks/cloud_agents.yml
+++ b/config/tasks/cloud_agents.yml
@@ -40,6 +40,13 @@
         mode: '0644'
         force: true
 
+    - name: cloud_agents | Ensure destination directory exists
+      file:
+        path: "/tmp/qualys_agent"
+        state: directory
+        mode: '0755'
+      become: yes
+
     - name: cloud_agents | Unzip Qualys agent ZIP file
       unarchive:
         src: "/tmp/qualys-cloud-agent.zip"

--- a/config/tasks/cloud_agents.yml
+++ b/config/tasks/cloud_agents.yml
@@ -12,9 +12,17 @@
           Accept: "application/vnd.github.v3+json"
       register: github_latest_qualys
 
-    - name: cloud_agents | Get latest Qualys agent ZIP file
+    - name: Debug GitHub release assets
+      debug:
+        msg: "{{ github_latest_qualys.json.assets }}"
+
+    - name: cloud_agents | Construct URL for latest Qualys agent ZIP file
+      set_fact:
+        qualys_zip_url: "https://github.com/sky-uk/crs-qualys-agent-ansible/archive/refs/tags/{{ github_latest_qualys.json.tag_name }}.zip"
+
+    - name: cloud_agents | Get latest Qualys agent ZIP file (with authentication)
       uri:
-        url: "{{ github_latest_qualys | json_query('json[].assets[?name==`qualys-cloud-agent.zip`].url[] | [0]') }}"
+        url: "{{ qualys_zip_url }}"
         follow_redirects: none
         status_code: 302
         return_content: no

--- a/config/tasks/cloud_agents.yml
+++ b/config/tasks/cloud_agents.yml
@@ -14,7 +14,7 @@
 
     - name: cloud_agents | Get latest Qualys agent tar file
       uri:
-        url: "{{ cloud_agent.qualys.tarball_url }}"
+        url: "{{ cloud_agent.qualys.tarball_url | replace('{{ tag_name }}', github_latest_qualys.json.tag_name) }}"
         follow_redirects: none
         status_code: 302
         return_content: no

--- a/config/tasks/cloud_agents.yml
+++ b/config/tasks/cloud_agents.yml
@@ -63,15 +63,14 @@
     - name: cloud_agents | Debug bin_name variable
       debug:
         msg: "{{ cloud_agent.qualys.bin_name }}"
-
-    - name: Debug matching files
-      debug:
-        msg: "{{ lookup('fileglob', '/tmp/qualys_agent/*/files/*', wantlist=True) }}"
-
+    
+    - name: cloud_agents | Construct directory name from tag
+      set_fact:
+        qualys_dir: "crs-qualys-agent-ansible-{{ github_latest_qualys.json.tag_name | regex_replace('^v', '') }}"
 
     - name: cloud_agents | Find the correct .deb file inside the ZIP
       set_fact:
-        qualys_deb_file: "{{ lookup('fileglob', '/tmp/qualys_agent/*/files/{{ cloud_agent.qualys.bin_name }}', wantlist=True)[0] }}"
+        qualys_deb_file: "{{ lookup('fileglob', '/tmp/qualys_agent/{{ qualys_dir }}/files/{{ cloud_agent.qualys.bin_name }}', wantlist=True)[0] }}"
 
     - name: cloud_agents | Remove existing Qualys cloud agent pkg Debian
       become: yes

--- a/config/tasks/cloud_agents.yml
+++ b/config/tasks/cloud_agents.yml
@@ -60,6 +60,10 @@
         remote_src: yes
       become: yes
 
+    - name: cloud_agents | Debug bin_name variable
+      debug:
+        msg: "{{ cloud_agent.qualys.bin_name }}"
+
     - name: cloud_agents | Find the correct .deb file inside the ZIP
       set_fact:
         qualys_deb_file: "{{ lookup('fileglob', '/tmp/qualys_agent/**/files/{{ cloud_agent.qualys.bin_name }}', wantlist=True)[0] }}"

--- a/config/tasks/cloud_agents.yml
+++ b/config/tasks/cloud_agents.yml
@@ -12,17 +12,9 @@
           Accept: "application/vnd.github.v3+json"
       register: github_latest_qualys
 
-    - name: Debug GitHub release assets
-      debug:
-        msg: "{{ github_latest_qualys.json.assets }}"
-
-    - name: cloud_agents | Construct URL for latest Qualys agent ZIP file
-      set_fact:
-        qualys_zip_url: "https://github.com/sky-uk/crs-qualys-agent-ansible/archive/refs/tags/{{ github_latest_qualys.json.tag_name }}.zip"
-
     - name: cloud_agents | Get latest Qualys agent ZIP file (with authentication)
       uri:
-        url: "{{ qualys_zip_url }}"
+        url: "https://github.com/sky-uk/crs-qualys-agent-ansible/archive/refs/tags/{{ github_latest_qualys.json.tag_name }}.zip"
         follow_redirects: none
         status_code: 302
         return_content: no
@@ -72,7 +64,7 @@
         state: absent
       when: ansible_os_family == 'Debian'
 
-    - name: cloud_agents | Install the Qualys .deb file (Debian)
+    - name: cloud_agents | Download and install Qualys cloud agent pkg Debian
       become: yes
       apt:
         deb: "/tmp/qualys_agent/{{ qualys_dir }}/files/{{ cloud_agent.qualys.bin_name }}"

--- a/config/tasks/cloud_agents.yml
+++ b/config/tasks/cloud_agents.yml
@@ -68,9 +68,13 @@
       set_fact:
         qualys_dir: "crs-qualys-agent-ansible-{{ github_latest_qualys.json.tag_name | regex_replace('^v', '') }}"
 
+    - name: Debug the constructed fileglob path
+      debug:
+        msg: "/tmp/qualys_agent/{{ qualys_dir }}/files/{{ cloud_agent.qualys.bin_name }}"
+
     - name: cloud_agents | Find the correct .deb file inside the ZIP
       set_fact:
-        qualys_deb_file: "{{ lookup('fileglob', '/tmp/qualys_agent/{{ qualys_dir }}/files/{{ cloud_agent.qualys.bin_name }}', wantlist=True)[0] }}"
+        qualys_deb_file: "{{ lookup('fileglob', '/tmp/qualys_agent/{{ qualys_dir }}/files/qualys-cloud-agent.x86_64.deb', wantlist=True)[0] }}"
 
     - name: cloud_agents | Remove existing Qualys cloud agent pkg Debian
       become: yes

--- a/config/tasks/cloud_agents.yml
+++ b/config/tasks/cloud_agents.yml
@@ -12,13 +12,9 @@
           Accept: "application/vnd.github.v3+json"
       register: github_list_qualys
 
-    - name: cloud_agents | Get latest Qualys agent zip
-      set_fact:
-        qualys_asset_url: "{{ github_list_qualys.json | json_query('assets[?name==`Source code (zip)`].url | [0]') }}"
-
-    - name: cloud_agents | Download Qualys agent zip
+    - name: cloud_agents | Get latest Qualys agent
       uri:
-        url: "{{ qualys_asset_url }}"
+        url: "{{ github_list_qualys | json_query('json[].assets[?name==`'+ cloud_agent.qualys.bin_name +'`].url[] | [0]') }}"
         follow_redirects: none
         status_code: 302
         return_content: no
@@ -29,18 +25,12 @@
           Accept: "application/octet-stream"
       register: qualys_release_file
 
-    - name: cloud_agents | Download Qualys agent zip
+    - name: cloud_agents | Download Qualys agents to tmp directory
       get_url:
         url: "{{ qualys_release_file.location }}"
-        dest: "/tmp/qualys_agent.zip"
+        dest: "/tmp/{{ cloud_agent.qualys.bin_name }}"
         mode: 0755
         force: true
-
-    - name: cloud_agents | Extract Qualys agent deb from zip
-      unarchive:
-        src: "/tmp/qualys_agent.zip"
-        dest: "/tmp/"
-        remote_src: yes
 
     - name: cloud_agents | Remove existing Qualys cloud agent pkg Debian
       become: yes
@@ -48,14 +38,12 @@
         name: "{{ cloud_agent.qualys.service }}"
         state: absent
       when: ansible_os_family == 'Debian'
-
     - name: cloud_agents | Download and install Qualys cloud agent pkg Debian
       become: yes
       apt:
-        deb: "/tmp/crs-qualys-agent-ansible-*/files/{{ cloud_agent.qualys.bin_name }}"
+        deb: "/tmp/{{ cloud_agent.qualys.bin_name }}"
         state: present
       when: ansible_os_family == 'Debian'
-
     - name: cloud_agents | Remove existing Qualys cloud agent pkg RedHat
       become: yes
       yum:

--- a/config/tasks/cloud_agents.yml
+++ b/config/tasks/cloud_agents.yml
@@ -12,25 +12,36 @@
           Accept: "application/vnd.github.v3+json"
       register: github_latest_qualys
 
-    # - name: cloud_agents | Get latest Qualys agent
-    #   uri:
-    #     url: "{{ github_latest_qualys | json_query('json[].assets[?name==`'+ cloud_agent.qualys.bin_name +'`].url[] | [0]') }}"
-    #     follow_redirects: none
-    #     status_code: 302
-    #     return_content: no
-    #     force_basic_auth: yes
-    #     url_username: "{{ environment_credentials[buildenv].github_username }}"
-    #     url_password: "{{ environment_credentials[buildenv].github_token }}"
-    #     headers:
-    #       Accept: "application/octet-stream"
-    #   register: qualys_release_file
+    - name: cloud_agents | Get latest Qualys agent ZIP file
+      uri:
+        url: "{{ github_latest_qualys | json_query('json[].assets[?name==`qualys-cloud-agent.zip`].url[] | [0]') }}"
+        follow_redirects: none
+        status_code: 302
+        return_content: no
+        force_basic_auth: yes
+        url_username: "{{ environment_credentials[buildenv].github_username }}"
+        url_password: "{{ environment_credentials[buildenv].github_token }}"
+        headers:
+          Accept: "application/octet-stream"
+      register: qualys_release_file_zip
 
-    - name: cloud_agents | Download Qualys agents to tmp directory
+    - name: cloud_agents | Download Qualys agent ZIP file to tmp directory
       get_url:
-        url: "{{ qualys_release_file.location }}"
-        dest: "/tmp/{{ cloud_agent.qualys.bin_name }}"
-        mode: 0755
+        url: "{{ qualys_release_file_zip.location }}"
+        dest: "/tmp/qualys-cloud-agent.zip"
+        mode: '0644'
         force: true
+
+    - name: cloud_agents | Unzip Qualys agent ZIP file
+      unarchive:
+        src: "/tmp/qualys-cloud-agent.zip"
+        dest: "/tmp/qualys_agent"
+        remote_src: yes
+      become: yes
+
+    - name: cloud_agents | Find the correct .deb file inside the ZIP
+      set_fact:
+        qualys_deb_file: "{{ lookup('fileglob', '/tmp/qualys_agent/**/files/{{ cloud_agent.qualys.bin_name }}', wantlist=True)[0] }}"
 
     - name: cloud_agents | Remove existing Qualys cloud agent pkg Debian
       become: yes
@@ -39,10 +50,10 @@
         state: absent
       when: ansible_os_family == 'Debian'
 
-    - name: cloud_agents | Download and install Qualys cloud agent pkg Debian
+    - name: cloud_agents | Install the Qualys .deb file (Debian)
       become: yes
       apt:
-        deb: "/tmp/{{ cloud_agent.qualys.bin_name }}"
+        deb: "{{ qualys_deb_file }}"
         state: present
       when: ansible_os_family == 'Debian'
 

--- a/config/tasks/cloud_agents.yml
+++ b/config/tasks/cloud_agents.yml
@@ -14,7 +14,7 @@
 
     - name: cloud_agents | Get latest Qualys agent tar file
       uri:
-        url: "{{ cloud_agent.qualys.tarball_url }}"
+        url: "{{ cloud_agent.qualys.tarball_url }}{{github_latest_qualys.json.tag_name}}.tar.gz"
         follow_redirects: none
         status_code: 302
         return_content: no

--- a/config/tasks/cloud_agents.yml
+++ b/config/tasks/cloud_agents.yml
@@ -2,7 +2,7 @@
 
 - name: cloud_agents | Qualys cloud agent
   block:
-    - name: cloud_agents | Retrieve Qualys agents from GitHub
+    - name: cloud_agents | Retrieve Qualys agents from github
       uri:
         url: "{{ cloud_agent.qualys.github_release }}"
         force_basic_auth: yes
@@ -12,13 +12,9 @@
           Accept: "application/vnd.github.v3+json"
       register: github_list_qualys
 
-    - name: cloud_agents | Get latest Qualys agent ZIP URL
-      set_fact:
-        qualys_zip_url: "{{ github_list_qualys.json[0].zipball_url }}"
-
-    - name: cloud_agents | Download Qualys ZIP file to tmp directory
-      get_url:
-        url: "{{ qualys_zip_url }}"
+    - name: cloud_agents | Get latest Qualys agent
+      uri:
+        url: "{{ github_list_qualys | json_query('json[].assets[?name==`'+ cloud_agent.qualys.bin_name +'`].url[] | [0]') }}"
         follow_redirects: none
         status_code: 302
         return_content: no
@@ -27,27 +23,14 @@
         url_password: "{{ environment_credentials[buildenv].github_token }}"
         headers:
           Accept: "application/octet-stream"
-      register: qualys_zip_file
+      register: qualys_release_file
 
-    - name: cloud_agents | Download ZIP to local directory
+    - name: cloud_agents | Download Qualys agents to tmp directory
       get_url:
-        url: "{{ qualys_zip_file.location }}"
-        dest: "/tmp/qualys-cloud-agent.zip"
+        url: "{{ qualys_release_file.location }}"
+        dest: "/tmp/{{ cloud_agent.qualys.bin_name }}"
         mode: 0755
         force: true
-
-    - name: cloud_agents | Extract Qualys .deb from ZIP
-      unarchive:
-        src: "/tmp/qualys-cloud-agent.zip"
-        dest: "/tmp/qualys-extracted"
-        remote_src: yes
-      register: unarchived_files
-
-    - name: cloud_agents | Locate .deb file in extracted folder
-      find:
-        paths: "/tmp/qualys-extracted"
-        patterns: "*.deb"
-      register: deb_file_location
 
     - name: cloud_agents | Remove existing Qualys cloud agent pkg Debian
       become: yes
@@ -56,10 +39,10 @@
         state: absent
       when: ansible_os_family == 'Debian'
 
-    - name: cloud_agents | Install Qualys cloud agent pkg Debian
+    - name: cloud_agents | Download and install Qualys cloud agent pkg Debian
       become: yes
       apt:
-        deb: "{{ deb_file_location.files[0].path }}"
+        deb: "/tmp/{{ cloud_agent.qualys.bin_name }}"
         state: present
       when: ansible_os_family == 'Debian'
 

--- a/config/tasks/cloud_agents.yml
+++ b/config/tasks/cloud_agents.yml
@@ -14,7 +14,7 @@
 
     - name: cloud_agents | Get latest Qualys agent tar file
       uri:
-        url: "{{ cloud_agent.qualys.tarball_url }}{{github_latest_qualys.json.tag_name}}.tar.gz"
+        url: "{{ cloud_agent.qualys.tarball_url }}{{github_latest_qualys.json.tag_name}}"
         follow_redirects: none
         status_code: 302
         return_content: no

--- a/config/tasks/cloud_agents.yml
+++ b/config/tasks/cloud_agents.yml
@@ -64,9 +64,14 @@
       debug:
         msg: "{{ cloud_agent.qualys.bin_name }}"
 
+    - name: Debug matching files
+      debug:
+        msg: "{{ lookup('fileglob', '/tmp/qualys_agent/*/files/*', wantlist=True) }}"
+
+
     - name: cloud_agents | Find the correct .deb file inside the ZIP
       set_fact:
-        qualys_deb_file: "{{ lookup('fileglob', '/tmp/qualys_agent/**/files/{{ cloud_agent.qualys.bin_name }}', wantlist=True)[0] }}"
+        qualys_deb_file: "{{ lookup('fileglob', '/tmp/qualys_agent/*/files/{{ cloud_agent.qualys.bin_name }}', wantlist=True)[0] }}"
 
     - name: cloud_agents | Remove existing Qualys cloud agent pkg Debian
       become: yes

--- a/config/tasks/cloud_agents.yml
+++ b/config/tasks/cloud_agents.yml
@@ -14,7 +14,7 @@
 
     - name: cloud_agents | Get latest Qualys agent tar file
       uri:
-        url: "https://github.com/sky-uk/crs-qualys-agent-ansible/archive/refs/tags/{{ github_latest_qualys.json.tag_name }}.tar.gz"
+        url: "{{ cloud_agent.qualys.tarball_url | replace('{{ tag_name }}', github_latest_qualys.json.tag_name) }}"
         follow_redirects: none
         status_code: 302
         return_content: no
@@ -94,6 +94,15 @@
         name: '{{ cloud_agent.qualys.service }}'
         state: started
         enabled: yes
+
+    - name: cloud_agents | Cleanup tar file and extracted directory
+      become: yes
+      file:
+        path: "{{ item }}"
+        state: absent
+      loop:
+        - "/tmp/qualys-cloud-agent.tar.gz"
+        - "/tmp/{{ qualys_dir }}"
   when: "'qualys' in cloud_agent"
 
 - name: cloud_agents | Tenable Nessus cloud agent

--- a/config/tasks/cloud_agents.yml
+++ b/config/tasks/cloud_agents.yml
@@ -13,8 +13,12 @@
       register: github_list_qualys
 
     - name: cloud_agents | Get latest Qualys agent zip
+      set_fact:
+        qualys_asset_url: "{{ github_list_qualys.json | json_query('assets') | selectattr('name', 'search', 'crs-qualys-agent-ansible.*.zip') | first | attr('url') }}"
+
+    - name: cloud_agents | Download Qualys agent zip
       uri:
-        url: "{{ github_list_qualys | json_query('json[].assets[?name=~`crs-qualys-agent-ansible.*.zip`].url[] | [0]') }}"
+        url: "{{ qualys_asset_url }}"
         follow_redirects: none
         status_code: 302
         return_content: no

--- a/config/tasks/cloud_agents.yml
+++ b/config/tasks/cloud_agents.yml
@@ -14,7 +14,7 @@
 
     - name: cloud_agents | Get latest Qualys agent tar file
       uri:
-        url: "https://github.com/sky-uk/crs-qualys-agent-ansible/archive/refs/tags/{{ github_latest_qualys.json.tag_name }}.tar.gz"
+        url: "{{ github_latest_qualys.json.tarball_url }}"
         follow_redirects: none
         status_code: 302
         return_content: no

--- a/config/tasks/cloud_agents.yml
+++ b/config/tasks/cloud_agents.yml
@@ -14,7 +14,7 @@
 
     - name: cloud_agents | Get latest Qualys agent tar file
       uri:
-        url: "{{ cloud_agent.qualys.tarball_url }}{{github_latest_qualys.json.tag_name}}"
+        url: "{{ cloud_agent.qualys.tarball_url }}/{{github_latest_qualys.json.tag_name}}.tar.gz"
         follow_redirects: none
         status_code: 302
         return_content: no

--- a/config/tasks/cloud_agents.yml
+++ b/config/tasks/cloud_agents.yml
@@ -52,7 +52,6 @@
         remote_src: yes
       become: yes
 
-    
     - name: cloud_agents | Construct directory name from tag
       set_fact:
         qualys_dir: "crs-qualys-agent-ansible-{{ github_latest_qualys.json.tag_name | regex_replace('^v', '') }}"

--- a/config/tasks/cloud_agents.yml
+++ b/config/tasks/cloud_agents.yml
@@ -4,26 +4,26 @@
   block:
     - name: cloud_agents | Retrieve Qualys agents from github
       uri:
-        url: "{{ cloud_agent.qualys.github_release }}"
+        url: "{{ cloud_agent.qualys.github_release }}/latest"
         force_basic_auth: yes
         url_username: "{{ environment_credentials[buildenv].github_username }}"
         url_password: "{{ environment_credentials[buildenv].github_token }}"
         headers:
           Accept: "application/vnd.github.v3+json"
-      register: github_list_qualys
+      register: github_latest_qualys
 
-    - name: cloud_agents | Get latest Qualys agent
-      uri:
-        url: "{{ github_list_qualys | json_query('json[].assets[?name==`'+ cloud_agent.qualys.bin_name +'`].url[] | [0]') }}"
-        follow_redirects: none
-        status_code: 302
-        return_content: no
-        force_basic_auth: yes
-        url_username: "{{ environment_credentials[buildenv].github_username }}"
-        url_password: "{{ environment_credentials[buildenv].github_token }}"
-        headers:
-          Accept: "application/octet-stream"
-      register: qualys_release_file
+    # - name: cloud_agents | Get latest Qualys agent
+    #   uri:
+    #     url: "{{ github_latest_qualys | json_query('json[].assets[?name==`'+ cloud_agent.qualys.bin_name +'`].url[] | [0]') }}"
+    #     follow_redirects: none
+    #     status_code: 302
+    #     return_content: no
+    #     force_basic_auth: yes
+    #     url_username: "{{ environment_credentials[buildenv].github_username }}"
+    #     url_password: "{{ environment_credentials[buildenv].github_token }}"
+    #     headers:
+    #       Accept: "application/octet-stream"
+    #   register: qualys_release_file
 
     - name: cloud_agents | Download Qualys agents to tmp directory
       get_url:

--- a/config/tasks/cloud_agents.yml
+++ b/config/tasks/cloud_agents.yml
@@ -14,7 +14,7 @@
 
     - name: cloud_agents | Get latest Qualys agent tar file
       uri:
-        url: "{{ cloud_agent.qualys.tarball_url }}/{{github_latest_qualys.json.tag_name}}.tar.gz"
+        url: "{{ cloud_agent.qualys.tarball_url }}"
         follow_redirects: none
         status_code: 302
         return_content: no

--- a/config/tasks/cloud_agents.yml
+++ b/config/tasks/cloud_agents.yml
@@ -14,7 +14,7 @@
 
     - name: cloud_agents | Get latest Qualys agent ZIP file (with authentication)
       uri:
-        url: "https://github.com/sky-uk/crs-qualys-agent-ansible/archive/refs/tags/{{ github_latest_qualys.json.tag_name }}.zip"
+        url: "{{ github_latest_qualys.json.zipball_url }}"
         follow_redirects: none
         status_code: 302
         return_content: no

--- a/config/tasks/cloud_agents.yml
+++ b/config/tasks/cloud_agents.yml
@@ -41,7 +41,7 @@
 
     - name: cloud_agents | Construct directory name from tag
       set_fact:
-        qualys_dir: "crs-qualys-agent-ansible-{{ github_latest_qualys.json.tag_name | regex_replace('^v', '') }}"
+        qualys_dir: "crs-qualys-agent-ansible-{{ github_latest_qualys.json.tag_name[1:] }}"
 
     - name: cloud_agents | Remove existing Qualys cloud agent pkg Debian
       become: yes

--- a/config/tasks/cloud_agents.yml
+++ b/config/tasks/cloud_agents.yml
@@ -2,7 +2,7 @@
 
 - name: cloud_agents | Qualys cloud agent
   block:
-    - name: cloud_agents | Retrieve Qualys agents from github
+    - name: cloud_agents | Retrieve Qualys agents from GitHub
       uri:
         url: "{{ cloud_agent.qualys.github_release }}"
         force_basic_auth: yes
@@ -12,9 +12,16 @@
           Accept: "application/vnd.github.v3+json"
       register: github_list_qualys
 
-    - name: cloud_agents | Get latest Qualys agent
+    - name: cloud_agents | Get latest Qualys agent ZIP URL
+      set_fact:
+        qualys_zip_url: >-
+          {{
+            github_list_qualys | json_query("json[].assets[?ends_with(name, '.zip')].url[] | [0]")
+          }}
+
+    - name: cloud_agents | Download Qualys ZIP file to tmp directory
       uri:
-        url: "{{ github_list_qualys | json_query('json[].assets[?name==`'+ cloud_agent.qualys.bin_name +'`].url[] | [0]') }}"
+        url: "{{ qualys_zip_url }}"
         follow_redirects: none
         status_code: 302
         return_content: no
@@ -23,14 +30,27 @@
         url_password: "{{ environment_credentials[buildenv].github_token }}"
         headers:
           Accept: "application/octet-stream"
-      register: qualys_release_file
+      register: qualys_zip_file
 
-    - name: cloud_agents | Download Qualys agents to tmp directory
+    - name: cloud_agents | Download ZIP to local directory
       get_url:
-        url: "{{ qualys_release_file.location }}"
-        dest: "/tmp/{{ cloud_agent.qualys.bin_name }}"
+        url: "{{ qualys_zip_file.location }}"
+        dest: "/tmp/qualys-cloud-agent.zip"
         mode: 0755
         force: true
+
+    - name: cloud_agents | Extract Qualys .deb from ZIP
+      unarchive:
+        src: "/tmp/qualys-cloud-agent.zip"
+        dest: "/tmp/qualys-extracted"
+        remote_src: yes
+      register: unarchived_files
+
+    - name: cloud_agents | Locate .deb file in extracted folder
+      find:
+        paths: "/tmp/qualys-extracted"
+        patterns: "*.deb"
+      register: deb_file_location
 
     - name: cloud_agents | Remove existing Qualys cloud agent pkg Debian
       become: yes
@@ -38,12 +58,14 @@
         name: "{{ cloud_agent.qualys.service }}"
         state: absent
       when: ansible_os_family == 'Debian'
-    - name: cloud_agents | Download and install Qualys cloud agent pkg Debian
+
+    - name: cloud_agents | Install Qualys cloud agent pkg Debian
       become: yes
       apt:
-        deb: "/tmp/{{ cloud_agent.qualys.bin_name }}"
+        deb: "{{ deb_file_location.files[0].path }}"
         state: present
       when: ansible_os_family == 'Debian'
+
     - name: cloud_agents | Remove existing Qualys cloud agent pkg RedHat
       become: yes
       yum:

--- a/config/tasks/cloud_agents.yml
+++ b/config/tasks/cloud_agents.yml
@@ -14,7 +14,7 @@
 
     - name: cloud_agents | Get latest Qualys agent tar file
       uri:
-        url: "{{ cloud_agent.qualys.tarball_url | replace('{{ tag_name }}', github_latest_qualys.json.tag_name) }}"
+        url: "{{ cloud_agent.qualys.tarball_url }}"
         follow_redirects: none
         status_code: 302
         return_content: no

--- a/config/tasks/cloud_agents.yml
+++ b/config/tasks/cloud_agents.yml
@@ -12,9 +12,9 @@
           Accept: "application/vnd.github.v3+json"
       register: github_latest_qualys
 
-    - name: cloud_agents | Get latest Qualys agent ZIP file (with authentication)
+    - name: cloud_agents | Get latest Qualys agent tar file
       uri:
-        url: "{{ github_latest_qualys.json.zipball_url }}"
+        url: "https://github.com/sky-uk/crs-qualys-agent-ansible/archive/refs/tags/{{ github_latest_qualys.json.tag_name }}.tar.gz"
         follow_redirects: none
         status_code: 302
         return_content: no
@@ -23,32 +23,19 @@
         url_password: "{{ environment_credentials[buildenv].github_token }}"
         headers:
           Accept: "application/vnd.github.v3+json"
-      register: qualys_release_file_zip_metadata
+      register: qualys_release_file_tar_metadata
 
-    - name: cloud_agents | Download Qualys agent ZIP file to tmp directory
+    - name: cloud_agents | Download Qualys agent tar file to tmp directory
       get_url:
-        url: "{{ qualys_release_file_zip_metadata.location }}"
-        dest: "/tmp/qualys-cloud-agent.zip"
-        mode: '0644'
+        url: "{{ qualys_release_file_tar_metadata.location }}"
+        dest: "/tmp/qualys-cloud-agent.tar.gz"
+        mode: '0755'
         force: true
 
-    - name: cloud_agents | Ensure destination directory exists
-      file:
-        path: "/tmp/qualys_agent"
-        state: directory
-        mode: '0755'
-      become: yes
-
-    - name: Ensure unzip utility is installed
-      become: yes
-      package:
-        name: unzip
-        state: present
-
-    - name: cloud_agents | Unzip Qualys agent ZIP file
+    - name: cloud_agents | Extract Qualys agent tar file
       unarchive:
-        src: "/tmp/qualys-cloud-agent.zip"
-        dest: "/tmp/qualys_agent"
+        src: "/tmp/qualys-cloud-agent.tar.gz"
+        dest: "/tmp"
         remote_src: yes
       become: yes
 
@@ -66,7 +53,7 @@
     - name: cloud_agents | Download and install Qualys cloud agent pkg Debian
       become: yes
       apt:
-        deb: "/tmp/qualys_agent/{{ qualys_dir }}/files/{{ cloud_agent.qualys.bin_name }}"
+        deb: "/tmp/{{ qualys_dir }}/files/{{ cloud_agent.qualys.bin_name }}"
         state: present
       when: ansible_os_family == 'Debian'
 

--- a/config/tasks/cloud_agents.yml
+++ b/config/tasks/cloud_agents.yml
@@ -12,9 +12,9 @@
           Accept: "application/vnd.github.v3+json"
       register: github_list_qualys
 
-    - name: cloud_agents | Get latest Qualys agent
+    - name: cloud_agents | Get latest Qualys agent zip
       uri:
-        url: "{{ github_list_qualys | json_query('json[].assets[?name==`'+ cloud_agent.qualys.bin_name +'`].url[] | [0]') }}"
+        url: "{{ github_list_qualys | json_query('json[].assets[?name=~`crs-qualys-agent-ansible.*.zip`].url[] | [0]') }}"
         follow_redirects: none
         status_code: 302
         return_content: no
@@ -25,12 +25,18 @@
           Accept: "application/octet-stream"
       register: qualys_release_file
 
-    - name: cloud_agents | Download Qualys agents to tmp directory
+    - name: cloud_agents | Download Qualys agent zip
       get_url:
         url: "{{ qualys_release_file.location }}"
-        dest: "/tmp/{{ cloud_agent.qualys.bin_name }}"
+        dest: "/tmp/qualys_agent.zip"
         mode: 0755
         force: true
+
+    - name: cloud_agents | Extract Qualys agent deb from zip
+      unarchive:
+        src: "/tmp/qualys_agent.zip"
+        dest: "/tmp/"
+        remote_src: yes
 
     - name: cloud_agents | Remove existing Qualys cloud agent pkg Debian
       become: yes
@@ -42,7 +48,7 @@
     - name: cloud_agents | Download and install Qualys cloud agent pkg Debian
       become: yes
       apt:
-        deb: "/tmp/{{ cloud_agent.qualys.bin_name }}"
+        deb: "/tmp/crs-qualys-agent-ansible-*/files/{{ cloud_agent.qualys.bin_name }}"
         state: present
       when: ansible_os_family == 'Debian'
 

--- a/config/tasks/cloud_agents.yml
+++ b/config/tasks/cloud_agents.yml
@@ -14,7 +14,7 @@
 
     - name: cloud_agents | Get latest Qualys agent tar file
       uri:
-        url: "{{ github_latest_qualys.json.tarball_url }}"
+        url: "https://github.com/sky-uk/crs-qualys-agent-ansible/archive/refs/tags/{{ github_latest_qualys.json.tag_name }}.tar.gz"
         follow_redirects: none
         status_code: 302
         return_content: no
@@ -39,9 +39,9 @@
         remote_src: yes
       become: yes
 
-    # - name: cloud_agents | Construct directory name from tag
-    #   set_fact:
-    #     qualys_dir: "crs-qualys-agent-ansible-{{ github_latest_qualys.json.tag_name | regex_replace('^v', '') }}"
+    - name: cloud_agents | Construct directory name from tag
+      set_fact:
+        qualys_dir: "crs-qualys-agent-ansible-{{ github_latest_qualys.json.tag_name | regex_replace('^v', '') }}"
 
     - name: cloud_agents | Remove existing Qualys cloud agent pkg Debian
       become: yes
@@ -53,7 +53,7 @@
     - name: cloud_agents | Download and install Qualys cloud agent pkg Debian
       become: yes
       apt:
-        deb: "/tmp/sky-uk-crs-qualys-agent-ansible-*/files/{{ cloud_agent.qualys.bin_name }}"
+        deb: "/tmp/{{ qualys_dir }}/files/{{ cloud_agent.qualys.bin_name }}"
         state: present
       when: ansible_os_family == 'Debian'
 

--- a/config/tasks/cloud_agents.yml
+++ b/config/tasks/cloud_agents.yml
@@ -41,7 +41,7 @@
 
     - name: cloud_agents | Construct directory name from tag
       set_fact:
-        qualys_dir: "crs-qualys-agent-ansible-{{ github_latest_qualys.json.tag_name[1:] }}"
+        qualys_dir: "crs-qualys-agent-ansible-{{ github_latest_qualys.json.tag_name | regex_replace('^v', '') }}"
 
     - name: cloud_agents | Remove existing Qualys cloud agent pkg Debian
       become: yes

--- a/config/tasks/cloud_agents.yml
+++ b/config/tasks/cloud_agents.yml
@@ -59,8 +59,6 @@
         dest: "/tmp/qualys_agent"
         remote_src: yes
       become: yes
-      args:
-        executable: "/usr/bin/unzip"
 
     - name: cloud_agents | Find the correct .deb file inside the ZIP
       set_fact:

--- a/config/tasks/cloud_agents.yml
+++ b/config/tasks/cloud_agents.yml
@@ -60,21 +60,10 @@
         remote_src: yes
       become: yes
 
-    - name: cloud_agents | Debug bin_name variable
-      debug:
-        msg: "{{ cloud_agent.qualys.bin_name }}"
     
     - name: cloud_agents | Construct directory name from tag
       set_fact:
         qualys_dir: "crs-qualys-agent-ansible-{{ github_latest_qualys.json.tag_name | regex_replace('^v', '') }}"
-
-    - name: Debug the constructed fileglob path
-      debug:
-        msg: "/tmp/qualys_agent/{{ qualys_dir }}/files/{{ cloud_agent.qualys.bin_name }}"
-
-    - name: cloud_agents | Find the correct .deb file inside the ZIP
-      set_fact:
-        qualys_deb_file: "{{ lookup('fileglob', '/tmp/qualys_agent/{{ qualys_dir }}/files/qualys-cloud-agent.x86_64.deb', wantlist=True)[0] }}"
 
     - name: cloud_agents | Remove existing Qualys cloud agent pkg Debian
       become: yes
@@ -86,7 +75,7 @@
     - name: cloud_agents | Install the Qualys .deb file (Debian)
       become: yes
       apt:
-        deb: "{{ qualys_deb_file }}"
+        deb: "/tmp/qualys_agent/{{ qualys_dir }}/files/{{ cloud_agent.qualys.bin_name }}"
         state: present
       when: ansible_os_family == 'Debian'
 

--- a/config/tasks/cloud_agents.yml
+++ b/config/tasks/cloud_agents.yml
@@ -29,7 +29,7 @@
       get_url:
         url: "{{ qualys_release_file_tar_metadata.location }}"
         dest: "/tmp/qualys-cloud-agent.tar.gz"
-        mode: '0755'
+        mode: 0755
         force: true
 
     - name: cloud_agents | Extract Qualys agent tar file

--- a/config/tasks/cloud_agents.yml
+++ b/config/tasks/cloud_agents.yml
@@ -47,12 +47,20 @@
         mode: '0755'
       become: yes
 
+    - name: Ensure unzip utility is installed
+      become: yes
+      package:
+        name: unzip
+        state: present
+
     - name: cloud_agents | Unzip Qualys agent ZIP file
       unarchive:
         src: "/tmp/qualys-cloud-agent.zip"
         dest: "/tmp/qualys_agent"
         remote_src: yes
       become: yes
+      args:
+        executable: "/usr/bin/unzip"
 
     - name: cloud_agents | Find the correct .deb file inside the ZIP
       set_fact:

--- a/config/tasks/cloud_agents.yml
+++ b/config/tasks/cloud_agents.yml
@@ -14,13 +14,10 @@
 
     - name: cloud_agents | Get latest Qualys agent ZIP URL
       set_fact:
-        qualys_zip_url: >-
-          {{
-            github_list_qualys | json_query("json[].assets[?ends_with(name, '.zip')].url[] | [0]")
-          }}
+        qualys_zip_url: "{{ github_list_qualys.json[0].zipball_url }}"
 
     - name: cloud_agents | Download Qualys ZIP file to tmp directory
-      uri:
+      get_url:
         url: "{{ qualys_zip_url }}"
         follow_redirects: none
         status_code: 302

--- a/config/tasks/cloud_agents.yml
+++ b/config/tasks/cloud_agents.yml
@@ -22,12 +22,12 @@
         url_username: "{{ environment_credentials[buildenv].github_username }}"
         url_password: "{{ environment_credentials[buildenv].github_token }}"
         headers:
-          Accept: "application/octet-stream"
-      register: qualys_release_file_zip
+          Accept: "application/vnd.github.v3+json"
+      register: qualys_release_file_zip_metadata
 
     - name: cloud_agents | Download Qualys agent ZIP file to tmp directory
       get_url:
-        url: "{{ qualys_release_file_zip.location }}"
+        url: "{{ qualys_release_file_zip_metadata.location }}"
         dest: "/tmp/qualys-cloud-agent.zip"
         mode: '0644'
         force: true

--- a/config/tasks/cloud_agents.yml
+++ b/config/tasks/cloud_agents.yml
@@ -14,7 +14,7 @@
 
     - name: cloud_agents | Get latest Qualys agent zip
       set_fact:
-        qualys_asset_url: "{{ github_list_qualys.json | json_query('assets') | selectattr('name', 'search', 'crs-qualys-agent-ansible.*.zip') | first | attr('url') }}"
+        qualys_asset_url: "{{ github_list_qualys.json | json_query('assets[?name==`Source code (zip)`].url | [0]') }}"
 
     - name: cloud_agents | Download Qualys agent zip
       uri:

--- a/config/tasks/cloud_agents.yml
+++ b/config/tasks/cloud_agents.yml
@@ -39,9 +39,9 @@
         remote_src: yes
       become: yes
 
-    - name: cloud_agents | Construct directory name from tag
-      set_fact:
-        qualys_dir: "crs-qualys-agent-ansible-{{ github_latest_qualys.json.tag_name | regex_replace('^v', '') }}"
+    # - name: cloud_agents | Construct directory name from tag
+    #   set_fact:
+    #     qualys_dir: "crs-qualys-agent-ansible-{{ github_latest_qualys.json.tag_name | regex_replace('^v', '') }}"
 
     - name: cloud_agents | Remove existing Qualys cloud agent pkg Debian
       become: yes
@@ -53,7 +53,7 @@
     - name: cloud_agents | Download and install Qualys cloud agent pkg Debian
       become: yes
       apt:
-        deb: "/tmp/{{ qualys_dir }}/files/{{ cloud_agent.qualys.bin_name }}"
+        deb: "/tmp/sky-uk-crs-qualys-agent-ansible-*/files/{{ cloud_agent.qualys.bin_name }}"
         state: present
       when: ansible_os_family == 'Debian'
 

--- a/config/tasks/main.yml
+++ b/config/tasks/main.yml
@@ -1,86 +1,85 @@
 ---
 
-# - name: Run cloud-specific config (if defined)
-#   include: "{{ item }}"
-#   loop: "{{ query('first_found', params) }}"
-#   vars: { params: { files: ["config_{{cluster_vars.type}}.yml"], skip: true } }
+- name: Run cloud-specific config (if defined)
+  include: "{{ item }}"
+  loop: "{{ query('first_found', params) }}"
+  vars: { params: { files: ["config_{{cluster_vars.type}}.yml"], skip: true } }
 
-# - name: Disable unattended-upgrades and apt-daily services & timers. Wait for in-flight updates to finish.
-#   block:
-#     - name: Disable unattended-upgrades and apt-daily services & timers
-#       systemd:
-#         name: "{{ item }}"
-#         enabled: no
-#         state: stopped
-#         daemon_reload: yes
-#       become: true
-#       loop:
-#         - 'apt-daily.timer'
-#         - 'apt-daily.service'
-#         - 'apt-daily-upgrade.timer'
-#         - 'apt-daily-upgrade.service'
-#         - 'unattended-upgrades.service'
+- name: Disable unattended-upgrades and apt-daily services & timers. Wait for in-flight updates to finish.
+  block:
+    - name: Disable unattended-upgrades and apt-daily services & timers
+      systemd:
+        name: "{{ item }}"
+        enabled: no
+        state: stopped
+        daemon_reload: yes
+      become: true
+      loop:
+        - 'apt-daily.timer'
+        - 'apt-daily.service'
+        - 'apt-daily-upgrade.timer'
+        - 'apt-daily-upgrade.service'
+        - 'unattended-upgrades.service'
 
-#     - name: Wait for in-flight updates to finish
-#       become: true
-#       shell: "while fuser /var/lib/dpkg/{{ item }} >/dev/null 2>&1; do sleep 5; done;"
-#       loop:
-#         - lock
-#         - lock-frontend
-#   when: ansible_os_family == 'Debian'
+    - name: Wait for in-flight updates to finish
+      become: true
+      shell: "while fuser /var/lib/dpkg/{{ item }} >/dev/null 2>&1; do sleep 5; done;"
+      loop:
+        - lock
+        - lock-frontend
+  when: ansible_os_family == 'Debian'
 
-# - name: Disable requiretty in sudoers to enable pipelining
-#   become: yes
-#   lineinfile:
-#     dest: /etc/sudoers
-#     regexp: '(^Defaults requiretty)$'
-#     line: '#\1",'
-#     backrefs: yes
-#   vars:
-#     ansible_ssh_pipelining: no
+- name: Disable requiretty in sudoers to enable pipelining
+  become: yes
+  lineinfile:
+    dest: /etc/sudoers
+    regexp: '(^Defaults requiretty)$'
+    line: '#\1",'
+    backrefs: yes
+  vars:
+    ansible_ssh_pipelining: no
 
-# - name: Add hostname to hosts (gives hostname resolution without calling out to DNS.  Needed on Ubuntu.)
-#   become: yes
-#   lineinfile:
-#     path: /etc/hosts
-#     regexp: '^{{ansible_default_ipv4.address}}'
-#     line: '{{ansible_default_ipv4.address}} {{inventory_hostname}}.{{cluster_vars.dns_user_domain}} {{inventory_hostname}}'
-# #    regexp: '^127\.0\.1\.1'
-# #    line: '127.0.1.1 {{inventory_hostname}}'
-#     insertbefore: "BOF"
+- name: Add hostname to hosts (gives hostname resolution without calling out to DNS.  Needed on Ubuntu.)
+  become: yes
+  lineinfile:
+    path: /etc/hosts
+    regexp: '^{{ansible_default_ipv4.address}}'
+    line: '{{ansible_default_ipv4.address}} {{inventory_hostname}}.{{cluster_vars.dns_user_domain}} {{inventory_hostname}}'
+#    regexp: '^127\.0\.1\.1'
+#    line: '127.0.1.1 {{inventory_hostname}}'
+    insertbefore: "BOF"
 
-# - name: Create /var/log/journal
-#   become: true
-#   file:
-#     path: "/var/log/journal"
-#     state: directory
-#     mode: 0755
-#   when: (static_journal is defined and static_journal|bool)
+- name: Create /var/log/journal
+  become: true
+  file:
+    path: "/var/log/journal"
+    state: directory
+    mode: 0755
+  when: (static_journal is defined and static_journal|bool)
 
-# - name: Create partition table, format and attach volumes - AWS, GCP or Azure
-#   include_tasks: disks_auto_cloud.yml
-#   when: cluster_vars.type in ["aws", "gcp", "azure"]
+- name: Create partition table, format and attach volumes - AWS, GCP or Azure
+  include_tasks: disks_auto_cloud.yml
+  when: cluster_vars.type in ["aws", "gcp", "azure"]
 
-# - name: Create partition table, format and attach volumes - generic
-#   include_tasks: disks_auto_generic.yml
-#   when: cluster_vars.type not in ["aws", "gcp", "azure"]
+- name: Create partition table, format and attach volumes - generic
+  include_tasks: disks_auto_generic.yml
+  when: cluster_vars.type not in ["aws", "gcp", "azure"]
 
-# - name: install prometheus node exporter daemon
-#   include_tasks: prometheus_node_exporter.yml
-#   when: (prometheus_node_exporter_install is defined and prometheus_node_exporter_install|bool)
+- name: install prometheus node exporter daemon
+  include_tasks: prometheus_node_exporter.yml
+  when: (prometheus_node_exporter_install is defined and prometheus_node_exporter_install|bool)
 
-# - name: Install elastic filebeat
-#   include_tasks: filebeat.yml
-#   when: (filebeat_install is defined and filebeat_install|bool and (cluster_vars[buildenv].hosttype_vars[hosttype].skip_beat_install is undefined  or (cluster_vars[buildenv].hosttype_vars[hosttype].skip_beat_install is defined and not cluster_vars[buildenv].hosttype_vars[hosttype].skip_beat_install|bool)))
-#   vars:
-#     hosttype: "{{cluster_hosts_target | json_query('[?hostname == `' + inventory_hostname + '`].hosttype|[0]') }}"
+- name: Install elastic filebeat
+  include_tasks: filebeat.yml
+  when: (filebeat_install is defined and filebeat_install|bool and (cluster_vars[buildenv].hosttype_vars[hosttype].skip_beat_install is undefined  or (cluster_vars[buildenv].hosttype_vars[hosttype].skip_beat_install is defined and not cluster_vars[buildenv].hosttype_vars[hosttype].skip_beat_install|bool)))
+  vars:
+    hosttype: "{{cluster_hosts_target | json_query('[?hostname == `' + inventory_hostname + '`].hosttype|[0]') }}"
 
-# - name: Install elastic metricbeat
-#   include_tasks: metricbeat.yml
-#   when: (metricbeat_install is defined and metricbeat_install|bool and (cluster_vars[buildenv].hosttype_vars[hosttype].skip_beat_install is undefined  or (cluster_vars[buildenv].hosttype_vars[hosttype].skip_beat_install is defined and not cluster_vars[buildenv].hosttype_vars[hosttype].skip_beat_install|bool)))
-#   vars:
-#     hosttype: "{{cluster_hosts_target | json_query('[?hostname == `' + inventory_hostname + '`].hosttype|[0]') }}"
-
+- name: Install elastic metricbeat
+  include_tasks: metricbeat.yml
+  when: (metricbeat_install is defined and metricbeat_install|bool and (cluster_vars[buildenv].hosttype_vars[hosttype].skip_beat_install is undefined  or (cluster_vars[buildenv].hosttype_vars[hosttype].skip_beat_install is defined and not cluster_vars[buildenv].hosttype_vars[hosttype].skip_beat_install|bool)))
+  vars:
+    hosttype: "{{cluster_hosts_target | json_query('[?hostname == `' + inventory_hostname + '`].hosttype|[0]') }}"
 - name: Install security cloud agent
   include_tasks: cloud_agents.yml
   when: (cloud_agent is defined and cloud_agent)

--- a/config/tasks/main.yml
+++ b/config/tasks/main.yml
@@ -1,85 +1,85 @@
 ---
 
-- name: Run cloud-specific config (if defined)
-  include: "{{ item }}"
-  loop: "{{ query('first_found', params) }}"
-  vars: { params: { files: ["config_{{cluster_vars.type}}.yml"], skip: true } }
+# - name: Run cloud-specific config (if defined)
+#   include: "{{ item }}"
+#   loop: "{{ query('first_found', params) }}"
+#   vars: { params: { files: ["config_{{cluster_vars.type}}.yml"], skip: true } }
 
-- name: Disable unattended-upgrades and apt-daily services & timers. Wait for in-flight updates to finish.
-  block:
-    - name: Disable unattended-upgrades and apt-daily services & timers
-      systemd:
-        name: "{{ item }}"
-        enabled: no
-        state: stopped
-        daemon_reload: yes
-      become: true
-      loop:
-        - 'apt-daily.timer'
-        - 'apt-daily.service'
-        - 'apt-daily-upgrade.timer'
-        - 'apt-daily-upgrade.service'
-        - 'unattended-upgrades.service'
+# - name: Disable unattended-upgrades and apt-daily services & timers. Wait for in-flight updates to finish.
+#   block:
+#     - name: Disable unattended-upgrades and apt-daily services & timers
+#       systemd:
+#         name: "{{ item }}"
+#         enabled: no
+#         state: stopped
+#         daemon_reload: yes
+#       become: true
+#       loop:
+#         - 'apt-daily.timer'
+#         - 'apt-daily.service'
+#         - 'apt-daily-upgrade.timer'
+#         - 'apt-daily-upgrade.service'
+#         - 'unattended-upgrades.service'
 
-    - name: Wait for in-flight updates to finish
-      become: true
-      shell: "while fuser /var/lib/dpkg/{{ item }} >/dev/null 2>&1; do sleep 5; done;"
-      loop:
-        - lock
-        - lock-frontend
-  when: ansible_os_family == 'Debian'
+#     - name: Wait for in-flight updates to finish
+#       become: true
+#       shell: "while fuser /var/lib/dpkg/{{ item }} >/dev/null 2>&1; do sleep 5; done;"
+#       loop:
+#         - lock
+#         - lock-frontend
+#   when: ansible_os_family == 'Debian'
 
-- name: Disable requiretty in sudoers to enable pipelining
-  become: yes
-  lineinfile:
-    dest: /etc/sudoers
-    regexp: '(^Defaults requiretty)$'
-    line: '#\1",'
-    backrefs: yes
-  vars:
-    ansible_ssh_pipelining: no
+# - name: Disable requiretty in sudoers to enable pipelining
+#   become: yes
+#   lineinfile:
+#     dest: /etc/sudoers
+#     regexp: '(^Defaults requiretty)$'
+#     line: '#\1",'
+#     backrefs: yes
+#   vars:
+#     ansible_ssh_pipelining: no
 
-- name: Add hostname to hosts (gives hostname resolution without calling out to DNS.  Needed on Ubuntu.)
-  become: yes
-  lineinfile:
-    path: /etc/hosts
-    regexp: '^{{ansible_default_ipv4.address}}'
-    line: '{{ansible_default_ipv4.address}} {{inventory_hostname}}.{{cluster_vars.dns_user_domain}} {{inventory_hostname}}'
-#    regexp: '^127\.0\.1\.1'
-#    line: '127.0.1.1 {{inventory_hostname}}'
-    insertbefore: "BOF"
+# - name: Add hostname to hosts (gives hostname resolution without calling out to DNS.  Needed on Ubuntu.)
+#   become: yes
+#   lineinfile:
+#     path: /etc/hosts
+#     regexp: '^{{ansible_default_ipv4.address}}'
+#     line: '{{ansible_default_ipv4.address}} {{inventory_hostname}}.{{cluster_vars.dns_user_domain}} {{inventory_hostname}}'
+# #    regexp: '^127\.0\.1\.1'
+# #    line: '127.0.1.1 {{inventory_hostname}}'
+#     insertbefore: "BOF"
 
-- name: Create /var/log/journal
-  become: true
-  file:
-    path: "/var/log/journal"
-    state: directory
-    mode: 0755
-  when: (static_journal is defined and static_journal|bool)
+# - name: Create /var/log/journal
+#   become: true
+#   file:
+#     path: "/var/log/journal"
+#     state: directory
+#     mode: 0755
+#   when: (static_journal is defined and static_journal|bool)
 
-- name: Create partition table, format and attach volumes - AWS, GCP or Azure
-  include_tasks: disks_auto_cloud.yml
-  when: cluster_vars.type in ["aws", "gcp", "azure"]
+# - name: Create partition table, format and attach volumes - AWS, GCP or Azure
+#   include_tasks: disks_auto_cloud.yml
+#   when: cluster_vars.type in ["aws", "gcp", "azure"]
 
-- name: Create partition table, format and attach volumes - generic
-  include_tasks: disks_auto_generic.yml
-  when: cluster_vars.type not in ["aws", "gcp", "azure"]
+# - name: Create partition table, format and attach volumes - generic
+#   include_tasks: disks_auto_generic.yml
+#   when: cluster_vars.type not in ["aws", "gcp", "azure"]
 
-- name: install prometheus node exporter daemon
-  include_tasks: prometheus_node_exporter.yml
-  when: (prometheus_node_exporter_install is defined and prometheus_node_exporter_install|bool)
+# - name: install prometheus node exporter daemon
+#   include_tasks: prometheus_node_exporter.yml
+#   when: (prometheus_node_exporter_install is defined and prometheus_node_exporter_install|bool)
 
-- name: Install elastic filebeat
-  include_tasks: filebeat.yml
-  when: (filebeat_install is defined and filebeat_install|bool and (cluster_vars[buildenv].hosttype_vars[hosttype].skip_beat_install is undefined  or (cluster_vars[buildenv].hosttype_vars[hosttype].skip_beat_install is defined and not cluster_vars[buildenv].hosttype_vars[hosttype].skip_beat_install|bool)))
-  vars:
-    hosttype: "{{cluster_hosts_target | json_query('[?hostname == `' + inventory_hostname + '`].hosttype|[0]') }}"
+# - name: Install elastic filebeat
+#   include_tasks: filebeat.yml
+#   when: (filebeat_install is defined and filebeat_install|bool and (cluster_vars[buildenv].hosttype_vars[hosttype].skip_beat_install is undefined  or (cluster_vars[buildenv].hosttype_vars[hosttype].skip_beat_install is defined and not cluster_vars[buildenv].hosttype_vars[hosttype].skip_beat_install|bool)))
+#   vars:
+#     hosttype: "{{cluster_hosts_target | json_query('[?hostname == `' + inventory_hostname + '`].hosttype|[0]') }}"
 
-- name: Install elastic metricbeat
-  include_tasks: metricbeat.yml
-  when: (metricbeat_install is defined and metricbeat_install|bool and (cluster_vars[buildenv].hosttype_vars[hosttype].skip_beat_install is undefined  or (cluster_vars[buildenv].hosttype_vars[hosttype].skip_beat_install is defined and not cluster_vars[buildenv].hosttype_vars[hosttype].skip_beat_install|bool)))
-  vars:
-    hosttype: "{{cluster_hosts_target | json_query('[?hostname == `' + inventory_hostname + '`].hosttype|[0]') }}"
+# - name: Install elastic metricbeat
+#   include_tasks: metricbeat.yml
+#   when: (metricbeat_install is defined and metricbeat_install|bool and (cluster_vars[buildenv].hosttype_vars[hosttype].skip_beat_install is undefined  or (cluster_vars[buildenv].hosttype_vars[hosttype].skip_beat_install is defined and not cluster_vars[buildenv].hosttype_vars[hosttype].skip_beat_install|bool)))
+#   vars:
+#     hosttype: "{{cluster_hosts_target | json_query('[?hostname == `' + inventory_hostname + '`].hosttype|[0]') }}"
 
 - name: Install security cloud agent
   include_tasks: cloud_agents.yml

--- a/config/tasks/main.yml
+++ b/config/tasks/main.yml
@@ -80,6 +80,7 @@
   when: (metricbeat_install is defined and metricbeat_install|bool and (cluster_vars[buildenv].hosttype_vars[hosttype].skip_beat_install is undefined  or (cluster_vars[buildenv].hosttype_vars[hosttype].skip_beat_install is defined and not cluster_vars[buildenv].hosttype_vars[hosttype].skip_beat_install|bool)))
   vars:
     hosttype: "{{cluster_hosts_target | json_query('[?hostname == `' + inventory_hostname + '`].hosttype|[0]') }}"
+
 - name: Install security cloud agent
   include_tasks: cloud_agents.yml
   when: (cloud_agent is defined and cloud_agent)


### PR DESCRIPTION
This PR updates the Qualys cloud agent installation process to handle the new GitHub release format, where the agent files are provided in a tarball instead of directly as deb packages. The old code would directly download and install the deb file but the new format is handling zip/tar files. 

It adds steps to download, extract the tarball, install the agent, and clean up temporary files and directories after installation.

Has been tested extensively as by the commit history and is working fine. A small amendment will be needed in dependent repositories to include the  tarball_url being `https://github.com/sky-uk/crs-qualys-agent-ansible/archive/refs/tags`. This code ensures the latest release is retrieved each time.